### PR TITLE
feat(pdf): pdfium-backed PDF open + render pipeline

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -18,6 +18,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,6 +64,38 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "async-broadcast"
@@ -214,6 +264,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.18",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,6 +334,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +352,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "bitstream-io"
+version = "4.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
+dependencies = [
+ "no_std_io2",
 ]
 
 [[package]]
@@ -308,6 +416,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,6 +438,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -408,6 +528,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -451,10 +573,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "combine"
@@ -473,6 +603,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "console_log"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f"
+dependencies = [
+ "log",
+ "web-sys",
 ]
 
 [[package]]
@@ -559,10 +709,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -831,9 +1006,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "eldraw"
 version = "0.1.0"
 dependencies = [
+ "image",
+ "pdfium-render",
  "serde",
  "serde_json",
  "sha2",
@@ -891,6 +1074,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -939,10 +1142,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "exr"
+version = "1.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
+dependencies = [
+ "fax_derive",
+]
+
+[[package]]
+name = "fax_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "fdeflate"
@@ -1293,6 +1531,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1438,6 +1686,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1620,7 +1879,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e795dff5605e0f04bff85ca41b51a96b83e80b281e96231bcaaf1ac35103371"
 dependencies = [
  "byteorder",
- "png",
+ "png 0.17.16",
 ]
 
 [[package]]
@@ -1739,6 +1998,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "exr",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
+ "tiff",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imgref"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1768,6 +2067,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
 dependencies = [
  "cfb",
+]
+
+[[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1803,6 +2113,15 @@ checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
 dependencies = [
  "is-docker",
  "once_cell",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1879,6 +2198,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1942,6 +2271,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
 name = "libappindicator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1970,6 +2305,16 @@ name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "libloading"
@@ -2016,6 +2361,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
 
 [[package]]
 name = "mac"
@@ -2066,6 +2420,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2108,6 +2478,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muda"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2122,7 +2502,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -2165,16 +2545,81 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "no_std_io2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2419,10 +2864,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pdfium-render"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "671afc8522e8f36c5854a8231bdba50c4144be0138521329629b8f102e55f65a"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytemuck",
+ "bytes",
+ "chrono",
+ "console_error_panic_hook",
+ "console_log",
+ "image",
+ "itertools",
+ "js-sys",
+ "libloading",
+ "log",
+ "maybe-owned",
+ "once_cell",
+ "utf16string",
+ "vecmath",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2635,6 +3118,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "piston-float"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad78bf43dcf80e8f950c92b84f938a0fc7590b7f6866fbcbeca781609c115590"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2660,6 +3149,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
 dependencies = [
  "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -2789,6 +3291,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "profiling"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2844,6 +3386,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2861,6 +3413,16 @@ checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2882,6 +3444,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2900,10 +3471,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "simd_helpers",
+ "thiserror 2.0.18",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -3007,6 +3648,12 @@ dependencies = [
  "wasm-streams",
  "web-sys",
 ]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
 name = "rustc-hash"
@@ -3356,6 +4003,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3703,7 +4359,7 @@ dependencies = [
  "ico",
  "json-patch",
  "plist",
- "png",
+ "png 0.17.16",
  "proc-macro2",
  "quote",
  "semver",
@@ -3944,6 +4600,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -4211,7 +4881,7 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -4337,6 +5007,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf16string"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b62a1e85e12d5d712bf47a85f426b73d303e2d00a90de5f3004df3596e9d216"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4352,6 +5031,26 @@ dependencies = [
  "js-sys",
  "serde_core",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "vecmath"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "956ae1e0d85bca567dee1dcf87fb1ca2e792792f66f87dced8381f99cd91156a"
+dependencies = [
+ "piston-float",
 ]
 
 [[package]]
@@ -4638,6 +5337,12 @@ dependencies = [
  "windows",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi"
@@ -5267,6 +5972,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5429,6 +6140,30 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
 
 [[package]]
 name = "zvariant"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,6 +19,13 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 sha2 = "0.10"
+pdfium-render = { version = "0.9", default-features = false, features = [
+  "pdfium_latest",
+  "image_latest",
+  "image_api",
+  "thread_safe",
+] }
+image = "0.25"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -12,6 +12,9 @@ pub enum AppError {
     #[error("pdf: {0}")]
     Pdf(String),
 
+    #[error("image: {0}")]
+    Image(#[from] image::ImageError),
+
     #[error("not implemented: {0}")]
     NotImplemented(&'static str),
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod error;
 mod export;
 mod model;
 mod pdf;
+mod state;
 mod storage;
 
 pub use error::{AppError, AppResult};
@@ -9,6 +10,7 @@ pub use error::{AppError, AppResult};
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .manage(state::AppState::default())
         .plugin(tauri_plugin_opener::init())
         .invoke_handler(tauri::generate_handler![
             pdf::open_pdf,

--- a/src-tauri/src/pdf.rs
+++ b/src-tauri/src/pdf.rs
@@ -1,14 +1,150 @@
-use crate::error::{AppError, AppResult};
-use crate::model::PdfMeta;
+//! PDF ingest & raster pipeline.
+//!
+//! Rendering uses pdfium-render. The native pdfium library is resolved at
+//! runtime by [`crate::state::pdfium`]: system loader first, then a binary
+//! placed next to the executable. Distributions should ship the matching
+//! `libpdfium.so` / `pdfium.dll` / `libpdfium.dylib` in the app bundle.
 
-#[tauri::command]
-pub async fn open_pdf(path: String) -> AppResult<PdfMeta> {
-    let _ = path;
-    Err(AppError::NotImplemented("open_pdf"))
+use std::io::Cursor;
+use std::path::PathBuf;
+
+use image::ImageFormat;
+use pdfium_render::prelude::{PdfRenderConfig, Pdfium};
+use sha2::{Digest, Sha256};
+use tauri::State;
+
+use crate::error::{AppError, AppResult};
+use crate::model::{PageDims, PdfMeta};
+use crate::state::{pdfium, AppState};
+
+/// Lowercase hex SHA-256 digest of `bytes`.
+pub fn hash_bytes(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex_lower(&hasher.finalize())
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push(HEX[(b >> 4) as usize] as char);
+        out.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    out
+}
+
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_precision_loss
+)]
+fn pixel_dim(points: f32, scale: f32) -> i32 {
+    let raw = (points * scale).round().max(1.0).min(i32::MAX as f32);
+    raw as i32
+}
+
+fn load_document<'a>(
+    pdfium: &'a Pdfium,
+    bytes: &'a [u8],
+) -> AppResult<pdfium_render::prelude::PdfDocument<'a>> {
+    pdfium
+        .load_pdf_from_byte_slice(bytes, None)
+        .map_err(|e| AppError::Pdf(format!("load_pdf: {e}")))
 }
 
 #[tauri::command]
-pub async fn render_page(page_index: u32, scale: f32) -> AppResult<Vec<u8>> {
-    let _ = (page_index, scale);
-    Err(AppError::NotImplemented("render_page"))
+pub async fn open_pdf(path: String, state: State<'_, AppState>) -> AppResult<PdfMeta> {
+    let pdf_path = PathBuf::from(&path);
+    let bytes = std::fs::read(&pdf_path)?;
+    let hash = hash_bytes(&bytes);
+
+    let pdfium = pdfium()?;
+    let doc = load_document(pdfium, &bytes)?;
+
+    let mut pages = Vec::with_capacity(usize::try_from(doc.pages().len()).unwrap_or(0));
+    for page in doc.pages().iter() {
+        pages.push(PageDims {
+            width: f64::from(page.width().value),
+            height: f64::from(page.height().value),
+        });
+    }
+    let page_count =
+        u32::try_from(pages.len()).map_err(|_| AppError::Pdf("page count exceeds u32".into()))?;
+
+    drop(doc);
+    state.set_open(pdf_path, bytes)?;
+
+    Ok(PdfMeta {
+        path,
+        hash,
+        page_count,
+        pages,
+    })
+}
+
+#[tauri::command]
+pub async fn render_page(
+    page_index: u32,
+    scale: f32,
+    state: State<'_, AppState>,
+) -> AppResult<Vec<u8>> {
+    if !scale.is_finite() || scale <= 0.0 {
+        return Err(AppError::Pdf(format!("invalid scale: {scale}")));
+    }
+    state.with_open(|open| {
+        let pdfium = pdfium()?;
+        let doc = load_document(pdfium, &open.bytes)?;
+        let page = doc
+            .pages()
+            .get(
+                i32::try_from(page_index)
+                    .map_err(|_| AppError::Pdf(format!("page_index {page_index} out of range")))?,
+            )
+            .map_err(|_| AppError::Pdf(format!("page_index {page_index} out of range")))?;
+
+        let width_px = pixel_dim(page.width().value, scale);
+        let height_px = pixel_dim(page.height().value, scale);
+
+        let config = PdfRenderConfig::new()
+            .set_target_width(width_px)
+            .set_target_height(height_px);
+
+        let bitmap = page
+            .render_with_config(&config)
+            .map_err(|e| AppError::Pdf(format!("render: {e}")))?;
+
+        let image = bitmap
+            .as_image()
+            .map_err(|e| AppError::Pdf(format!("bitmap: {e}")))?;
+        let mut out = Cursor::new(Vec::<u8>::new());
+        image.write_to(&mut out, ImageFormat::Png)?;
+        Ok(out.into_inner())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sha256_of_abc_matches_nist_vector() {
+        assert_eq!(
+            hash_bytes(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn sha256_of_empty_matches_nist_vector() {
+        assert_eq!(
+            hash_bytes(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn hex_lower_pads_leading_zeros() {
+        assert_eq!(hex_lower(&[0x00, 0x0f, 0xff]), "000fff");
+    }
 }

--- a/src-tauri/src/pdf.rs
+++ b/src-tauri/src/pdf.rs
@@ -83,6 +83,10 @@ pub async fn open_pdf(path: String, state: State<'_, AppState>) -> AppResult<Pdf
     })
 }
 
+/// Upper bound on the rendered bitmap size (pixels). Guards against
+/// pathological scale values producing multi-GB bitmaps.
+const MAX_PIXEL_AREA: u64 = 64 * 1024 * 1024;
+
 #[tauri::command]
 pub async fn render_page(
     page_index: u32,
@@ -105,6 +109,12 @@ pub async fn render_page(
 
         let width_px = pixel_dim(page.width().value, scale);
         let height_px = pixel_dim(page.height().value, scale);
+        let area = u64::from(width_px.unsigned_abs()) * u64::from(height_px.unsigned_abs());
+        if area > MAX_PIXEL_AREA {
+            return Err(AppError::Pdf(format!(
+                "requested bitmap {width_px}x{height_px} exceeds {MAX_PIXEL_AREA}-pixel cap"
+            )));
+        }
 
         let config = PdfRenderConfig::new()
             .set_target_width(width_px)

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,0 +1,61 @@
+use pdfium_render::prelude::Pdfium;
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+
+use crate::error::{AppError, AppResult};
+
+/// Owns the currently-open PDF bytes, keyed by absolute path, plus a lazily
+/// initialised Pdfium handle shared across commands.
+#[derive(Default)]
+pub struct AppState {
+    inner: Mutex<Option<OpenPdf>>,
+}
+
+pub struct OpenPdf {
+    #[allow(dead_code)] // retained for future cache invalidation / diagnostics
+    pub path: PathBuf,
+    pub bytes: Vec<u8>,
+}
+
+impl AppState {
+    pub fn set_open(&self, path: PathBuf, bytes: Vec<u8>) -> AppResult<()> {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| AppError::Pdf("state mutex poisoned".into()))?;
+        *guard = Some(OpenPdf { path, bytes });
+        Ok(())
+    }
+
+    /// Run `f` with the currently open PDF bytes, if any.
+    pub fn with_open<T>(&self, f: impl FnOnce(&OpenPdf) -> AppResult<T>) -> AppResult<T> {
+        let guard = self
+            .inner
+            .lock()
+            .map_err(|_| AppError::Pdf("state mutex poisoned".into()))?;
+        match guard.as_ref() {
+            Some(open) => f(open),
+            None => Err(AppError::Pdf("no PDF is open".into())),
+        }
+    }
+}
+
+/// Returns a process-wide Pdfium handle. The library resolves its native
+/// binary by first trying the system loader (`Pdfium::default()`), then
+/// falling back to a binary co-located with the executable. If neither is
+/// available, the error is surfaced to the caller.
+pub fn pdfium() -> AppResult<&'static Pdfium> {
+    static PDFIUM: OnceLock<Result<Pdfium, String>> = OnceLock::new();
+    let slot = PDFIUM.get_or_init(|| {
+        let bindings = Pdfium::bind_to_system_library()
+            .or_else(|_| {
+                Pdfium::bind_to_library(Pdfium::pdfium_platform_library_name_at_path("./"))
+            })
+            .map_err(|e| format!("failed to load pdfium binary: {e}"))?;
+        Ok(Pdfium::new(bindings))
+    });
+    match slot {
+        Ok(p) => Ok(p),
+        Err(msg) => Err(AppError::Pdf(msg.clone())),
+    }
+}

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -4,8 +4,8 @@ use std::sync::{Mutex, OnceLock};
 
 use crate::error::{AppError, AppResult};
 
-/// Owns the currently-open PDF bytes, keyed by absolute path, plus a lazily
-/// initialised Pdfium handle shared across commands.
+/// Owns the currently-open PDF bytes, keyed by canonical absolute path, plus
+/// a lazily initialised Pdfium handle shared across commands.
 #[derive(Default)]
 pub struct AppState {
     inner: Mutex<Option<OpenPdf>>,
@@ -23,7 +23,11 @@ impl AppState {
             .inner
             .lock()
             .map_err(|_| AppError::Pdf("state mutex poisoned".into()))?;
-        *guard = Some(OpenPdf { path, bytes });
+        let canonical = std::fs::canonicalize(&path).unwrap_or(path);
+        *guard = Some(OpenPdf {
+            path: canonical,
+            bytes,
+        });
         Ok(())
     }
 
@@ -40,16 +44,20 @@ impl AppState {
     }
 }
 
-/// Returns a process-wide Pdfium handle. The library resolves its native
-/// binary by first trying the system loader (`Pdfium::default()`), then
-/// falling back to a binary co-located with the executable. If neither is
-/// available, the error is surfaced to the caller.
+/// Returns a process-wide Pdfium handle. The native binary is resolved by
+/// first trying `Pdfium::bind_to_system_library()`, then falling back to a
+/// binary co-located with the running executable. If neither is available,
+/// the error is surfaced to the caller.
 pub fn pdfium() -> AppResult<&'static Pdfium> {
     static PDFIUM: OnceLock<Result<Pdfium, String>> = OnceLock::new();
     let slot = PDFIUM.get_or_init(|| {
         let bindings = Pdfium::bind_to_system_library()
             .or_else(|_| {
-                Pdfium::bind_to_library(Pdfium::pdfium_platform_library_name_at_path("./"))
+                let exe_dir = std::env::current_exe()
+                    .ok()
+                    .and_then(|p| p.parent().map(PathBuf::from))
+                    .unwrap_or_else(|| PathBuf::from("."));
+                Pdfium::bind_to_library(Pdfium::pdfium_platform_library_name_at_path(&exe_dir))
             })
             .map_err(|e| format!("failed to load pdfium binary: {e}"))?;
         Ok(Pdfium::new(bindings))

--- a/src/lib/canvas/PdfLayer.svelte
+++ b/src/lib/canvas/PdfLayer.svelte
@@ -10,25 +10,33 @@
 
   let canvas: HTMLCanvasElement | undefined = $state();
   let error: string | null = $state(null);
+  let latestRequestId = 0;
 
-  async function draw(index: number, s: number): Promise<void> {
-    if (!canvas) return;
+  async function draw(
+    target: HTMLCanvasElement,
+    index: number,
+    s: number,
+    requestId: number,
+  ): Promise<void> {
     error = null;
     try {
       const pngBytes = await renderPage(index, s);
+      if (requestId !== latestRequestId) return;
       const blob = new Blob([pngBytes], { type: 'image/png' });
       const url = URL.createObjectURL(blob);
       try {
         const image = await loadImage(url);
-        canvas.width = image.width;
-        canvas.height = image.height;
-        const ctx = canvas.getContext('2d');
+        if (requestId !== latestRequestId) return;
+        target.width = image.width;
+        target.height = image.height;
+        const ctx = target.getContext('2d');
         if (!ctx) throw new Error('2d canvas context unavailable');
         ctx.drawImage(image, 0, 0);
       } finally {
         URL.revokeObjectURL(url);
       }
     } catch (err) {
+      if (requestId !== latestRequestId) return;
       error = err instanceof Error ? err.message : String(err);
     }
   }
@@ -43,7 +51,10 @@
   }
 
   $effect(() => {
-    void draw(pageIndex, scale);
+    const target = canvas;
+    if (!target) return;
+    const requestId = ++latestRequestId;
+    void draw(target, pageIndex, scale, requestId);
   });
 </script>
 

--- a/src/lib/canvas/PdfLayer.svelte
+++ b/src/lib/canvas/PdfLayer.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+  import { renderPage } from '$lib/ipc';
+
+  interface Props {
+    pageIndex: number;
+    scale: number;
+  }
+
+  let { pageIndex, scale }: Props = $props();
+
+  let canvas: HTMLCanvasElement | undefined = $state();
+  let error: string | null = $state(null);
+
+  async function draw(index: number, s: number): Promise<void> {
+    if (!canvas) return;
+    error = null;
+    try {
+      const pngBytes = await renderPage(index, s);
+      const blob = new Blob([pngBytes], { type: 'image/png' });
+      const url = URL.createObjectURL(blob);
+      try {
+        const image = await loadImage(url);
+        canvas.width = image.width;
+        canvas.height = image.height;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) throw new Error('2d canvas context unavailable');
+        ctx.drawImage(image, 0, 0);
+      } finally {
+        URL.revokeObjectURL(url);
+      }
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  function loadImage(url: string): Promise<HTMLImageElement> {
+    return new Promise((resolve, reject) => {
+      const img = new Image();
+      img.onload = () => resolve(img);
+      img.onerror = () => reject(new Error('failed to decode page image'));
+      img.src = url;
+    });
+  }
+
+  $effect(() => {
+    void draw(pageIndex, scale);
+  });
+</script>
+
+<div class="pdf-layer">
+  <canvas bind:this={canvas} aria-label="Rendered PDF page"></canvas>
+  {#if error}
+    <div class="error" role="alert">{error}</div>
+  {/if}
+</div>
+
+<style>
+  .pdf-layer {
+    position: relative;
+    display: inline-block;
+  }
+  canvas {
+    display: block;
+    background: #fff;
+  }
+  .error {
+    position: absolute;
+    top: 8px;
+    left: 8px;
+    padding: 6px 10px;
+    background: rgba(180, 30, 30, 0.9);
+    color: #fff;
+    font-size: 12px;
+    border-radius: 4px;
+    max-width: 80%;
+  }
+</style>

--- a/src/lib/ipc/pdf.ts
+++ b/src/lib/ipc/pdf.ts
@@ -1,0 +1,15 @@
+import { openPdf } from '$lib/ipc';
+import type { PdfMeta } from '$lib/types';
+import { setError, setLoading, setMeta } from '$lib/store/pdf';
+
+export async function openAndLoadPdf(path: string): Promise<PdfMeta | null> {
+  setLoading(true);
+  try {
+    const meta = await openPdf(path);
+    setMeta(meta);
+    return meta;
+  } catch (err) {
+    setError(err instanceof Error ? err.message : String(err));
+    return null;
+  }
+}

--- a/src/lib/store/pdf.ts
+++ b/src/lib/store/pdf.ts
@@ -1,0 +1,30 @@
+import { writable, type Readable } from 'svelte/store';
+import type { PdfMeta } from '$lib/types';
+
+export interface PdfState {
+  meta: PdfMeta | null;
+  error: string | null;
+  loading: boolean;
+}
+
+const initial: PdfState = { meta: null, error: null, loading: false };
+
+const internal = writable<PdfState>(initial);
+
+export const pdf: Readable<PdfState> = { subscribe: internal.subscribe };
+
+export function setLoading(loading: boolean): void {
+  internal.update((s) => ({ ...s, loading }));
+}
+
+export function setMeta(meta: PdfMeta): void {
+  internal.set({ meta, error: null, loading: false });
+}
+
+export function setError(error: string): void {
+  internal.update((s) => ({ ...s, error, loading: false }));
+}
+
+export function reset(): void {
+  internal.set(initial);
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,21 @@
 <script lang="ts">
-  // Placeholder shell. Phase 1 worktrees will replace this with the real
-  // sidebar + canvas layout. See AGENTS.md for the parallel work plan.
+  import PdfLayer from '$lib/canvas/PdfLayer.svelte';
+  import { pdf } from '$lib/store/pdf';
+  import { openAndLoadPdf } from '$lib/ipc/pdf';
+
+  let pageIndex = $state(0);
+  const scale = 1.5;
+
+  async function onFileChosen(event: Event): Promise<void> {
+    const input = event.currentTarget as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) return;
+    // In the Tauri runtime File.path is available; in a browser dev session
+    // we fall back to the plain name for debugging.
+    const path = (file as File & { path?: string }).path ?? file.name;
+    await openAndLoadPdf(path);
+    pageIndex = 0;
+  }
 </script>
 
 <main class="app">
@@ -9,6 +24,13 @@
   </aside>
   <section class="canvas-area" aria-label="Canvas area">
     <p class="placeholder">canvas stack (feat/pdf-pipeline + feat/ink-engine)</p>
+    <label class="dev-open">
+      Open PDF
+      <input type="file" accept="application/pdf" onchange={onFileChosen} />
+    </label>
+    {#if $pdf.meta}
+      <PdfLayer {pageIndex} {scale} />
+    {/if}
   </section>
 </main>
 
@@ -38,5 +60,19 @@
   .placeholder {
     color: #888;
     font-size: 13px;
+  }
+  .dev-open {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    font-size: 12px;
+    color: #aaa;
+    background: #2a2a2a;
+    padding: 4px 8px;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  .dev-open input {
+    display: none;
   }
 </style>

--- a/tests/pdf-store.test.ts
+++ b/tests/pdf-store.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+import { pdf, setLoading, setMeta, setError, reset } from '$lib/store/pdf';
+
+describe('pdf store', () => {
+  beforeEach(() => reset());
+
+  it('starts empty', () => {
+    const s = get(pdf);
+    expect(s.meta).toBeNull();
+    expect(s.error).toBeNull();
+    expect(s.loading).toBe(false);
+  });
+
+  it('tracks loading and meta transitions', () => {
+    setLoading(true);
+    expect(get(pdf).loading).toBe(true);
+
+    setMeta({ path: '/tmp/a.pdf', hash: 'h', pageCount: 2, pages: [] });
+    const s = get(pdf);
+    expect(s.loading).toBe(false);
+    expect(s.meta?.pageCount).toBe(2);
+    expect(s.error).toBeNull();
+  });
+
+  it('captures errors', () => {
+    setError('boom');
+    expect(get(pdf).error).toBe('boom');
+    expect(get(pdf).loading).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Lands the real PDF ingest + raster pipeline for eldraw.

### Rust (`src-tauri/`)
- Depend on `pdfium-render 0.9` with `thread_safe` + `image` features.
- New `AppState` (in `state.rs`) holds the currently open PDF bytes + path behind a `Mutex`. Registered via `.manage(...)` in `lib.rs`.
- `open_pdf(path)` reads the file, computes SHA-256, opens with pdfium, returns `PdfMeta { path, hash, page_count, pages[] }` with per-page dimensions in PDF points.
- `render_page(page_index, scale)` renders the current PDF's page at the given scale (1.0 = 72 DPI) and returns PNG bytes. Validates `scale` and `page_index`.
- Pdfium binary resolution: `bind_to_system_library()` first, then a binary next to the executable. Documented at the top of `pdf.rs`.
- `AppError::Pdf` / `AppError::Image` variants; `thiserror` kept clean.
- Unit tests for SHA-256 against NIST vectors + hex helper.

### Frontend (`src/`)
- `$lib/store/pdf.ts` — Svelte store tracking `{ meta, error, loading }`.
- `$lib/ipc/pdf.ts` — `openAndLoadPdf(path)` helper around the IPC call.
- `$lib/canvas/PdfLayer.svelte` — renders PNG bytes returned from `render_page` into a `<canvas>`; shows an error overlay on failure; re-renders on prop changes via `\$effect`.
- `src/routes/+page.svelte` — conditionally mounts `<PdfLayer>` inside `.canvas-area` when a PDF is loaded, plus a tiny dev-only file input (to be replaced by app-shell). Existing sidebar / placeholder markup untouched.
- Vitest coverage for the pdf store.

### Testing
- `pnpm lint` ✅ (prettier + eslint + svelte-check)
- `pnpm test` ✅ (4 tests)
- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test` ✅ (3 tests)

### Follow-ups / TODOs
- **Page cache**: `render_page` currently re-parses the document from bytes per call. Next step is to cache the parsed `PdfDocument` (lifetime-bound to the bytes in `AppState`) plus an LRU of rendered PNGs by `(page_index, scale)`.
- **Thumbnails**: dedicated low-DPI thumbnail command for the page sidebar.
- **Pdfium bundling**: CI + release builds need to ship the matching `libpdfium.*` next to the binary (or under `./`). The bundler config will be set up by the app-shell worktree.
- **File picker**: current dev `<input type=file>` only provides `file.name` in the webview; real Tauri file-dialog wiring lives in the app-shell worktree.