### PR TITLE
feat(storage): sidecar persistence + autosave + per-page undo/redo

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -837,9 +837,11 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "sysinfo",
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
+ "tempfile",
  "thiserror 2.0.18",
 ]
 
@@ -2169,6 +2171,15 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "num-conv"
@@ -3552,6 +3563,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "windows 0.57.0",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3596,7 +3620,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -3667,7 +3691,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3768,7 +3792,7 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "url",
- "windows",
+ "windows 0.61.3",
  "zbus",
 ]
 
@@ -3794,7 +3818,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3819,7 +3843,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -4611,10 +4635,10 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
 ]
 
 [[package]]
@@ -4635,7 +4659,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -4687,6 +4711,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -4709,12 +4743,24 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -4726,8 +4772,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -4746,9 +4792,31 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4786,6 +4854,15 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5239,7 +5316,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,6 +19,10 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 sha2 = "0.10"
+sysinfo = { version = "0.33", default-features = false, features = ["system"] }
+
+[dev-dependencies]
+tempfile = "3"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -12,6 +12,12 @@ pub enum AppError {
     #[error("pdf: {0}")]
     Pdf(String),
 
+    #[error("unsupported sidecar version: {0}")]
+    Version(u32),
+
+    #[error("lock held by another process: {0}")]
+    Lock(String),
+
     #[error("not implemented: {0}")]
     NotImplemented(&'static str),
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,6 +15,8 @@ pub fn run() {
             pdf::render_page,
             storage::load_sidecar,
             storage::save_sidecar,
+            storage::acquire_lock,
+            storage::release_lock,
             export::export_flattened_pdf,
         ])
         .run(tauri::generate_context!())

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -1,14 +1,238 @@
+//! Sidecar persistence and cross-process locking.
+//!
+//! Sidecar path convention: `"{pdf_path}.eldraw.json"`.
+//! Lock file:               `"{pdf_path}.eldraw.lock"`.
+//! Writes go via `"{pdf_path}.eldraw.json.tmp"` + rename for atomicity.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use sysinfo::{Pid, System};
+
 use crate::error::{AppError, AppResult};
 use crate::model::EldrawDocument;
 
+const SUPPORTED_VERSION: u32 = 1;
+
+fn sidecar_path(pdf_path: &str) -> PathBuf {
+    PathBuf::from(format!("{pdf_path}.eldraw.json"))
+}
+
+fn tmp_path(pdf_path: &str) -> PathBuf {
+    PathBuf::from(format!("{pdf_path}.eldraw.json.tmp"))
+}
+
+fn lock_path(pdf_path: &str) -> PathBuf {
+    PathBuf::from(format!("{pdf_path}.eldraw.lock"))
+}
+
+fn ensure_parent(path: &Path) -> AppResult<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() && !parent.exists() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+    Ok(())
+}
+
+pub fn load_sidecar_impl(pdf_path: &str) -> AppResult<Option<EldrawDocument>> {
+    let path = sidecar_path(pdf_path);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let bytes = fs::read(&path)?;
+    let doc: EldrawDocument = serde_json::from_slice(&bytes)?;
+    if doc.version != SUPPORTED_VERSION {
+        return Err(AppError::Version(doc.version));
+    }
+    Ok(Some(doc))
+}
+
+pub fn save_sidecar_impl(pdf_path: &str, doc: &EldrawDocument) -> AppResult<()> {
+    let final_path = sidecar_path(pdf_path);
+    let tmp = tmp_path(pdf_path);
+    ensure_parent(&final_path)?;
+    let json = serde_json::to_vec_pretty(doc)?;
+    fs::write(&tmp, &json)?;
+    fs::rename(&tmp, &final_path)?;
+    Ok(())
+}
+
+fn pid_alive(pid: u32) -> bool {
+    let mut sys = System::new();
+    sys.refresh_processes(
+        sysinfo::ProcessesToUpdate::Some(&[Pid::from_u32(pid)]),
+        true,
+    );
+    sys.process(Pid::from_u32(pid)).is_some()
+}
+
+fn iso_now() -> String {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs());
+    format!("{secs}")
+}
+
+fn parse_lock_pid(contents: &str) -> Option<u32> {
+    contents
+        .lines()
+        .next()
+        .and_then(|l| l.trim().parse::<u32>().ok())
+}
+
+pub fn acquire_lock_impl(pdf_path: &str) -> AppResult<bool> {
+    let path = lock_path(pdf_path);
+    ensure_parent(&path)?;
+    if path.exists() {
+        let contents = fs::read_to_string(&path).unwrap_or_default();
+        if let Some(existing_pid) = parse_lock_pid(&contents) {
+            if existing_pid != std::process::id() && pid_alive(existing_pid) {
+                return Ok(false);
+            }
+        }
+    }
+    let body = format!("{}\n{}\n", std::process::id(), iso_now());
+    fs::write(&path, body)?;
+    Ok(true)
+}
+
+pub fn release_lock_impl(pdf_path: &str) -> AppResult<()> {
+    let path = lock_path(pdf_path);
+    if path.exists() {
+        fs::remove_file(&path)?;
+    }
+    Ok(())
+}
+
 #[tauri::command]
 pub async fn load_sidecar(pdf_path: String) -> AppResult<Option<EldrawDocument>> {
-    let _ = pdf_path;
-    Err(AppError::NotImplemented("load_sidecar"))
+    load_sidecar_impl(&pdf_path)
 }
 
 #[tauri::command]
 pub async fn save_sidecar(pdf_path: String, doc: EldrawDocument) -> AppResult<()> {
-    let _ = (pdf_path, doc);
-    Err(AppError::NotImplemented("save_sidecar"))
+    save_sidecar_impl(&pdf_path, &doc)
+}
+
+#[tauri::command]
+pub async fn acquire_lock(pdf_path: String) -> AppResult<bool> {
+    acquire_lock_impl(&pdf_path)
+}
+
+#[tauri::command]
+pub async fn release_lock(pdf_path: String) -> AppResult<()> {
+    release_lock_impl(&pdf_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    fn sample_doc() -> EldrawDocument {
+        EldrawDocument {
+            version: 1,
+            pdf_hash: "abc123".into(),
+            pdf_path: Some("/tmp/foo.pdf".into()),
+            pages: vec![
+                json!({"pageIndex": 0, "type": "pdf", "width": 612.0, "height": 792.0, "objects": [], "insertedAfterPdfPage": null}),
+            ],
+            palettes: vec![],
+            prefs: json!({}),
+        }
+    }
+
+    fn pdf_str(dir: &TempDir, name: &str) -> String {
+        dir.path().join(name).to_string_lossy().into_owned()
+    }
+
+    #[test]
+    fn missing_sidecar_returns_none() {
+        let dir = TempDir::new().unwrap();
+        let pdf = pdf_str(&dir, "nope.pdf");
+        assert!(load_sidecar_impl(&pdf).unwrap().is_none());
+    }
+
+    #[test]
+    fn round_trip_save_load() {
+        let dir = TempDir::new().unwrap();
+        let pdf = pdf_str(&dir, "doc.pdf");
+        let doc = sample_doc();
+        save_sidecar_impl(&pdf, &doc).unwrap();
+        let loaded = load_sidecar_impl(&pdf).unwrap().expect("doc");
+        assert_eq!(loaded.version, doc.version);
+        assert_eq!(loaded.pdf_hash, doc.pdf_hash);
+        assert_eq!(loaded.pages.len(), 1);
+    }
+
+    #[test]
+    fn save_does_not_leave_tmp() {
+        let dir = TempDir::new().unwrap();
+        let pdf = pdf_str(&dir, "doc.pdf");
+        save_sidecar_impl(&pdf, &sample_doc()).unwrap();
+        assert!(!tmp_path(&pdf).exists());
+        assert!(sidecar_path(&pdf).exists());
+    }
+
+    #[test]
+    fn unsupported_version_rejected() {
+        let dir = TempDir::new().unwrap();
+        let pdf = pdf_str(&dir, "doc.pdf");
+        let mut doc = sample_doc();
+        doc.version = 99;
+        fs::write(sidecar_path(&pdf), serde_json::to_vec_pretty(&doc).unwrap()).unwrap();
+        match load_sidecar_impl(&pdf) {
+            Err(AppError::Version(99)) => {}
+            other => panic!("expected Version(99), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lock_acquire_release_reacquire() {
+        let dir = TempDir::new().unwrap();
+        let pdf = pdf_str(&dir, "doc.pdf");
+        assert!(acquire_lock_impl(&pdf).unwrap());
+        // Same-process re-acquire should succeed (we treat our own PID as reclaimable).
+        assert!(acquire_lock_impl(&pdf).unwrap());
+        release_lock_impl(&pdf).unwrap();
+        assert!(!lock_path(&pdf).exists());
+        assert!(acquire_lock_impl(&pdf).unwrap());
+        release_lock_impl(&pdf).unwrap();
+    }
+
+    #[test]
+    fn stale_lock_is_overwritten() {
+        let dir = TempDir::new().unwrap();
+        let pdf = pdf_str(&dir, "doc.pdf");
+        // PID 0 is never a live user process on Linux; a very high PID is also
+        // extremely unlikely to be alive during tests.
+        let fake_pid: u32 = 4_000_000_000;
+        fs::write(lock_path(&pdf), format!("{fake_pid}\nstale\n")).unwrap();
+        assert!(acquire_lock_impl(&pdf).unwrap());
+        let contents = fs::read_to_string(lock_path(&pdf)).unwrap();
+        let pid = parse_lock_pid(&contents).unwrap();
+        assert_eq!(pid, std::process::id());
+        release_lock_impl(&pdf).unwrap();
+    }
+
+    #[test]
+    fn live_foreign_pid_blocks_lock() {
+        let dir = TempDir::new().unwrap();
+        let pdf = pdf_str(&dir, "doc.pdf");
+        // Spawn a child we know is alive, write its PID into the lock, then
+        // try to acquire.
+        let mut child = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn sleep");
+        fs::write(lock_path(&pdf), format!("{}\nx\n", child.id())).unwrap();
+        let result = acquire_lock_impl(&pdf).unwrap();
+        let _ = child.kill();
+        let _ = child.wait();
+        assert!(!result, "expected acquire to fail while foreign PID alive");
+        let _ = fs::remove_file(lock_path(&pdf));
+    }
 }

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -4,7 +4,8 @@
 //! Lock file:               `"{pdf_path}.eldraw.lock"`.
 //! Writes go via `"{pdf_path}.eldraw.json.tmp"` + rename for atomicity.
 
-use std::fs;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -54,8 +55,16 @@ pub fn save_sidecar_impl(pdf_path: &str, doc: &EldrawDocument) -> AppResult<()> 
     let tmp = tmp_path(pdf_path);
     ensure_parent(&final_path)?;
     let json = serde_json::to_vec_pretty(doc)?;
-    fs::write(&tmp, &json)?;
-    fs::rename(&tmp, &final_path)?;
+    // Write to tmp first; on any subsequent failure, remove tmp so we don't
+    // leave a partial file lying next to the PDF.
+    if let Err(e) = fs::write(&tmp, &json) {
+        let _ = fs::remove_file(&tmp);
+        return Err(e.into());
+    }
+    if let Err(e) = fs::rename(&tmp, &final_path) {
+        let _ = fs::remove_file(&tmp);
+        return Err(e.into());
+    }
     Ok(())
 }
 
@@ -85,25 +94,51 @@ fn parse_lock_pid(contents: &str) -> Option<u32> {
 pub fn acquire_lock_impl(pdf_path: &str) -> AppResult<bool> {
     let path = lock_path(pdf_path);
     ensure_parent(&path)?;
-    if path.exists() {
-        let contents = fs::read_to_string(&path).unwrap_or_default();
-        if let Some(existing_pid) = parse_lock_pid(&contents) {
-            if existing_pid != std::process::id() && pid_alive(existing_pid) {
-                return Ok(false);
+    let body = format!("{}\n{}\n", std::process::id(), iso_now());
+
+    match OpenOptions::new().write(true).create_new(true).open(&path) {
+        Ok(mut f) => {
+            f.write_all(body.as_bytes())?;
+            Ok(true)
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            let contents = fs::read_to_string(&path).unwrap_or_default();
+            if let Some(existing_pid) = parse_lock_pid(&contents) {
+                if existing_pid != std::process::id() && pid_alive(existing_pid) {
+                    return Ok(false);
+                }
+            }
+            // Stale (or our own) lock: reclaim by overwriting atomically via
+            // remove + create_new so no other process can sneak in.
+            let _ = fs::remove_file(&path);
+            match OpenOptions::new().write(true).create_new(true).open(&path) {
+                Ok(mut f) => {
+                    f.write_all(body.as_bytes())?;
+                    Ok(true)
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(false),
+                Err(e) => Err(e.into()),
             }
         }
+        Err(e) => Err(e.into()),
     }
-    let body = format!("{}\n{}\n", std::process::id(), iso_now());
-    fs::write(&path, body)?;
-    Ok(true)
 }
 
 pub fn release_lock_impl(pdf_path: &str) -> AppResult<()> {
     let path = lock_path(pdf_path);
-    if path.exists() {
-        fs::remove_file(&path)?;
+    let contents = match fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e.into()),
+    };
+    match parse_lock_pid(&contents) {
+        Some(pid) if pid == std::process::id() => match fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e.into()),
+        },
+        _ => Ok(()),
     }
-    Ok(())
 }
 
 #[tauri::command]
@@ -218,6 +253,7 @@ mod tests {
         release_lock_impl(&pdf).unwrap();
     }
 
+    #[cfg(unix)]
     #[test]
     fn live_foreign_pid_blocks_lock() {
         let dir = TempDir::new().unwrap();

--- a/src/lib/ipc/index.ts
+++ b/src/lib/ipc/index.ts
@@ -17,6 +17,14 @@ export async function saveSidecar(pdfPath: string, doc: EldrawDocument): Promise
   return invoke('save_sidecar', { pdfPath, doc });
 }
 
+export async function acquireLock(pdfPath: string): Promise<boolean> {
+  return invoke('acquire_lock', { pdfPath });
+}
+
+export async function releaseLock(pdfPath: string): Promise<void> {
+  return invoke('release_lock', { pdfPath });
+}
+
 export async function exportFlattenedPdf(
   pdfPath: string,
   doc: EldrawDocument,

--- a/src/lib/store/autosave.ts
+++ b/src/lib/store/autosave.ts
@@ -1,0 +1,54 @@
+import { writable, type Readable } from 'svelte/store';
+import type { EldrawDocument } from '$lib/types';
+import { saveSidecar } from '$lib/ipc';
+import { currentDocument } from './document';
+
+const AUTOSAVE_DEBOUNCE_MS = 1500;
+
+export const autosaveError = writable<string | null>(null);
+
+export interface AutosaveOptions {
+  /** Override debounce, primarily for tests. */
+  debounceMs?: number;
+  /** Injectable IPC for tests. */
+  save?: (pdfPath: string, doc: EldrawDocument) => Promise<void>;
+  /** Source store to observe. Tests can inject a fake. */
+  source?: Readable<EldrawDocument | null>;
+}
+
+export function startAutosave(pdfPath: string | null, opts: AutosaveOptions = {}): () => void {
+  if (pdfPath === null) return () => {};
+
+  const debounceMs = opts.debounceMs ?? AUTOSAVE_DEBOUNCE_MS;
+  const save = opts.save ?? saveSidecar;
+  const source = opts.source ?? currentDocument;
+
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let pending: EldrawDocument | null = null;
+  let skipFirst = true;
+
+  const unsubscribe = source.subscribe((doc) => {
+    if (skipFirst) {
+      skipFirst = false;
+      return;
+    }
+    if (!doc) return;
+    pending = doc;
+    if (timer !== null) clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = null;
+      const snapshot = pending;
+      pending = null;
+      if (!snapshot) return;
+      save(pdfPath, snapshot).then(
+        () => autosaveError.set(null),
+        (err: unknown) => autosaveError.set(err instanceof Error ? err.message : String(err)),
+      );
+    }, debounceMs);
+  });
+
+  return () => {
+    if (timer !== null) clearTimeout(timer);
+    unsubscribe();
+  };
+}

--- a/src/lib/store/autosave.ts
+++ b/src/lib/store/autosave.ts
@@ -25,14 +25,14 @@ export function startAutosave(pdfPath: string | null, opts: AutosaveOptions = {}
 
   let timer: ReturnType<typeof setTimeout> | null = null;
   let pending: EldrawDocument | null = null;
-  let skipFirst = true;
+  let skipInitialDocument = true;
 
   const unsubscribe = source.subscribe((doc) => {
-    if (skipFirst) {
-      skipFirst = false;
+    if (!doc) return;
+    if (skipInitialDocument) {
+      skipInitialDocument = false;
       return;
     }
-    if (!doc) return;
     pending = doc;
     if (timer !== null) clearTimeout(timer);
     timer = setTimeout(() => {

--- a/src/lib/store/document.ts
+++ b/src/lib/store/document.ts
@@ -104,6 +104,7 @@ export function createDocumentStore(): DocumentStore {
         const pages = [...doc.pages];
         pages.splice(insertIdx, 0, blank);
         const reindexed = pages.map((p, i) => ({ ...p, pageIndex: i }));
+        history.shiftPageIndicesFrom(insertIdx);
         return { ...doc, pages: reindexed };
       });
     },

--- a/src/lib/store/document.ts
+++ b/src/lib/store/document.ts
@@ -1,0 +1,152 @@
+import { derived, get, writable, type Readable } from 'svelte/store';
+import type { AnyObject, EldrawDocument, ObjectId, Page } from '$lib/types';
+import { applyCommand, createHistory, type Command, type History } from './history';
+
+export interface DocumentStore {
+  subscribe: Readable<EldrawDocument | null>['subscribe'];
+  load(doc: EldrawDocument): void;
+  clear(): void;
+
+  addObject(pageIndex: number, obj: AnyObject): void;
+  removeObject(pageIndex: number, id: ObjectId): void;
+  updateObject(pageIndex: number, id: ObjectId, patch: Partial<AnyObject>): void;
+
+  insertBlankPageAfter(pdfPageIndex: number, width: number, height: number): void;
+
+  undo(pageIndex: number): void;
+  redo(pageIndex: number): void;
+  canUndo(pageIndex: number): Readable<boolean>;
+  canRedo(pageIndex: number): Readable<boolean>;
+
+  objectsOnPage(pageIndex: number): Readable<AnyObject[]>;
+
+  /** Escape hatch for undo/redo replays that must not re-push history. */
+  _internalApply(pageIndex: number, cmd: Command): void;
+
+  history: History;
+}
+
+function replacePage(doc: EldrawDocument, pageIndex: number, next: Page): EldrawDocument {
+  return {
+    ...doc,
+    pages: doc.pages.map((p, i) => (i === pageIndex ? next : p)),
+  };
+}
+
+export function createDocumentStore(): DocumentStore {
+  const state = writable<EldrawDocument | null>(null);
+  const history = createHistory();
+
+  function mutatePage(pageIndex: number, fn: (p: Page) => Page) {
+    state.update((doc) => {
+      if (!doc) return doc;
+      const page = doc.pages[pageIndex];
+      if (!page) return doc;
+      return replacePage(doc, pageIndex, fn(page));
+    });
+  }
+
+  function pushAndApply(pageIndex: number, cmd: Command) {
+    history.pushCommand(pageIndex, cmd);
+    mutatePage(pageIndex, (p) => applyCommand(p, cmd));
+  }
+
+  return {
+    subscribe: state.subscribe,
+
+    load(doc) {
+      state.set(doc);
+      history.clear();
+    },
+
+    clear() {
+      state.set(null);
+      history.clear();
+    },
+
+    addObject(pageIndex, obj) {
+      pushAndApply(pageIndex, { type: 'add', object: obj });
+    },
+
+    removeObject(pageIndex, id) {
+      const doc = get(state);
+      if (!doc) return;
+      const page = doc.pages[pageIndex];
+      if (!page) return;
+      const obj = page.objects.find((o) => o.id === id);
+      if (!obj) return;
+      pushAndApply(pageIndex, { type: 'remove', object: obj });
+    },
+
+    updateObject(pageIndex, id, patch) {
+      const doc = get(state);
+      if (!doc) return;
+      const page = doc.pages[pageIndex];
+      if (!page) return;
+      const before = page.objects.find((o) => o.id === id);
+      if (!before) return;
+      const after = { ...before, ...patch } as AnyObject;
+      pushAndApply(pageIndex, { type: 'update', objectId: id, before, after });
+    },
+
+    insertBlankPageAfter(pdfPageIndex, width, height) {
+      state.update((doc) => {
+        if (!doc) return doc;
+        const insertIdx = pdfPageIndex + 1;
+        const blank: Page = {
+          pageIndex: insertIdx,
+          type: 'blank',
+          insertedAfterPdfPage: pdfPageIndex,
+          width,
+          height,
+          objects: [],
+        };
+        const pages = [...doc.pages];
+        pages.splice(insertIdx, 0, blank);
+        const reindexed = pages.map((p, i) => ({ ...p, pageIndex: i }));
+        return { ...doc, pages: reindexed };
+      });
+    },
+
+    undo(pageIndex) {
+      const doc = get(state);
+      if (!doc) return;
+      const page = doc.pages[pageIndex];
+      if (!page) return;
+      const next = history.undo(pageIndex, page);
+      if (next) mutatePage(pageIndex, () => next);
+    },
+
+    redo(pageIndex) {
+      const doc = get(state);
+      if (!doc) return;
+      const page = doc.pages[pageIndex];
+      if (!page) return;
+      const next = history.redo(pageIndex, page);
+      if (next) mutatePage(pageIndex, () => next);
+    },
+
+    canUndo(pageIndex) {
+      return history.canUndo(pageIndex);
+    },
+
+    canRedo(pageIndex) {
+      return history.canRedo(pageIndex);
+    },
+
+    objectsOnPage(pageIndex) {
+      return derived(state, ($doc) => $doc?.pages[pageIndex]?.objects ?? []);
+    },
+
+    _internalApply(pageIndex, cmd) {
+      mutatePage(pageIndex, (p) => applyCommand(p, cmd));
+    },
+
+    history,
+  };
+}
+
+export const documentStore = createDocumentStore();
+export const currentDocument: Readable<EldrawDocument | null> = {
+  subscribe: documentStore.subscribe,
+};

--- a/src/lib/store/history.ts
+++ b/src/lib/store/history.ts
@@ -57,6 +57,9 @@ export interface History {
   redo(pageIndex: number, page: Page): Page | null;
   canUndo(pageIndex: number): Readable<boolean>;
   canRedo(pageIndex: number): Readable<boolean>;
+  /** Shift all page stacks at index >= `from` up by one to keep them
+   *  aligned with document pages after an insert at `from`. */
+  shiftPageIndicesFrom(from: number): void;
   clear(): void;
   /** For tests. */
   _stacks: Readable<Record<number, PageStack>>;
@@ -117,6 +120,17 @@ export function createHistory(): History {
 
     clear() {
       stacks.set({});
+    },
+
+    shiftPageIndicesFrom(from) {
+      stacks.update((all) => {
+        const next: Record<number, PageStack> = {};
+        for (const [k, v] of Object.entries(all)) {
+          const idx = Number(k);
+          next[idx >= from ? idx + 1 : idx] = v;
+        }
+        return next;
+      });
     },
 
     _stacks: { subscribe: stacks.subscribe },

--- a/src/lib/store/history.ts
+++ b/src/lib/store/history.ts
@@ -1,0 +1,124 @@
+import { derived, writable, get, type Readable } from 'svelte/store';
+import type { AnyObject, ObjectId, Page } from '$lib/types';
+
+export type Command =
+  | { type: 'add'; object: AnyObject }
+  | { type: 'remove'; object: AnyObject }
+  | { type: 'update'; objectId: ObjectId; before: AnyObject; after: AnyObject };
+
+export const HISTORY_LIMIT = 200;
+
+export function applyCommand(page: Page, cmd: Command): Page {
+  switch (cmd.type) {
+    case 'add':
+      return { ...page, objects: [...page.objects, cmd.object] };
+    case 'remove':
+      return { ...page, objects: page.objects.filter((o) => o.id !== cmd.object.id) };
+    case 'update':
+      return {
+        ...page,
+        objects: page.objects.map((o) => (o.id === cmd.objectId ? cmd.after : o)),
+      };
+  }
+}
+
+export function invertCommand(cmd: Command): Command {
+  switch (cmd.type) {
+    case 'add':
+      return { type: 'remove', object: cmd.object };
+    case 'remove':
+      return { type: 'add', object: cmd.object };
+    case 'update':
+      return {
+        type: 'update',
+        objectId: cmd.objectId,
+        before: cmd.after,
+        after: cmd.before,
+      };
+  }
+}
+
+interface PageStack {
+  undo: Command[];
+  redo: Command[];
+}
+
+function emptyStack(): PageStack {
+  return { undo: [], redo: [] };
+}
+
+function trim(stack: Command[]): Command[] {
+  return stack.length > HISTORY_LIMIT ? stack.slice(stack.length - HISTORY_LIMIT) : stack;
+}
+
+export interface History {
+  pushCommand(pageIndex: number, cmd: Command): void;
+  undo(pageIndex: number, page: Page): Page | null;
+  redo(pageIndex: number, page: Page): Page | null;
+  canUndo(pageIndex: number): Readable<boolean>;
+  canRedo(pageIndex: number): Readable<boolean>;
+  clear(): void;
+  /** For tests. */
+  _stacks: Readable<Record<number, PageStack>>;
+}
+
+export function createHistory(): History {
+  const stacks = writable<Record<number, PageStack>>({});
+
+  function mutate(pageIndex: number, fn: (s: PageStack) => PageStack) {
+    stacks.update((all) => {
+      const current = all[pageIndex] ?? emptyStack();
+      return { ...all, [pageIndex]: fn(current) };
+    });
+  }
+
+  return {
+    pushCommand(pageIndex, cmd) {
+      mutate(pageIndex, (s) => ({
+        undo: trim([...s.undo, cmd]),
+        redo: [],
+      }));
+    },
+
+    undo(pageIndex, page) {
+      const all = get(stacks);
+      const stack = all[pageIndex];
+      if (!stack || stack.undo.length === 0) return null;
+      const cmd = stack.undo[stack.undo.length - 1];
+      const inverse = invertCommand(cmd);
+      const nextPage = applyCommand(page, inverse);
+      mutate(pageIndex, (s) => ({
+        undo: s.undo.slice(0, -1),
+        redo: trim([...s.redo, cmd]),
+      }));
+      return nextPage;
+    },
+
+    redo(pageIndex, page) {
+      const all = get(stacks);
+      const stack = all[pageIndex];
+      if (!stack || stack.redo.length === 0) return null;
+      const cmd = stack.redo[stack.redo.length - 1];
+      const nextPage = applyCommand(page, cmd);
+      mutate(pageIndex, (s) => ({
+        undo: trim([...s.undo, cmd]),
+        redo: s.redo.slice(0, -1),
+      }));
+      return nextPage;
+    },
+
+    canUndo(pageIndex) {
+      return derived(stacks, ($s) => ($s[pageIndex]?.undo.length ?? 0) > 0);
+    },
+
+    canRedo(pageIndex) {
+      return derived(stacks, ($s) => ($s[pageIndex]?.redo.length ?? 0) > 0);
+    },
+
+    clear() {
+      stacks.set({});
+    },
+
+    _stacks: { subscribe: stacks.subscribe },
+  };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -135,6 +135,8 @@ export interface IpcCommands {
   render_page: (args: { pageIndex: number; scale: number }) => Promise<Uint8Array>;
   load_sidecar: (args: { pdfPath: string }) => Promise<EldrawDocument | null>;
   save_sidecar: (args: { pdfPath: string; doc: EldrawDocument }) => Promise<void>;
+  acquire_lock: (args: { pdfPath: string }) => Promise<boolean>;
+  release_lock: (args: { pdfPath: string }) => Promise<void>;
   export_flattened_pdf: (args: {
     pdfPath: string;
     doc: EldrawDocument;

--- a/tests/autosave.test.ts
+++ b/tests/autosave.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { writable } from 'svelte/store';
+import { startAutosave, autosaveError } from '$lib/store/autosave';
+import type { EldrawDocument } from '$lib/types';
+
+function doc(hash: string): EldrawDocument {
+  return {
+    version: 1,
+    pdfHash: hash,
+    pdfPath: '/tmp/x.pdf',
+    pages: [],
+    palettes: [],
+    prefs: {
+      sidebarPinned: true,
+      defaultTool: 'pen',
+      toolDefaults: {
+        pen: { color: '#000', width: 2, dash: 'solid', opacity: 1 },
+        highlighter: { color: '#ff0', width: 14, dash: 'solid', opacity: 0.3 },
+        line: { color: '#000', width: 2, dash: 'solid', opacity: 1 },
+      },
+    },
+  };
+}
+
+describe('autosave', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    autosaveError.set(null);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('debounces multiple edits into one save', async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const source = writable<EldrawDocument | null>(doc('initial'));
+    const stop = startAutosave('/tmp/x.pdf', { debounceMs: 100, save, source });
+
+    source.set(doc('a'));
+    await vi.advanceTimersByTimeAsync(50);
+    source.set(doc('b'));
+    await vi.advanceTimersByTimeAsync(50);
+    source.set(doc('c'));
+    expect(save).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(save.mock.calls[0][1].pdfHash).toBe('c');
+    stop();
+  });
+
+  it('does not save when pdfPath is null', async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const source = writable<EldrawDocument | null>(doc('a'));
+    const stop = startAutosave(null, { debounceMs: 50, save, source });
+    source.set(doc('b'));
+    await vi.advanceTimersByTimeAsync(200);
+    expect(save).not.toHaveBeenCalled();
+    stop();
+  });
+
+  it('populates autosaveError on failure', async () => {
+    const save = vi.fn().mockRejectedValue(new Error('disk full'));
+    const source = writable<EldrawDocument | null>(doc('a'));
+    const stop = startAutosave('/tmp/x.pdf', { debounceMs: 50, save, source });
+    source.set(doc('b'));
+    await vi.advanceTimersByTimeAsync(60);
+    await Promise.resolve();
+    let err: string | null = null;
+    autosaveError.subscribe((v) => (err = v))();
+    expect(err).toBe('disk full');
+    stop();
+  });
+
+  it('stop cancels pending save', async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const source = writable<EldrawDocument | null>(doc('a'));
+    const stop = startAutosave('/tmp/x.pdf', { debounceMs: 100, save, source });
+    source.set(doc('b'));
+    stop();
+    await vi.advanceTimersByTimeAsync(500);
+    expect(save).not.toHaveBeenCalled();
+  });
+});

--- a/tests/document-store.test.ts
+++ b/tests/document-store.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import { get } from 'svelte/store';
+import { createDocumentStore } from '$lib/store/document';
+import type { EldrawDocument, Page, StrokeObject } from '$lib/types';
+
+function stroke(id: string, width = 2): StrokeObject {
+  return {
+    id,
+    createdAt: 0,
+    type: 'stroke',
+    tool: 'pen',
+    style: { color: '#000', width, dash: 'solid', opacity: 1 },
+    points: [],
+  };
+}
+
+function docWithPages(pages: Page[]): EldrawDocument {
+  return {
+    version: 1,
+    pdfHash: 'h',
+    pdfPath: '/tmp/x.pdf',
+    pages,
+    palettes: [],
+    prefs: {
+      sidebarPinned: true,
+      defaultTool: 'pen',
+      toolDefaults: {
+        pen: { color: '#000', width: 2, dash: 'solid', opacity: 1 },
+        highlighter: { color: '#ff0', width: 14, dash: 'solid', opacity: 0.3 },
+        line: { color: '#000', width: 2, dash: 'solid', opacity: 1 },
+      },
+    },
+  };
+}
+
+function pdfPage(index: number): Page {
+  return {
+    pageIndex: index,
+    type: 'pdf',
+    insertedAfterPdfPage: null,
+    width: 612,
+    height: 792,
+    objects: [],
+  };
+}
+
+describe('documentStore', () => {
+  it('addObject appends and pushes history', () => {
+    const store = createDocumentStore();
+    store.load(docWithPages([pdfPage(0)]));
+    store.addObject(0, stroke('a'));
+    const doc = get(store)!;
+    expect(doc.pages[0].objects).toHaveLength(1);
+    expect(get(store.canUndo(0))).toBe(true);
+
+    store.undo(0);
+    expect(get(store)!.pages[0].objects).toHaveLength(0);
+    expect(get(store.canRedo(0))).toBe(true);
+  });
+
+  it('removeObject drops and undo restores', () => {
+    const store = createDocumentStore();
+    const initial = docWithPages([{ ...pdfPage(0), objects: [stroke('a'), stroke('b')] }]);
+    store.load(initial);
+    store.removeObject(0, 'a');
+    expect(get(store)!.pages[0].objects.map((o) => o.id)).toEqual(['b']);
+    store.undo(0);
+    expect(get(store)!.pages[0].objects.map((o) => o.id)).toEqual(['b', 'a']);
+  });
+
+  it('updateObject patches, undo reverts', () => {
+    const store = createDocumentStore();
+    const initial = docWithPages([{ ...pdfPage(0), objects: [stroke('a', 2)] }]);
+    store.load(initial);
+    const existing = get(store)!.pages[0].objects[0] as StrokeObject;
+    store.updateObject(0, 'a', { style: { ...existing.style, width: 8 } });
+    expect((get(store)!.pages[0].objects[0] as StrokeObject).style.width).toBe(8);
+    store.undo(0);
+    expect((get(store)!.pages[0].objects[0] as StrokeObject).style.width).toBe(2);
+    store.redo(0);
+    expect((get(store)!.pages[0].objects[0] as StrokeObject).style.width).toBe(8);
+  });
+
+  it('insertBlankPageAfter inserts at correct index with blank metadata', () => {
+    const store = createDocumentStore();
+    store.load(docWithPages([pdfPage(0), pdfPage(1)]));
+    store.insertBlankPageAfter(0, 500, 700);
+    const pages = get(store)!.pages;
+    expect(pages).toHaveLength(3);
+    expect(pages[1].type).toBe('blank');
+    expect(pages[1].insertedAfterPdfPage).toBe(0);
+    expect(pages[1].width).toBe(500);
+    expect(pages[1].height).toBe(700);
+    expect(pages[0].pageIndex).toBe(0);
+    expect(pages[1].pageIndex).toBe(1);
+    expect(pages[2].pageIndex).toBe(2);
+  });
+
+  it('load clears history', () => {
+    const store = createDocumentStore();
+    store.load(docWithPages([pdfPage(0)]));
+    store.addObject(0, stroke('a'));
+    expect(get(store.canUndo(0))).toBe(true);
+    store.load(docWithPages([pdfPage(0)]));
+    expect(get(store.canUndo(0))).toBe(false);
+  });
+
+  it('objectsOnPage derived tracks updates', () => {
+    const store = createDocumentStore();
+    store.load(docWithPages([pdfPage(0)]));
+    const derivedStore = store.objectsOnPage(0);
+    expect(get(derivedStore)).toEqual([]);
+    store.addObject(0, stroke('a'));
+    expect(get(derivedStore).map((o) => o.id)).toEqual(['a']);
+  });
+});

--- a/tests/history.test.ts
+++ b/tests/history.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { get } from 'svelte/store';
+import { createHistory, HISTORY_LIMIT, applyCommand, type Command } from '$lib/store/history';
+import type { Page, StrokeObject } from '$lib/types';
+
+function stroke(id: string): StrokeObject {
+  return {
+    id,
+    createdAt: 0,
+    type: 'stroke',
+    tool: 'pen',
+    style: { color: '#000', width: 2, dash: 'solid', opacity: 1 },
+    points: [],
+  };
+}
+
+function emptyPage(): Page {
+  return {
+    pageIndex: 0,
+    type: 'pdf',
+    insertedAfterPdfPage: null,
+    width: 100,
+    height: 100,
+    objects: [],
+  };
+}
+
+describe('history', () => {
+  it('add + undo removes, redo restores', () => {
+    const h = createHistory();
+    const obj = stroke('a');
+    const cmd: Command = { type: 'add', object: obj };
+    h.pushCommand(0, cmd);
+    let page = applyCommand(emptyPage(), cmd);
+    expect(page.objects).toHaveLength(1);
+
+    const undone = h.undo(0, page);
+    expect(undone).not.toBeNull();
+    page = undone!;
+    expect(page.objects).toHaveLength(0);
+
+    const redone = h.redo(0, page);
+    expect(redone).not.toBeNull();
+    page = redone!;
+    expect(page.objects).toHaveLength(1);
+    expect(page.objects[0].id).toBe('a');
+  });
+
+  it('update undo restores before, redo reapplies after', () => {
+    const h = createHistory();
+    const before = stroke('a');
+    const after: StrokeObject = { ...before, style: { ...before.style, width: 9 } };
+    let page: Page = { ...emptyPage(), objects: [before] };
+    const cmd: Command = { type: 'update', objectId: 'a', before, after };
+    h.pushCommand(0, cmd);
+    page = applyCommand(page, cmd);
+    expect((page.objects[0] as StrokeObject).style.width).toBe(9);
+
+    page = h.undo(0, page)!;
+    expect((page.objects[0] as StrokeObject).style.width).toBe(2);
+    page = h.redo(0, page)!;
+    expect((page.objects[0] as StrokeObject).style.width).toBe(9);
+  });
+
+  it('canUndo / canRedo transitions', () => {
+    const h = createHistory();
+    expect(get(h.canUndo(0))).toBe(false);
+    expect(get(h.canRedo(0))).toBe(false);
+    const cmd: Command = { type: 'add', object: stroke('a') };
+    h.pushCommand(0, cmd);
+    expect(get(h.canUndo(0))).toBe(true);
+    expect(get(h.canRedo(0))).toBe(false);
+    let page = applyCommand(emptyPage(), cmd);
+    page = h.undo(0, page)!;
+    expect(page.objects).toHaveLength(0);
+    expect(get(h.canUndo(0))).toBe(false);
+    expect(get(h.canRedo(0))).toBe(true);
+  });
+
+  it('caps stack at HISTORY_LIMIT', () => {
+    const h = createHistory();
+    for (let i = 0; i < HISTORY_LIMIT + 50; i++) {
+      h.pushCommand(0, { type: 'add', object: stroke(`s${i}`) });
+    }
+    const stacks = get(h._stacks);
+    expect(stacks[0].undo.length).toBe(HISTORY_LIMIT);
+    // oldest entries were dropped
+    const first = stacks[0].undo[0] as { type: 'add'; object: StrokeObject };
+    expect(first.object.id).toBe('s50');
+  });
+
+  it('new command after undo clears redo stack', () => {
+    const h = createHistory();
+    const c1: Command = { type: 'add', object: stroke('a') };
+    h.pushCommand(0, c1);
+    let page = applyCommand(emptyPage(), c1);
+    page = h.undo(0, page)!;
+    expect(page.objects).toHaveLength(0);
+    expect(get(h.canRedo(0))).toBe(true);
+
+    const c2: Command = { type: 'add', object: stroke('b') };
+    h.pushCommand(0, c2);
+    expect(get(h.canRedo(0))).toBe(false);
+  });
+
+  it('per-page stacks are independent', () => {
+    const h = createHistory();
+    h.pushCommand(0, { type: 'add', object: stroke('a') });
+    expect(get(h.canUndo(0))).toBe(true);
+    expect(get(h.canUndo(1))).toBe(false);
+  });
+});

--- a/tests/history.test.ts
+++ b/tests/history.test.ts
@@ -109,4 +109,15 @@ describe('history', () => {
     expect(get(h.canUndo(0))).toBe(true);
     expect(get(h.canUndo(1))).toBe(false);
   });
+
+  it('shiftPageIndicesFrom moves stacks to match page inserts', () => {
+    const h = createHistory();
+    h.pushCommand(0, { type: 'add', object: stroke('a') });
+    h.pushCommand(2, { type: 'add', object: stroke('b') });
+    h.shiftPageIndicesFrom(1);
+    expect(get(h.canUndo(0))).toBe(true);
+    expect(get(h.canUndo(1))).toBe(false);
+    expect(get(h.canUndo(2))).toBe(false);
+    expect(get(h.canUndo(3))).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- Real sidecar persistence in Rust (`load_sidecar`/`save_sidecar`) with atomic rename-based writes, parent-dir creation, and version validation. New `acquire_lock`/`release_lock` commands use `sysinfo` to detect live owner PIDs cross-platform; stale locks are reclaimed.
- New frontend stores under `src/lib/store/`: a pure `applyCommand`/`invertCommand` pair, a per-page `createHistory()` with 200-entry cap and redo-clear-on-push, a `createDocumentStore()` that threads `addObject` / `removeObject` / `updateObject` through history, and `insertBlankPageAfter` per PLAN.md Phase 1.
- `startAutosave(pdfPath)` debounces `currentDocument` edits at 1500ms and dispatches `saveSidecar`. No-ops when `pdfPath` is null; errors land in a new `autosaveError` store instead of throwing. Debounce and IPC are injectable for tests.
- IPC surface: added `acquire_lock` / `release_lock` to `IpcCommands` and TS wrappers in `$lib/ipc`.

## Testing
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` — 7 storage tests (round-trip, missing sidecar, unsupported version, atomic `.tmp` cleanup, lock acquire/release/reacquire, stale-PID reclaim, live-foreign-PID blocks acquire).
- `pnpm lint`, `pnpm test` — 17 tests total across `history.test.ts`, `document-store.test.ts`, `autosave.test.ts`.

## Notes / Caveats
- Cross-platform PID liveness relies on `sysinfo` (runtime dep, no-default-features + `system`). The `live_foreign_pid_blocks_lock` test spawns `sleep 30`, which is Unix-only. If we need that assertion on Windows we can gate it with `#[cfg(unix)]` or switch to spawning the current test binary with an idle arg.
- Same-process re-acquire of an existing lock succeeds (we treat our own PID as reclaimable). If we want strict single-writer semantics even within one process, that's a follow-up.
- `types.ts` only grew by the two new `IpcCommands` entries, as specified.