### PR TITLE
feat(ink): perfect-freehand inking + layered canvas stack

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,14 +18,15 @@
   "license": "MIT",
   "dependencies": {
     "@tauri-apps/api": "^2",
-    "@tauri-apps/plugin-opener": "^2"
+    "@tauri-apps/plugin-opener": "^2",
+    "perfect-freehand": "^1.2.3"
   },
   "devDependencies": {
+    "@eslint/js": "^9.17.0",
     "@sveltejs/adapter-static": "^3.0.6",
     "@sveltejs/kit": "^2.9.0",
     "@sveltejs/vite-plugin-svelte": "^5.0.0",
     "@tauri-apps/cli": "^2",
-    "@eslint/js": "^9.17.0",
     "@types/node": "^22.10.0",
     "eslint": "^9.17.0",
     "eslint-config-prettier": "^9.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@tauri-apps/plugin-opener':
         specifier: ^2
         version: 2.5.3
+      perfect-freehand:
+        specifier: ^1.2.3
+        version: 1.2.3
     devDependencies:
       '@eslint/js':
         specifier: ^9.17.0
@@ -1079,6 +1082,9 @@ packages:
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
+
+  perfect-freehand@1.2.3:
+    resolution: {integrity: sha512-bHZSfqDHGNlPpgH2yxXgPHlQSPpEbo+qg7li0M78J9vNAi2yjwLeA4x79BEQhX44lEWpCLSFCeRZwpw0niiXPA==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2274,6 +2280,8 @@ snapshots:
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
+
+  perfect-freehand@1.2.3: {}
 
   picocolors@1.1.1: {}
 

--- a/src/lib/canvas/CanvasStack.svelte
+++ b/src/lib/canvas/CanvasStack.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import type { StrokeObject } from '$lib/types';
+  import HighlightLayer from './HighlightLayer.svelte';
+  import InkLayer from './InkLayer.svelte';
+  import LiveLayer from './LiveLayer.svelte';
+
+  interface Props {
+    strokes: StrokeObject[];
+    width: number;
+    height: number;
+    ptToPx: number;
+    objects?: Snippet;
+    oncommit?: (stroke: StrokeObject) => void;
+    onerase?: (at: { x: number; y: number }) => void;
+  }
+
+  let { strokes, width, height, ptToPx, objects, oncommit, onerase }: Props = $props();
+</script>
+
+<div class="stack" style="width: {width}px; height: {height}px;">
+  <div class="layer layer-highlight">
+    <HighlightLayer {strokes} {width} {height} {ptToPx} />
+  </div>
+
+  {#if objects}
+    <div class="layer layer-objects">
+      {@render objects()}
+    </div>
+  {/if}
+
+  <div class="layer layer-ink">
+    <InkLayer {strokes} {width} {height} {ptToPx} />
+  </div>
+
+  <div class="layer layer-live">
+    <LiveLayer {width} {height} {ptToPx} {oncommit} {onerase} />
+  </div>
+</div>
+
+<style>
+  .stack {
+    position: relative;
+  }
+  .layer {
+    position: absolute;
+    inset: 0;
+  }
+  .layer-highlight {
+    z-index: 1;
+  }
+  .layer-objects {
+    z-index: 2;
+    pointer-events: none;
+  }
+  .layer-ink {
+    z-index: 3;
+  }
+  .layer-live {
+    z-index: 4;
+  }
+</style>

--- a/src/lib/canvas/HighlightLayer.svelte
+++ b/src/lib/canvas/HighlightLayer.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import type { StrokeObject } from '$lib/types';
+  import { drawStroke } from './strokeRenderer';
+
+  interface Props {
+    strokes: StrokeObject[];
+    width: number;
+    height: number;
+    ptToPx: number;
+  }
+
+  let { strokes, width, height, ptToPx }: Props = $props();
+
+  let canvas: HTMLCanvasElement;
+
+  function redraw() {
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.globalCompositeOperation = 'multiply';
+    for (const s of strokes) {
+      if (s.tool !== 'highlighter') continue;
+      const faded: StrokeObject = {
+        ...s,
+        style: { ...s.style, opacity: Math.min(s.style.opacity, 0.3) },
+      };
+      drawStroke(ctx, faded, { ptToPx });
+    }
+  }
+
+  onMount(redraw);
+
+  $effect(() => {
+    void strokes;
+    void width;
+    void height;
+    void ptToPx;
+    redraw();
+  });
+</script>
+
+<canvas
+  bind:this={canvas}
+  {width}
+  {height}
+  class="highlight-layer"
+  style="width: {width}px; height: {height}px;"
+></canvas>
+
+<style>
+  .highlight-layer {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+  }
+</style>

--- a/src/lib/canvas/InkLayer.svelte
+++ b/src/lib/canvas/InkLayer.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import type { StrokeObject } from '$lib/types';
+  import { drawStroke } from './strokeRenderer';
+
+  interface Props {
+    strokes: StrokeObject[];
+    width: number;
+    height: number;
+    ptToPx: number;
+  }
+
+  let { strokes, width, height, ptToPx }: Props = $props();
+
+  let canvas: HTMLCanvasElement;
+
+  function redraw() {
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.globalCompositeOperation = 'source-over';
+    for (const s of strokes) {
+      if (s.tool === 'pen') drawStroke(ctx, s, { ptToPx });
+    }
+  }
+
+  onMount(redraw);
+
+  $effect(() => {
+    void strokes;
+    void width;
+    void height;
+    void ptToPx;
+    redraw();
+  });
+</script>
+
+<canvas
+  bind:this={canvas}
+  {width}
+  {height}
+  class="ink-layer"
+  style="width: {width}px; height: {height}px;"
+></canvas>
+
+<style>
+  .ink-layer {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+  }
+</style>

--- a/src/lib/canvas/LiveLayer.svelte
+++ b/src/lib/canvas/LiveLayer.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
   import type { Point, StrokeObject, StrokeStyle, ToolKind } from '$lib/types';
   import { toolStore } from '$lib/store/tool';
   import { strokeFromInput } from '$lib/tools/pen';
@@ -27,10 +27,11 @@
     opacity: 1,
   };
 
-  toolStore.subscribe((s) => {
+  const unsubscribeTool = toolStore.subscribe((s) => {
     currentTool = s.tool;
     currentStyle = s.style;
   });
+  onDestroy(unsubscribeTool);
 
   function ctx(): CanvasRenderingContext2D | null {
     return canvas?.getContext('2d') ?? null;
@@ -43,6 +44,13 @@
   }
 
   export function clearLive() {
+    if (activePointerId !== null) {
+      try {
+        canvas?.releasePointerCapture(activePointerId);
+      } catch {
+        // not captured; ignore
+      }
+    }
     activePointerId = null;
     points = [];
     clear();
@@ -67,13 +75,7 @@
     clear();
     if (currentTool === 'highlighter') {
       c.globalCompositeOperation = 'multiply';
-      drawLiveStroke(
-        c,
-        points,
-        { ...currentStyle, opacity: Math.min(currentStyle.opacity, 0.3) },
-        'highlighter',
-        ptToPx,
-      );
+      drawLiveStroke(c, points, currentStyle, 'highlighter', ptToPx);
     } else if (currentTool === 'pen') {
       c.globalCompositeOperation = 'source-over';
       drawLiveStroke(c, points, currentStyle, 'pen', ptToPx);

--- a/src/lib/canvas/LiveLayer.svelte
+++ b/src/lib/canvas/LiveLayer.svelte
@@ -1,0 +1,169 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import type { Point, StrokeObject, StrokeStyle, ToolKind } from '$lib/types';
+  import { toolStore } from '$lib/store/tool';
+  import { strokeFromInput } from '$lib/tools/pen';
+  import { drawLiveStroke } from './strokeRenderer';
+
+  interface Props {
+    width: number;
+    height: number;
+    ptToPx: number;
+    oncommit?: (stroke: StrokeObject) => void;
+    onerase?: (at: { x: number; y: number }) => void;
+  }
+
+  let { width, height, ptToPx, oncommit, onerase }: Props = $props();
+
+  let canvas: HTMLCanvasElement;
+  let activePointerId: number | null = null;
+  let startTime = 0;
+  let points: Point[] = [];
+  let currentTool: ToolKind = 'pen';
+  let currentStyle: StrokeStyle = {
+    color: '#000',
+    width: 2,
+    dash: 'solid',
+    opacity: 1,
+  };
+
+  toolStore.subscribe((s) => {
+    currentTool = s.tool;
+    currentStyle = s.style;
+  });
+
+  function ctx(): CanvasRenderingContext2D | null {
+    return canvas?.getContext('2d') ?? null;
+  }
+
+  function clear() {
+    const c = ctx();
+    if (!c) return;
+    c.clearRect(0, 0, canvas.width, canvas.height);
+  }
+
+  export function clearLive() {
+    activePointerId = null;
+    points = [];
+    clear();
+  }
+
+  function toPoint(e: PointerEvent): Point {
+    const rect = canvas.getBoundingClientRect();
+    const px = e.clientX - rect.left;
+    const py = e.clientY - rect.top;
+    const pressure = e.pressure > 0 ? e.pressure : 0.5;
+    return {
+      x: px / ptToPx,
+      y: py / ptToPx,
+      pressure,
+      t: performance.now() - startTime,
+    };
+  }
+
+  function redrawLive() {
+    const c = ctx();
+    if (!c) return;
+    clear();
+    if (currentTool === 'highlighter') {
+      c.globalCompositeOperation = 'multiply';
+      drawLiveStroke(
+        c,
+        points,
+        { ...currentStyle, opacity: Math.min(currentStyle.opacity, 0.3) },
+        'highlighter',
+        ptToPx,
+      );
+    } else if (currentTool === 'pen') {
+      c.globalCompositeOperation = 'source-over';
+      drawLiveStroke(c, points, currentStyle, 'pen', ptToPx);
+    }
+  }
+
+  function onPointerDown(e: PointerEvent) {
+    if (e.pointerType === 'touch') return;
+    if (currentTool !== 'pen' && currentTool !== 'highlighter' && currentTool !== 'eraser') {
+      return;
+    }
+    canvas.setPointerCapture(e.pointerId);
+    activePointerId = e.pointerId;
+    startTime = performance.now();
+
+    if (currentTool === 'eraser') {
+      const p = toPoint(e);
+      onerase?.({ x: p.x, y: p.y });
+      return;
+    }
+
+    points = [toPoint(e)];
+    redrawLive();
+    e.preventDefault();
+  }
+
+  function onPointerMove(e: PointerEvent) {
+    if (activePointerId !== e.pointerId) return;
+    if (currentTool === 'eraser') {
+      const p = toPoint(e);
+      onerase?.({ x: p.x, y: p.y });
+      return;
+    }
+    if (currentTool !== 'pen' && currentTool !== 'highlighter') return;
+    points.push(toPoint(e));
+    redrawLive();
+    e.preventDefault();
+  }
+
+  function finish(e: PointerEvent, commit: boolean) {
+    if (activePointerId !== e.pointerId) return;
+    try {
+      canvas.releasePointerCapture(e.pointerId);
+    } catch {
+      // not captured; ignore
+    }
+    activePointerId = null;
+
+    if (commit && (currentTool === 'pen' || currentTool === 'highlighter') && points.length > 0) {
+      const stroke = strokeFromInput(points, currentStyle, currentTool);
+      oncommit?.(stroke);
+    }
+    points = [];
+    clear();
+  }
+
+  function onPointerUp(e: PointerEvent) {
+    finish(e, true);
+  }
+
+  function onPointerCancel(e: PointerEvent) {
+    finish(e, false);
+  }
+
+  onMount(clear);
+
+  $effect(() => {
+    void width;
+    void height;
+    if (canvas) redrawLive();
+  });
+</script>
+
+<canvas
+  bind:this={canvas}
+  {width}
+  {height}
+  class="live-layer"
+  style="width: {width}px; height: {height}px;"
+  onpointerdown={onPointerDown}
+  onpointermove={onPointerMove}
+  onpointerup={onPointerUp}
+  onpointercancel={onPointerCancel}
+></canvas>
+
+<style>
+  .live-layer {
+    position: absolute;
+    inset: 0;
+    touch-action: none;
+    cursor: crosshair;
+  }
+</style>

--- a/src/lib/canvas/strokeRenderer.ts
+++ b/src/lib/canvas/strokeRenderer.ts
@@ -1,0 +1,108 @@
+import { getStroke } from 'perfect-freehand';
+import type { Point, StrokeObject } from '$lib/types';
+
+export interface StrokeRenderOptions {
+  ptToPx: number;
+  simulatePressure?: boolean;
+}
+
+function toSvgPath(points: number[][]): string {
+  if (points.length === 0) return '';
+  const [first, ...rest] = points;
+  let d = `M ${first[0].toFixed(3)} ${first[1].toFixed(3)}`;
+  for (let i = 0; i < rest.length; i++) {
+    const [x, y] = rest[i];
+    const next = rest[i + 1];
+    if (next) {
+      const mx = (x + next[0]) / 2;
+      const my = (y + next[1]) / 2;
+      d += ` Q ${x.toFixed(3)} ${y.toFixed(3)} ${mx.toFixed(3)} ${my.toFixed(3)}`;
+    } else {
+      d += ` L ${x.toFixed(3)} ${y.toFixed(3)}`;
+    }
+  }
+  d += ' Z';
+  return d;
+}
+
+function inputToPx(points: Point[], ptToPx: number): [number, number, number][] {
+  return points.map((p) => [p.x * ptToPx, p.y * ptToPx, p.pressure]);
+}
+
+function dashPattern(dash: StrokeObject['style']['dash'], widthPx: number): number[] {
+  switch (dash) {
+    case 'dashed':
+      return [widthPx * 3, widthPx * 2];
+    case 'dotted':
+      return [widthPx, widthPx * 1.5];
+    case 'solid':
+    default:
+      return [];
+  }
+}
+
+export function drawStroke(
+  ctx: CanvasRenderingContext2D,
+  stroke: StrokeObject,
+  opts: StrokeRenderOptions,
+): void {
+  if (stroke.points.length === 0) return;
+
+  const { ptToPx } = opts;
+  const widthPx = stroke.style.width * ptToPx;
+  const input = inputToPx(stroke.points, ptToPx);
+
+  const outline = getStroke(input, {
+    size: widthPx * 2,
+    thinning: 0.6,
+    smoothing: 0.5,
+    streamline: 0.5,
+    simulatePressure: opts.simulatePressure ?? false,
+    last: true,
+  });
+
+  ctx.save();
+  ctx.globalAlpha = stroke.style.opacity;
+  ctx.fillStyle = stroke.style.color;
+
+  if (outline.length > 0) {
+    const path = new Path2D(toSvgPath(outline));
+    ctx.fill(path);
+  }
+
+  if (stroke.style.dash !== 'solid' && input.length > 1) {
+    ctx.strokeStyle = stroke.style.color;
+    ctx.lineWidth = Math.max(1, widthPx * 0.6);
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.setLineDash(dashPattern(stroke.style.dash, widthPx));
+    ctx.beginPath();
+    ctx.moveTo(input[0][0], input[0][1]);
+    for (let i = 1; i < input.length; i++) {
+      ctx.lineTo(input[i][0], input[i][1]);
+    }
+    ctx.stroke();
+    ctx.setLineDash([]);
+  }
+
+  ctx.restore();
+}
+
+export function drawLiveStroke(
+  ctx: CanvasRenderingContext2D,
+  points: Point[],
+  style: StrokeObject['style'],
+  tool: 'pen' | 'highlighter',
+  ptToPx: number,
+): void {
+  if (points.length === 0) return;
+  const temp: StrokeObject = {
+    id: 'live',
+    createdAt: 0,
+    type: 'stroke',
+    tool,
+    style,
+    points,
+  };
+  drawStroke(ctx, temp, { ptToPx, simulatePressure: false });
+}

--- a/src/lib/store/tool.ts
+++ b/src/lib/store/tool.ts
@@ -18,6 +18,15 @@ const perToolStyle: Record<StrokeTool, StrokeStyle> = {
   highlighter: { ...DEFAULT_STYLES.highlighter },
 };
 
+const HIGHLIGHTER_MAX_OPACITY = 0.3;
+
+function clampStyle(tool: ToolKind, style: StrokeStyle): StrokeStyle {
+  if (tool === 'highlighter' && style.opacity > HIGHLIGHTER_MAX_OPACITY) {
+    return { ...style, opacity: HIGHLIGHTER_MAX_OPACITY };
+  }
+  return style;
+}
+
 function initialState(): ToolState {
   return { tool: 'pen', style: { ...perToolStyle.pen } };
 }
@@ -35,14 +44,14 @@ export function setTool(tool: ToolKind): void {
     if (isStrokeTool(s.tool)) {
       perToolStyle[s.tool] = { ...s.style };
     }
-    const style = isStrokeTool(tool) ? { ...perToolStyle[tool] } : s.style;
+    const style = isStrokeTool(tool) ? clampStyle(tool, { ...perToolStyle[tool] }) : s.style;
     return { tool, style };
   });
 }
 
 export function setStyle(patch: Partial<StrokeStyle>): void {
   store.update((s) => {
-    const style = { ...s.style, ...patch };
+    const style = clampStyle(s.tool, { ...s.style, ...patch });
     if (isStrokeTool(s.tool)) {
       perToolStyle[s.tool] = { ...style };
     }

--- a/src/lib/store/tool.ts
+++ b/src/lib/store/tool.ts
@@ -1,0 +1,77 @@
+import { writable, get, type Readable } from 'svelte/store';
+import type { DashStyle, StrokeStyle, ToolKind } from '$lib/types';
+
+export type StrokeTool = 'pen' | 'highlighter';
+
+export interface ToolState {
+  tool: ToolKind;
+  style: StrokeStyle;
+}
+
+const DEFAULT_STYLES: Record<StrokeTool, StrokeStyle> = {
+  pen: { color: '#000000', width: 2, dash: 'solid', opacity: 1 },
+  highlighter: { color: '#ffeb3b', width: 14, dash: 'solid', opacity: 0.3 },
+};
+
+const perToolStyle: Record<StrokeTool, StrokeStyle> = {
+  pen: { ...DEFAULT_STYLES.pen },
+  highlighter: { ...DEFAULT_STYLES.highlighter },
+};
+
+function initialState(): ToolState {
+  return { tool: 'pen', style: { ...perToolStyle.pen } };
+}
+
+function isStrokeTool(tool: ToolKind): tool is StrokeTool {
+  return tool === 'pen' || tool === 'highlighter';
+}
+
+const store = writable<ToolState>(initialState());
+
+export const toolStore: Readable<ToolState> = { subscribe: store.subscribe };
+
+export function setTool(tool: ToolKind): void {
+  store.update((s) => {
+    if (isStrokeTool(s.tool)) {
+      perToolStyle[s.tool] = { ...s.style };
+    }
+    const style = isStrokeTool(tool) ? { ...perToolStyle[tool] } : s.style;
+    return { tool, style };
+  });
+}
+
+export function setStyle(patch: Partial<StrokeStyle>): void {
+  store.update((s) => {
+    const style = { ...s.style, ...patch };
+    if (isStrokeTool(s.tool)) {
+      perToolStyle[s.tool] = { ...style };
+    }
+    return { ...s, style };
+  });
+}
+
+export function setColor(color: string): void {
+  setStyle({ color });
+}
+
+export function setWidth(width: number): void {
+  setStyle({ width });
+}
+
+export function setDash(dash: DashStyle): void {
+  setStyle({ dash });
+}
+
+export function setOpacity(opacity: number): void {
+  setStyle({ opacity });
+}
+
+export function getToolState(): ToolState {
+  return get(store);
+}
+
+export function resetToolStoreForTests(): void {
+  perToolStyle.pen = { ...DEFAULT_STYLES.pen };
+  perToolStyle.highlighter = { ...DEFAULT_STYLES.highlighter };
+  store.set(initialState());
+}

--- a/src/lib/tools/eraser.ts
+++ b/src/lib/tools/eraser.ts
@@ -1,0 +1,63 @@
+import type { Point, StrokeObject } from '$lib/types';
+
+interface Vec {
+  x: number;
+  y: number;
+}
+
+function distanceToSegment(p: Vec, a: Vec, b: Vec): number {
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  const lenSq = dx * dx + dy * dy;
+  if (lenSq === 0) {
+    const ex = p.x - a.x;
+    const ey = p.y - a.y;
+    return Math.hypot(ex, ey);
+  }
+  let t = ((p.x - a.x) * dx + (p.y - a.y) * dy) / lenSq;
+  t = Math.max(0, Math.min(1, t));
+  const cx = a.x + t * dx;
+  const cy = a.y + t * dy;
+  return Math.hypot(p.x - cx, p.y - cy);
+}
+
+/**
+ * Hit-test an eraser touch against a stroke.
+ * Treats the stroke as a thick polyline whose half-thickness is
+ * max(style.width / 2, pressure * style.width) at each segment, plus `radius`.
+ */
+export function hitTestStroke(
+  stroke: StrokeObject,
+  at: { x: number; y: number },
+  radius: number,
+): boolean {
+  const pts = stroke.points;
+  if (pts.length === 0) return false;
+
+  const baseHalf = stroke.style.width / 2;
+
+  if (pts.length === 1) {
+    const d = Math.hypot(pts[0].x - at.x, pts[0].y - at.y);
+    return d <= baseHalf + radius;
+  }
+
+  for (let i = 0; i < pts.length - 1; i++) {
+    const a = pts[i];
+    const b = pts[i + 1];
+    const pressure = Math.max(a.pressure, b.pressure);
+    const half = Math.max(baseHalf, baseHalf * 2 * pressure);
+    const d = distanceToSegment(at, a, b);
+    if (d <= half + radius) return true;
+  }
+  return false;
+}
+
+export function hitTestStrokes(
+  strokes: StrokeObject[],
+  at: { x: number; y: number },
+  radius: number,
+): StrokeObject[] {
+  return strokes.filter((s) => hitTestStroke(s, at, radius));
+}
+
+export type { Point };

--- a/src/lib/tools/highlighter.ts
+++ b/src/lib/tools/highlighter.ts
@@ -1,0 +1,1 @@
+export { strokeFromInput } from './pen';

--- a/src/lib/tools/pen.ts
+++ b/src/lib/tools/pen.ts
@@ -1,0 +1,16 @@
+import type { Point, StrokeObject, StrokeStyle } from '$lib/types';
+
+export function strokeFromInput(
+  points: Point[],
+  style: StrokeStyle,
+  tool: 'pen' | 'highlighter',
+): StrokeObject {
+  return {
+    id: crypto.randomUUID(),
+    createdAt: Date.now(),
+    type: 'stroke',
+    tool,
+    style: { ...style },
+    points: points.map((p) => ({ ...p })),
+  };
+}

--- a/tests/eraser.test.ts
+++ b/tests/eraser.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { hitTestStroke } from '$lib/tools/eraser';
+import type { Point, StrokeObject } from '$lib/types';
+
+function pt(x: number, y: number, pressure = 0.5): Point {
+  return { x, y, pressure, t: 0 };
+}
+
+function mkStroke(points: Point[], width = 2): StrokeObject {
+  return {
+    id: 's',
+    createdAt: 0,
+    type: 'stroke',
+    tool: 'pen',
+    style: { color: '#000', width, dash: 'solid', opacity: 1 },
+    points,
+  };
+}
+
+describe('hitTestStroke', () => {
+  it('hits a point inside a thin stroke', () => {
+    const s = mkStroke([pt(0, 0), pt(100, 0)], 2);
+    expect(hitTestStroke(s, { x: 50, y: 0 }, 1)).toBe(true);
+  });
+
+  it('misses a point far outside', () => {
+    const s = mkStroke([pt(0, 0), pt(100, 0)], 2);
+    expect(hitTestStroke(s, { x: 50, y: 100 }, 1)).toBe(false);
+  });
+
+  it('hits near the endpoint of a stroke', () => {
+    const s = mkStroke([pt(0, 0), pt(100, 0)], 2);
+    expect(hitTestStroke(s, { x: 100, y: 0.5 }, 0.5)).toBe(true);
+  });
+
+  it('hits inside a fat stroke even when segment center is far', () => {
+    const s = mkStroke([pt(0, 0), pt(100, 0)], 20);
+    expect(hitTestStroke(s, { x: 50, y: 9 }, 0)).toBe(true);
+    expect(hitTestStroke(s, { x: 50, y: 20 }, 0)).toBe(false);
+  });
+
+  it('returns false for empty strokes', () => {
+    const s = mkStroke([], 2);
+    expect(hitTestStroke(s, { x: 0, y: 0 }, 5)).toBe(false);
+  });
+
+  it('single-point stroke behaves like a disc', () => {
+    const s = mkStroke([pt(10, 10)], 4);
+    expect(hitTestStroke(s, { x: 11, y: 10 }, 0)).toBe(true);
+    expect(hitTestStroke(s, { x: 20, y: 10 }, 0)).toBe(false);
+    expect(hitTestStroke(s, { x: 20, y: 10 }, 10)).toBe(true);
+  });
+
+  it('eraser radius grows the hit area', () => {
+    const s = mkStroke([pt(0, 0), pt(100, 0)], 2);
+    expect(hitTestStroke(s, { x: 50, y: 5 }, 0)).toBe(false);
+    expect(hitTestStroke(s, { x: 50, y: 5 }, 5)).toBe(true);
+  });
+});

--- a/tests/stroke-from-input.test.ts
+++ b/tests/stroke-from-input.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { strokeFromInput } from '$lib/tools/pen';
+import type { Point, StrokeStyle } from '$lib/types';
+
+const style: StrokeStyle = {
+  color: '#112233',
+  width: 3,
+  dash: 'solid',
+  opacity: 1,
+};
+
+describe('strokeFromInput', () => {
+  it('produces a stroke with id, timestamp, type, tool, and style copy', () => {
+    const points: Point[] = [
+      { x: 0, y: 0, pressure: 0.4, t: 0 },
+      { x: 10, y: 5, pressure: 0.7, t: 16 },
+    ];
+    const before = Date.now();
+    const stroke = strokeFromInput(points, style, 'pen');
+    const after = Date.now();
+
+    expect(stroke.type).toBe('stroke');
+    expect(stroke.tool).toBe('pen');
+    expect(typeof stroke.id).toBe('string');
+    expect(stroke.id.length).toBeGreaterThan(0);
+    expect(stroke.createdAt).toBeGreaterThanOrEqual(before);
+    expect(stroke.createdAt).toBeLessThanOrEqual(after);
+    expect(stroke.style).toEqual(style);
+    expect(stroke.style).not.toBe(style);
+    expect(stroke.points).toHaveLength(2);
+    expect(stroke.points[0]).toEqual(points[0]);
+    expect(stroke.points[0]).not.toBe(points[0]);
+  });
+
+  it('preserves explicit pressure values', () => {
+    const points: Point[] = [
+      { x: 0, y: 0, pressure: 0.25, t: 0 },
+      { x: 1, y: 1, pressure: 0.9, t: 8 },
+    ];
+    const s = strokeFromInput(points, style, 'pen');
+    expect(s.points.map((p) => p.pressure)).toEqual([0.25, 0.9]);
+  });
+
+  it('produces unique ids across calls', () => {
+    const p: Point[] = [{ x: 0, y: 0, pressure: 0.5, t: 0 }];
+    const a = strokeFromInput(p, style, 'pen');
+    const b = strokeFromInput(p, style, 'pen');
+    expect(a.id).not.toBe(b.id);
+  });
+
+  it('accepts highlighter tool', () => {
+    const p: Point[] = [{ x: 0, y: 0, pressure: 0.5, t: 0 }];
+    const s = strokeFromInput(p, style, 'highlighter');
+    expect(s.tool).toBe('highlighter');
+  });
+
+  it('keeps 0.5 pressure default when caller set it that way', () => {
+    const p: Point[] = [{ x: 0, y: 0, pressure: 0.5, t: 0 }];
+    const s = strokeFromInput(p, style, 'pen');
+    expect(s.points[0].pressure).toBe(0.5);
+    expect(s.points[0].t).toBe(0);
+  });
+});

--- a/tests/tool-store.test.ts
+++ b/tests/tool-store.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+import {
+  toolStore,
+  setTool,
+  setStyle,
+  setColor,
+  setWidth,
+  resetToolStoreForTests,
+} from '$lib/store/tool';
+
+describe('tool store', () => {
+  beforeEach(() => resetToolStoreForTests());
+
+  it('starts with pen + sensible defaults', () => {
+    const s = get(toolStore);
+    expect(s.tool).toBe('pen');
+    expect(s.style.color).toBe('#000000');
+    expect(s.style.width).toBe(2);
+    expect(s.style.dash).toBe('solid');
+    expect(s.style.opacity).toBe(1);
+  });
+
+  it('switching tools remembers per-tool style', () => {
+    setColor('#ff0000');
+    setWidth(5);
+    expect(get(toolStore).style.color).toBe('#ff0000');
+
+    setTool('highlighter');
+    const hl = get(toolStore);
+    expect(hl.tool).toBe('highlighter');
+    expect(hl.style.color).toBe('#ffeb3b');
+    expect(hl.style.width).toBe(14);
+
+    setColor('#00ff00');
+    expect(get(toolStore).style.color).toBe('#00ff00');
+
+    setTool('pen');
+    const pen = get(toolStore);
+    expect(pen.tool).toBe('pen');
+    expect(pen.style.color).toBe('#ff0000');
+    expect(pen.style.width).toBe(5);
+
+    setTool('highlighter');
+    expect(get(toolStore).style.color).toBe('#00ff00');
+  });
+
+  it('setStyle merges partial updates', () => {
+    setStyle({ dash: 'dashed', opacity: 0.5 });
+    const s = get(toolStore);
+    expect(s.style.dash).toBe('dashed');
+    expect(s.style.opacity).toBe(0.5);
+    expect(s.style.color).toBe('#000000');
+  });
+
+  it('switching to a non-stroke tool keeps current style', () => {
+    setColor('#123456');
+    setTool('eraser');
+    expect(get(toolStore).tool).toBe('eraser');
+    expect(get(toolStore).style.color).toBe('#123456');
+  });
+});

--- a/tests/tool-store.test.ts
+++ b/tests/tool-store.test.ts
@@ -59,4 +59,17 @@ describe('tool store', () => {
     expect(get(toolStore).tool).toBe('eraser');
     expect(get(toolStore).style.color).toBe('#123456');
   });
+
+  it('clamps highlighter opacity to 0.3 at the store boundary', () => {
+    setTool('highlighter');
+    setStyle({ opacity: 0.9 });
+    expect(get(toolStore).style.opacity).toBe(0.3);
+
+    setStyle({ opacity: 0.1 });
+    expect(get(toolStore).style.opacity).toBe(0.1);
+
+    setTool('pen');
+    setStyle({ opacity: 0.9 });
+    expect(get(toolStore).style.opacity).toBe(0.9);
+  });
 });


### PR DESCRIPTION
## Summary

Core inking engine for eldraw: Pointer Events capture with stylus pressure, perfect-freehand stroke rendering, and the layered canvas stack from PLAN.md (minus the PDF layer, handled by the `pdf-pipeline` worktree).

## What's included

- `perfect-freehand` added as a runtime dep.
- `src/lib/canvas/`:
  - `InkLayer.svelte` — renders committed pen strokes.
  - `HighlightLayer.svelte` — renders highlighter strokes with `globalCompositeOperation = 'multiply'` and capped 0.3 alpha.
  - `LiveLayer.svelte` — Pointer Events capture (`setPointerCapture`, ignores `pointerType === 'touch'`), tracks one in-progress stroke, redraws via perfect-freehand on every move, emits `oncommit` / `onerase` callbacks. Exposes `clearLive()`.
  - `CanvasStack.svelte` — composes HighlightLayer → (objects slot) → InkLayer → LiveLayer with absolute positioning and z-index.
  - `strokeRenderer.ts` — shared helper: feeds input into `getStroke` with recommended options (`size = width*2`, `thinning=0.6`, `smoothing=0.5`, `streamline=0.5`, `simulatePressure=false`), fills the outline polygon via `Path2D`, and draws a dashed/dotted centerline on top for non-solid styles.
- `src/lib/tools/`:
  - `pen.ts` / `highlighter.ts` — `strokeFromInput()` builder (UUID id, `Date.now()` timestamp, deep-copies style + points).
  - `eraser.ts` — pure `hitTestStroke()` using point-to-thick-polyline distance, plus a `hitTestStrokes()` helper.
- `src/lib/store/tool.ts` — Svelte store with per-tool remembered styles (pen, highlighter). Defaults: pen black width 2 solid; helpers to switch tool / color / width / dash / opacity.

## Tests

`pnpm test` → 17 passed.

- `tests/eraser.test.ts` — inside, outside, endpoint, fat-stroke, empty, single-point, eraser-radius cases.
- `tests/tool-store.test.ts` — defaults, per-tool style memory across switches, partial `setStyle` merging, non-stroke tool preserves style.
- `tests/stroke-from-input.test.ts` — valid id/timestamp/type/tool, style + points deep-copied, unique ids, explicit pressure preserved.

## Verification

- `pnpm lint` ✅ (prettier + eslint + svelte-check, 0 errors, 0 warnings).
- `pnpm test` ✅ (4 files, 17 tests).

## Out of scope

- PDF rendering layer (owned by `feat/pdf-pipeline`).
- Sidebar UI (owned by `feat/sidebar-tools`).
- Undo/redo + persistence (owned by `feat/storage-history`).
- `+page.svelte` wiring (owned by `feat/app-shell`).