### PR TITLE
feat(sidebar): tool + color + width + dash sidebar with pin toggle

### DIFF
--- a/src/lib/sidebar/ColorPalette.svelte
+++ b/src/lib/sidebar/ColorPalette.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+  import { sidebar } from '$lib/store/sidebar';
+  import type { ColorPalette as Palette } from '$lib/types';
+
+  interface Props {
+    palettes: Palette[];
+    activeColor: string;
+    onChange?: (color: string) => void;
+  }
+
+  let { palettes, activeColor, onChange }: Props = $props();
+
+  let colorInput: HTMLInputElement | undefined = $state();
+
+  function select(color: string) {
+    sidebar.setActiveColor(color);
+    onChange?.(color);
+  }
+
+  function openPicker() {
+    colorInput?.click();
+  }
+
+  function onPicked(e: Event) {
+    const value = (e.target as HTMLInputElement).value;
+    sidebar.addCustomColor(value);
+    select(value);
+  }
+
+  function onContext(e: MouseEvent, paletteId: string, color: string) {
+    if (paletteId !== 'custom') return;
+    e.preventDefault();
+    sidebar.removeCustomColor(color);
+  }
+</script>
+
+<div class="palette">
+  {#each palettes as palette (palette.id)}
+    {#if palette.colors.length > 0}
+      <div class="row" role="group" aria-label={palette.name}>
+        {#each palette.colors as color (color)}
+          <button
+            type="button"
+            class="swatch"
+            class:active={color === activeColor}
+            style="background: {color}"
+            title={color}
+            aria-label={`${palette.name} ${color}`}
+            oncontextmenu={(e) => onContext(e, palette.id, color)}
+            onclick={() => select(color)}
+          ></button>
+        {/each}
+      </div>
+    {/if}
+  {/each}
+
+  <button type="button" class="add" title="Add custom color" onclick={openPicker}> + </button>
+  <input
+    bind:this={colorInput}
+    type="color"
+    class="hidden-color"
+    aria-hidden="true"
+    tabindex="-1"
+    onchange={onPicked}
+  />
+</div>
+
+<style>
+  .palette {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
+  }
+  .row {
+    display: contents;
+  }
+  .swatch {
+    width: 22px;
+    height: 22px;
+    border-radius: 4px;
+    border: 1px solid #3a3a3a;
+    padding: 0;
+    cursor: pointer;
+    box-sizing: border-box;
+  }
+  .swatch:hover {
+    transform: scale(1.08);
+  }
+  .swatch.active {
+    outline: 2px solid #7ab7ff;
+    outline-offset: 1px;
+  }
+  .add {
+    width: 22px;
+    height: 22px;
+    border-radius: 4px;
+    border: 1px dashed #666;
+    background: transparent;
+    color: #bbb;
+    font-size: 14px;
+    line-height: 1;
+    cursor: pointer;
+  }
+  .add:hover {
+    color: #fff;
+    border-color: #aaa;
+  }
+  .hidden-color {
+    position: absolute;
+    width: 0;
+    height: 0;
+    opacity: 0;
+    pointer-events: none;
+  }
+</style>

--- a/src/lib/sidebar/ColorPalette.svelte
+++ b/src/lib/sidebar/ColorPalette.svelte
@@ -73,7 +73,10 @@
     align-items: center;
   }
   .row {
-    display: contents;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
   }
   .swatch {
     width: 22px;

--- a/src/lib/sidebar/DashStyleToggle.svelte
+++ b/src/lib/sidebar/DashStyleToggle.svelte
@@ -24,7 +24,13 @@
 <div class="dash">
   <div class="header">
     <span class="label">Dash</span>
-    <button type="button" class="cycle" title="Cycle dash (D)" onclick={cycle}>{value}</button>
+    <button
+      type="button"
+      class="cycle"
+      aria-label="Cycle dash style"
+      title="Cycle dash (D)"
+      onclick={cycle}>{value}</button
+    >
   </div>
   <div class="row" role="group" aria-label="Dash style">
     {#each order as style (style)}

--- a/src/lib/sidebar/DashStyleToggle.svelte
+++ b/src/lib/sidebar/DashStyleToggle.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+  import type { DashStyle } from '$lib/types';
+
+  interface Props {
+    value: DashStyle;
+    onChange?: (dash: DashStyle) => void;
+  }
+
+  let { value, onChange }: Props = $props();
+
+  const order: DashStyle[] = ['solid', 'dashed', 'dotted'];
+
+  function cycle() {
+    const idx = order.indexOf(value);
+    const next = order[(idx + 1) % order.length];
+    onChange?.(next);
+  }
+
+  function select(dash: DashStyle) {
+    if (dash !== value) onChange?.(dash);
+  }
+</script>
+
+<div class="dash">
+  <div class="header">
+    <span class="label">Dash</span>
+    <button type="button" class="cycle" title="Cycle dash (D)" onclick={cycle}>{value}</button>
+  </div>
+  <div class="row" role="group" aria-label="Dash style">
+    {#each order as style (style)}
+      <button
+        type="button"
+        class="option"
+        class:active={style === value}
+        title={style}
+        aria-pressed={style === value}
+        onclick={() => select(style)}
+      >
+        <svg viewBox="0 0 60 12" width="60" height="12" aria-hidden="true">
+          <line
+            x1="2"
+            y1="6"
+            x2="58"
+            y2="6"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-dasharray={style === 'solid' ? undefined : style === 'dashed' ? '8 5' : '1 5'}
+          />
+        </svg>
+      </button>
+    {/each}
+  </div>
+</div>
+
+<style>
+  .dash {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    color: #bbb;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .cycle {
+    background: transparent;
+    border: none;
+    color: #eee;
+    text-transform: none;
+    font: inherit;
+    cursor: pointer;
+    letter-spacing: 0;
+  }
+  .row {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 6px;
+  }
+  .option {
+    background: #1b1b1b;
+    border: 1px solid #333;
+    color: #ccc;
+    border-radius: 4px;
+    padding: 6px 4px;
+    cursor: pointer;
+    display: grid;
+    place-items: center;
+  }
+  .option:hover {
+    border-color: #555;
+    color: #fff;
+  }
+  .option.active {
+    border-color: #7ab7ff;
+    color: #fff;
+    background: #2a3847;
+  }
+</style>

--- a/src/lib/sidebar/Sidebar.svelte
+++ b/src/lib/sidebar/Sidebar.svelte
@@ -36,7 +36,9 @@
     if (disabled) return;
     sidebar.setTool(tool);
     onToolChange?.(tool);
-    onStyleChange?.(sidebar.snapshot().toolStyles.pen);
+    if (tool === 'pen' || tool === 'highlighter' || tool === 'line') {
+      onStyleChange?.(sidebar.snapshot().toolStyles[tool]);
+    }
   }
 
   function onColor(color: string) {
@@ -71,10 +73,11 @@
       type="button"
       class="pin"
       aria-pressed={state.pinned}
+      aria-label={state.pinned ? 'Unpin sidebar' : 'Pin sidebar'}
       title={state.pinned ? 'Unpin sidebar' : 'Pin sidebar'}
       onclick={togglePin}
     >
-      {state.pinned ? '📌' : '📍'}
+      <span aria-hidden="true">{state.pinned ? '📌' : '📍'}</span>
     </button>
   </header>
 

--- a/src/lib/sidebar/Sidebar.svelte
+++ b/src/lib/sidebar/Sidebar.svelte
@@ -1,0 +1,228 @@
+<script lang="ts">
+  import { currentStyle, sidebar } from '$lib/store/sidebar';
+  import type { DashStyle, StrokeStyle, ToolKind } from '$lib/types';
+  import ColorPalette from './ColorPalette.svelte';
+  import WidthPicker from './WidthPicker.svelte';
+  import DashStyleToggle from './DashStyleToggle.svelte';
+
+  interface Props {
+    onToolChange?: (tool: ToolKind) => void;
+    onStyleChange?: (style: StrokeStyle) => void;
+    onPinChange?: (pinned: boolean) => void;
+  }
+
+  let { onToolChange, onStyleChange, onPinChange }: Props = $props();
+
+  interface ToolSpec {
+    id: ToolKind;
+    label: string;
+    shortcut: string;
+    icon: string;
+    disabled?: boolean;
+  }
+
+  const tools: ToolSpec[] = [
+    { id: 'pen', label: 'Pen', shortcut: 'P', icon: '✏️' },
+    { id: 'highlighter', label: 'Highlighter', shortcut: 'H', icon: '🖍️' },
+    { id: 'eraser', label: 'Eraser', shortcut: 'E', icon: '🧽' },
+    { id: 'line', label: 'Line', shortcut: 'L', icon: '／' },
+    { id: 'graph', label: 'Graph (coming soon)', shortcut: 'G', icon: '📈', disabled: true },
+  ];
+
+  const state = $derived($sidebar);
+  const style = $derived($currentStyle);
+
+  function pickTool(tool: ToolKind, disabled: boolean | undefined) {
+    if (disabled) return;
+    sidebar.setTool(tool);
+    onToolChange?.(tool);
+    onStyleChange?.(sidebar.snapshot().toolStyles.pen);
+  }
+
+  function onColor(color: string) {
+    onStyleChange?.({ ...style, color });
+  }
+
+  function onWidth(width: number) {
+    sidebar.setWidth(width);
+    onStyleChange?.({ ...style, width });
+  }
+
+  function onDash(dash: DashStyle) {
+    sidebar.setDash(dash);
+    onStyleChange?.({ ...style, dash });
+  }
+
+  function togglePin() {
+    sidebar.togglePin();
+    onPinChange?.(sidebar.snapshot().pinned);
+  }
+</script>
+
+<aside
+  class="sidebar"
+  class:pinned={state.pinned}
+  class:floating={!state.pinned}
+  aria-label="Tool sidebar"
+>
+  <header class="head">
+    <span class="title">Tools</span>
+    <button
+      type="button"
+      class="pin"
+      aria-pressed={state.pinned}
+      title={state.pinned ? 'Unpin sidebar' : 'Pin sidebar'}
+      onclick={togglePin}
+    >
+      {state.pinned ? '📌' : '📍'}
+    </button>
+  </header>
+
+  <section class="tools" aria-label="Tools">
+    {#each tools as tool (tool.id)}
+      <button
+        type="button"
+        class="tool"
+        class:active={state.activeTool === tool.id}
+        disabled={tool.disabled}
+        title={`${tool.label} (${tool.shortcut})`}
+        aria-pressed={state.activeTool === tool.id}
+        onclick={() => pickTool(tool.id, tool.disabled)}
+      >
+        <span class="icon" aria-hidden="true">{tool.icon}</span>
+        <span class="label">{tool.label.split(' ')[0]}</span>
+        <span class="hint" aria-hidden="true">{tool.shortcut}</span>
+      </button>
+    {/each}
+  </section>
+
+  <section class="section" aria-label="Color">
+    <h3 class="section-title">Color</h3>
+    <ColorPalette palettes={state.palettes} activeColor={state.activeColor} onChange={onColor} />
+  </section>
+
+  <section class="section" aria-label="Width">
+    <WidthPicker value={style.width} color={style.color} onChange={onWidth} />
+  </section>
+
+  <section class="section" aria-label="Dash">
+    <DashStyleToggle value={style.dash} onChange={onDash} />
+  </section>
+</aside>
+
+<style>
+  .sidebar {
+    background: #252525;
+    color: #e8e8e8;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    padding: 12px;
+    box-sizing: border-box;
+    min-width: 200px;
+    font-family:
+      system-ui,
+      -apple-system,
+      Segoe UI,
+      sans-serif;
+    font-size: 13px;
+  }
+  .sidebar.pinned {
+    width: 220px;
+    height: 100%;
+    border-right: 1px solid #1a1a1a;
+  }
+  .sidebar.floating {
+    position: absolute;
+    left: 12px;
+    top: 12px;
+    width: 220px;
+    border-radius: 8px;
+    border: 1px solid #1a1a1a;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+    z-index: 10;
+  }
+
+  .head {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  .title {
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    font-size: 11px;
+    color: #aaa;
+  }
+  .pin {
+    background: transparent;
+    border: 1px solid #3a3a3a;
+    color: #ddd;
+    border-radius: 4px;
+    padding: 2px 6px;
+    cursor: pointer;
+  }
+  .pin:hover {
+    border-color: #666;
+  }
+
+  .tools {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 6px;
+  }
+  .tool {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    background: #1b1b1b;
+    border: 1px solid #333;
+    color: #ddd;
+    border-radius: 6px;
+    padding: 8px 4px;
+    cursor: pointer;
+    position: relative;
+  }
+  .tool:hover:not(:disabled) {
+    border-color: #666;
+  }
+  .tool.active {
+    border-color: #7ab7ff;
+    background: #2a3847;
+    color: #fff;
+    box-shadow: 0 0 0 2px rgba(122, 183, 255, 0.25);
+  }
+  .tool:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+  .tool .icon {
+    font-size: 18px;
+  }
+  .tool .label {
+    font-size: 11px;
+  }
+  .tool .hint {
+    position: absolute;
+    top: 4px;
+    right: 6px;
+    font-size: 10px;
+    color: #888;
+  }
+
+  .section {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .section-title {
+    font-size: 11px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: #bbb;
+    margin: 0;
+    font-weight: 500;
+  }
+</style>

--- a/src/lib/sidebar/WidthPicker.svelte
+++ b/src/lib/sidebar/WidthPicker.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+  interface Props {
+    value: number;
+    color: string;
+    min?: number;
+    max?: number;
+    onChange?: (width: number) => void;
+  }
+
+  let { value, color, min = 1, max = 40, onChange }: Props = $props();
+
+  const dotSize = $derived(Math.min(max, Math.max(min, value)));
+
+  function onInput(e: Event) {
+    const next = Number((e.target as HTMLInputElement).value);
+    onChange?.(next);
+  }
+</script>
+
+<div class="width-picker">
+  <div class="header">
+    <span class="label">Width</span>
+    <span class="value">{value}px</span>
+  </div>
+  <div class="row">
+    <input type="range" {min} {max} {value} oninput={onInput} aria-label="Stroke width" />
+    <div class="preview" aria-hidden="true">
+      <span class="dot" style="width: {dotSize}px; height: {dotSize}px; background: {color};"
+      ></span>
+    </div>
+  </div>
+</div>
+
+<style>
+  .width-picker {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .header {
+    display: flex;
+    justify-content: space-between;
+    color: #bbb;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .value {
+    color: #eee;
+    text-transform: none;
+    letter-spacing: 0;
+  }
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  input[type='range'] {
+    flex: 1;
+    accent-color: #7ab7ff;
+  }
+  .preview {
+    width: 44px;
+    height: 44px;
+    display: grid;
+    place-items: center;
+    border: 1px solid #333;
+    border-radius: 4px;
+    background: #1b1b1b;
+  }
+  .dot {
+    display: block;
+    border-radius: 50%;
+    max-width: 40px;
+    max-height: 40px;
+  }
+</style>

--- a/src/lib/sidebar/index.ts
+++ b/src/lib/sidebar/index.ts
@@ -1,0 +1,4 @@
+export { default as Sidebar } from './Sidebar.svelte';
+export { default as ColorPalette } from './ColorPalette.svelte';
+export { default as WidthPicker } from './WidthPicker.svelte';
+export { default as DashStyleToggle } from './DashStyleToggle.svelte';

--- a/src/lib/store/sidebar.ts
+++ b/src/lib/store/sidebar.ts
@@ -1,0 +1,177 @@
+import { derived, get, writable, type Readable } from 'svelte/store';
+import type { ColorPalette, DashStyle, StrokeStyle, ToolKind } from '$lib/types';
+
+export type StyledTool = 'pen' | 'highlighter' | 'line';
+
+export const PRESET_COLORS: readonly string[] = [
+  '#000000',
+  '#e53935',
+  '#1e88e5',
+  '#43a047',
+  '#fb8c00',
+  '#8e24aa',
+  '#fdd835',
+  '#00acc1',
+  '#ec407a',
+  '#ffffff',
+];
+
+const DEFAULT_PEN: StrokeStyle = { color: '#000000', width: 2, dash: 'solid', opacity: 1 };
+const DEFAULT_HIGHLIGHTER: StrokeStyle = {
+  color: '#fdd835',
+  width: 14,
+  dash: 'solid',
+  opacity: 0.3,
+};
+const DEFAULT_LINE: StrokeStyle = { color: '#000000', width: 2, dash: 'solid', opacity: 1 };
+
+export interface SidebarState {
+  pinned: boolean;
+  activeTool: ToolKind;
+  toolStyles: Record<StyledTool, StrokeStyle>;
+  palettes: ColorPalette[];
+  activeColor: string;
+}
+
+function initialState(): SidebarState {
+  return {
+    pinned: true,
+    activeTool: 'pen',
+    toolStyles: {
+      pen: { ...DEFAULT_PEN },
+      highlighter: { ...DEFAULT_HIGHLIGHTER },
+      line: { ...DEFAULT_LINE },
+    },
+    palettes: [
+      { id: 'presets', name: 'Presets', colors: [...PRESET_COLORS] },
+      { id: 'custom', name: 'Custom', colors: [] },
+    ],
+    activeColor: '#000000',
+  };
+}
+
+function isStyledTool(tool: ToolKind): tool is StyledTool {
+  return tool === 'pen' || tool === 'highlighter' || tool === 'line';
+}
+
+function nextDash(current: DashStyle): DashStyle {
+  if (current === 'solid') return 'dashed';
+  if (current === 'dashed') return 'dotted';
+  return 'solid';
+}
+
+function mapPalette(
+  state: SidebarState,
+  id: string,
+  fn: (colors: string[]) => string[],
+): SidebarState {
+  return {
+    ...state,
+    palettes: state.palettes.map((p) => (p.id === id ? { ...p, colors: fn(p.colors) } : p)),
+  };
+}
+
+function createSidebarStore() {
+  const store = writable<SidebarState>(initialState());
+  const { subscribe, update, set } = store;
+
+  return {
+    subscribe,
+    set,
+    reset: () => set(initialState()),
+
+    setTool(tool: ToolKind) {
+      update((s) => {
+        if (s.activeTool === tool) return s;
+        const next: SidebarState = { ...s, activeTool: tool };
+        if (isStyledTool(tool)) {
+          next.activeColor = s.toolStyles[tool].color;
+        }
+        return next;
+      });
+    },
+
+    setActiveColor(color: string) {
+      update((s) => {
+        const next: SidebarState = { ...s, activeColor: color };
+        if (isStyledTool(s.activeTool)) {
+          next.toolStyles = {
+            ...s.toolStyles,
+            [s.activeTool]: { ...s.toolStyles[s.activeTool], color },
+          };
+        }
+        return next;
+      });
+    },
+
+    addCustomColor(color: string) {
+      update((s) => {
+        const presets = s.palettes.find((p) => p.id === 'presets');
+        const custom = s.palettes.find((p) => p.id === 'custom');
+        if (presets?.colors.includes(color) || custom?.colors.includes(color)) return s;
+        return mapPalette(s, 'custom', (colors) => [...colors, color]);
+      });
+    },
+
+    removeCustomColor(color: string) {
+      update((s) => mapPalette(s, 'custom', (colors) => colors.filter((c) => c !== color)));
+    },
+
+    setWidth(width: number) {
+      update((s) => {
+        if (!isStyledTool(s.activeTool)) return s;
+        return {
+          ...s,
+          toolStyles: {
+            ...s.toolStyles,
+            [s.activeTool]: { ...s.toolStyles[s.activeTool], width },
+          },
+        };
+      });
+    },
+
+    setDash(dash: DashStyle) {
+      update((s) => {
+        if (!isStyledTool(s.activeTool)) return s;
+        return {
+          ...s,
+          toolStyles: {
+            ...s.toolStyles,
+            [s.activeTool]: { ...s.toolStyles[s.activeTool], dash },
+          },
+        };
+      });
+    },
+
+    cycleDash() {
+      update((s) => {
+        if (!isStyledTool(s.activeTool)) return s;
+        const current = s.toolStyles[s.activeTool];
+        return {
+          ...s,
+          toolStyles: {
+            ...s.toolStyles,
+            [s.activeTool]: { ...current, dash: nextDash(current.dash) },
+          },
+        };
+      });
+    },
+
+    togglePin() {
+      update((s) => ({ ...s, pinned: !s.pinned }));
+    },
+
+    snapshot(): SidebarState {
+      return get(store);
+    },
+  };
+}
+
+export const sidebar = createSidebarStore();
+
+export const currentStyle: Readable<StrokeStyle> = derived(sidebar, (s) => {
+  const base = isStyledTool(s.activeTool)
+    ? s.toolStyles[s.activeTool]
+    : { color: s.activeColor, width: 2, dash: 'solid' as DashStyle, opacity: 1 };
+  return { ...base, color: s.activeColor };
+});

--- a/tests/sidebar-store.test.ts
+++ b/tests/sidebar-store.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+import { currentStyle, PRESET_COLORS, sidebar } from '$lib/store/sidebar';
+
+describe('sidebar store', () => {
+  beforeEach(() => sidebar.reset());
+
+  it('switches tools while preserving per-tool width, dash, opacity', () => {
+    sidebar.setTool('pen');
+    sidebar.setWidth(7);
+    sidebar.setDash('dashed');
+
+    sidebar.setTool('highlighter');
+    expect(sidebar.snapshot().toolStyles.highlighter.width).toBe(14);
+    expect(sidebar.snapshot().toolStyles.highlighter.dash).toBe('solid');
+    expect(sidebar.snapshot().toolStyles.highlighter.opacity).toBe(0.3);
+
+    sidebar.setWidth(20);
+    sidebar.setDash('dotted');
+
+    sidebar.setTool('pen');
+    const pen = sidebar.snapshot().toolStyles.pen;
+    expect(pen.width).toBe(7);
+    expect(pen.dash).toBe('dashed');
+    expect(pen.opacity).toBe(1);
+
+    const hl = sidebar.snapshot().toolStyles.highlighter;
+    expect(hl.width).toBe(20);
+    expect(hl.dash).toBe('dotted');
+  });
+
+  it('adds and removes custom colors; refuses to remove presets', () => {
+    sidebar.addCustomColor('#123456');
+    sidebar.addCustomColor('#abcdef');
+    sidebar.addCustomColor('#123456');
+    const custom = sidebar.snapshot().palettes.find((p) => p.id === 'custom');
+    expect(custom?.colors).toEqual(['#123456', '#abcdef']);
+
+    sidebar.removeCustomColor('#123456');
+    expect(sidebar.snapshot().palettes.find((p) => p.id === 'custom')?.colors).toEqual(['#abcdef']);
+
+    sidebar.removeCustomColor(PRESET_COLORS[0]);
+    const presets = sidebar.snapshot().palettes.find((p) => p.id === 'presets');
+    expect(presets?.colors).toEqual([...PRESET_COLORS]);
+  });
+
+  it('refuses to add a color that is already a preset', () => {
+    sidebar.addCustomColor(PRESET_COLORS[1]);
+    expect(sidebar.snapshot().palettes.find((p) => p.id === 'custom')?.colors).toEqual([]);
+  });
+
+  it('cycleDash walks solid -> dashed -> dotted -> solid', () => {
+    sidebar.setTool('pen');
+    expect(sidebar.snapshot().toolStyles.pen.dash).toBe('solid');
+    sidebar.cycleDash();
+    expect(sidebar.snapshot().toolStyles.pen.dash).toBe('dashed');
+    sidebar.cycleDash();
+    expect(sidebar.snapshot().toolStyles.pen.dash).toBe('dotted');
+    sidebar.cycleDash();
+    expect(sidebar.snapshot().toolStyles.pen.dash).toBe('solid');
+  });
+
+  it('currentStyle reflects the active color', () => {
+    sidebar.setTool('pen');
+    sidebar.setActiveColor('#ff00aa');
+    expect(get(currentStyle).color).toBe('#ff00aa');
+    expect(sidebar.snapshot().toolStyles.pen.color).toBe('#ff00aa');
+
+    sidebar.setTool('highlighter');
+    expect(get(currentStyle).color).toBe(sidebar.snapshot().toolStyles.highlighter.color);
+  });
+
+  it('togglePin flips pinned', () => {
+    expect(sidebar.snapshot().pinned).toBe(true);
+    sidebar.togglePin();
+    expect(sidebar.snapshot().pinned).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a self-contained sidebar UI (`src/lib/sidebar/`) with tool buttons (Pen, Highlighter, Eraser, Line, Graph-disabled-stub), color palette, width slider, and three-state dash toggle.
- Pin/unpin control switches between a 220px locked column and a floating overlay; both modes share the `#252525` dark theme.
- New `src/lib/store/sidebar.ts` holds UI source-of-truth state: `pinned`, `activeTool`, per-tool `StrokeStyle` (pen/highlighter/line preserved independently), preset + custom palettes, `activeColor`. Exposes `setTool`, `setActiveColor`, `addCustomColor`, `removeCustomColor`, `setWidth`, `setDash`, `cycleDash`, `togglePin`, and a derived `currentStyle`.

## Why
Phase 1 sidebar-tools worktree per `PLAN.md`. Keeps the sidebar mountable anywhere so the app-shell worktree can compose it, and reconciliation with `src/lib/store/tool.ts` happens there.

## Testing
- `pnpm lint` — clean (prettier + eslint + svelte-check).
- `pnpm test` — 7/7 pass, including new `tests/sidebar-store.test.ts` covering tool-style isolation, custom color add/remove with preset protection, dash cycling, and `currentStyle` reactivity.

## Notes
- Svelte 5 callback-prop API; no `createEventDispatcher`.
- Keyboard shortcut hints surface via `title` attributes; actual key handling belongs to the app-shell worktree.
- Graph tool button is intentionally disabled for Phase 1.