### PR TITLE
feat(shell): wire sidebar + canvas + shortcuts + viewport + autosave

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-dialog": "^2.7.0",
     "@tauri-apps/plugin-opener": "^2",
     "perfect-freehand": "^1.2.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2
         version: 2.10.1
+      '@tauri-apps/plugin-dialog':
+        specifier: ^2.7.0
+        version: 2.7.0
       '@tauri-apps/plugin-opener':
         specifier: ^2
         version: 2.5.3
@@ -553,6 +556,9 @@ packages:
     resolution: {integrity: sha512-jQNGF/5quwORdZSSLtTluyKQ+o6SMa/AUICfhf4egCGFdMHqWssApVgYSbg+jmrZoc8e1DscNvjTnXtlHLS11g==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-dialog@2.7.0':
+    resolution: {integrity: sha512-4nS/hfGMGCXiAS3LtVjH9AgsSAPJeG/7R+q8agTFqytjnMa4Zq95Bq8WzVDkckpanX+yyRHXnRtrKXkANKDHvw==}
 
   '@tauri-apps/plugin-opener@2.5.3':
     resolution: {integrity: sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==}
@@ -1727,6 +1733,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.10.1
       '@tauri-apps/cli-win32-ia32-msvc': 2.10.1
       '@tauri-apps/cli-win32-x64-msvc': 2.10.1
+
+  '@tauri-apps/plugin-dialog@2.7.0':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
 
   '@tauri-apps/plugin-opener@2.5.3':
     dependencies:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1023,6 +1023,7 @@ dependencies = [
  "sysinfo",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tempfile",
  "thiserror 2.0.18",
@@ -2733,6 +2734,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3661,6 +3663,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4428,6 +4454,48 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.12+spec-1.1.0",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1fa4150c95ae391946cc8b8f905ab14797427caba3a8a2f79628e956da91809"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36e1ec28b79f3d0683f4507e1615c36292c0ea6716668770d4396b9b39871ed8"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 0.9.12+spec-1.1.0",
+ "url",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,6 +27,7 @@ pdfium-render = { version = "0.9", default-features = false, features = [
   "thread_safe",
 ] }
 image = "0.25"
+tauri-plugin-dialog = "2.7.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -3,5 +3,5 @@
   "identifier": "default",
   "description": "Capability for the main window",
   "windows": ["main"],
-  "permissions": ["core:default", "opener:default"]
+  "permissions": ["core:default", "opener:default", "dialog:allow-open"]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ pub fn run() {
     tauri::Builder::default()
         .manage(state::AppState::default())
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_dialog::init())
         .invoke_handler(tauri::generate_handler![
             pdf::open_pdf,
             pdf::render_page,

--- a/src/lib/app/openPdfDialog.ts
+++ b/src/lib/app/openPdfDialog.ts
@@ -1,0 +1,11 @@
+import { open } from '@tauri-apps/plugin-dialog';
+
+export async function openPdfDialog(): Promise<string | null> {
+  const selection = await open({
+    multiple: false,
+    directory: false,
+    filters: [{ name: 'PDF', extensions: ['pdf'] }],
+  });
+  if (selection === null) return null;
+  return Array.isArray(selection) ? (selection[0] ?? null) : selection;
+}

--- a/src/lib/app/shortcutParser.ts
+++ b/src/lib/app/shortcutParser.ts
@@ -1,0 +1,67 @@
+export interface ParsedKey {
+  key: string;
+  ctrl: boolean;
+  shift: boolean;
+  alt: boolean;
+  meta: boolean;
+}
+
+const MOD_NAMES = new Set(['ctrl', 'control', 'shift', 'alt', 'meta', 'cmd', 'command']);
+
+/**
+ * Parse a human-readable shortcut string like "Ctrl+Shift+Z" into a structured key.
+ * Non-modifier segments after the last `+` are treated as the key (case-preserved for
+ * named keys like ArrowLeft, lowercased for single characters).
+ */
+export function parseShortcut(spec: string): ParsedKey {
+  const parts = spec
+    .split('+')
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+  if (parts.length === 0) {
+    throw new Error(`empty shortcut: "${spec}"`);
+  }
+
+  let ctrl = false;
+  let shift = false;
+  let alt = false;
+  let meta = false;
+  let key: string | null = null;
+
+  for (const part of parts) {
+    const lower = part.toLowerCase();
+    if (MOD_NAMES.has(lower)) {
+      if (lower === 'ctrl' || lower === 'control') ctrl = true;
+      else if (lower === 'shift') shift = true;
+      else if (lower === 'alt') alt = true;
+      else meta = true;
+    } else {
+      key = part.length === 1 ? part.toLowerCase() : part;
+    }
+  }
+
+  if (key === null) {
+    throw new Error(`shortcut "${spec}" has no non-modifier key`);
+  }
+  return { key, ctrl, shift, alt, meta };
+}
+
+/** Does a DOM KeyboardEvent match the parsed shortcut? */
+export function matchesEvent(parsed: ParsedKey, event: KeyboardEvent): boolean {
+  if (parsed.ctrl !== event.ctrlKey) return false;
+  if (parsed.shift !== event.shiftKey) return false;
+  if (parsed.alt !== event.altKey) return false;
+  if (parsed.meta !== event.metaKey) return false;
+  const eventKey = event.key.length === 1 ? event.key.toLowerCase() : event.key;
+  return eventKey === parsed.key;
+}
+
+export function isEditableTarget(target: EventTarget | null): boolean {
+  if (target === null) return false;
+  const t = target as { tagName?: unknown; isContentEditable?: unknown };
+  if (typeof t.tagName === 'string') {
+    const tag = t.tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+  }
+  return t.isContentEditable === true;
+}

--- a/src/lib/app/shortcuts.ts
+++ b/src/lib/app/shortcuts.ts
@@ -1,0 +1,176 @@
+import type { Action } from 'svelte/action';
+import { get } from 'svelte/store';
+import { sidebar } from '$lib/store/sidebar';
+import { documentStore, currentDocument } from '$lib/store/document';
+import { viewport } from '$lib/store/viewport';
+import { isEditableTarget } from './shortcutParser';
+
+/**
+ * Global keyboard shortcuts for the app shell. Mounted on the root so events
+ * fire regardless of focused element, unless the target is a text input.
+ *
+ * Space is tracked separately from the keydown routing to distinguish
+ * hold-vs-tap for pan mode.
+ */
+export const shortcuts: Action<HTMLElement> = (node) => {
+  let spaceHeld = false;
+
+  function pickPaletteSlot(slot: number): void {
+    const snap = sidebar.snapshot();
+    const presets = snap.palettes.find((p) => p.id === 'presets');
+    const color = presets?.colors[slot - 1];
+    if (color) sidebar.setActiveColor(color);
+  }
+
+  function currentWidth(): number | null {
+    const snap = sidebar.snapshot();
+    const tool = snap.activeTool;
+    if (tool === 'pen' || tool === 'highlighter' || tool === 'line') {
+      return snap.toolStyles[tool].width;
+    }
+    return null;
+  }
+
+  function adjustWidth(delta: number): void {
+    const w = currentWidth();
+    if (w === null) return;
+    const next = Math.max(1, Math.min(40, Math.round(w + delta)));
+    sidebar.setWidth(next);
+  }
+
+  function currentPageCount(): number {
+    const doc = get(currentDocument);
+    return doc?.pages.length ?? 0;
+  }
+
+  function currentPage(): number {
+    return viewport.snapshot().currentPageIndex;
+  }
+
+  function toggleFullscreen(): void {
+    if (typeof document === 'undefined') return;
+    if (document.fullscreenElement) {
+      void document.exitFullscreen();
+    } else {
+      void document.documentElement.requestFullscreen();
+    }
+  }
+
+  function insertBlankAfterCurrent(): void {
+    const doc = get(currentDocument);
+    if (!doc) return;
+    const idx = currentPage();
+    const page = doc.pages[idx];
+    if (!page) return;
+    documentStore.insertBlankPageAfter(idx, page.width, page.height);
+  }
+
+  function handleKeyDown(event: KeyboardEvent): void {
+    if (isEditableTarget(event.target)) return;
+
+    const ctrlOrMeta = event.ctrlKey || event.metaKey;
+    const key = event.key;
+
+    if (ctrlOrMeta) {
+      const lower = key.toLowerCase();
+      if (lower === 'z' && event.shiftKey) {
+        event.preventDefault();
+        documentStore.redo(currentPage());
+        return;
+      }
+      if (lower === 'z') {
+        event.preventDefault();
+        documentStore.undo(currentPage());
+        return;
+      }
+      return;
+    }
+
+    if (event.shiftKey || event.altKey) return;
+
+    switch (key) {
+      case 'p':
+      case 'P':
+        sidebar.setTool('pen');
+        return;
+      case 'h':
+      case 'H':
+        sidebar.setTool('highlighter');
+        return;
+      case 'e':
+      case 'E':
+        sidebar.setTool('eraser');
+        return;
+      case 'l':
+      case 'L':
+        sidebar.setTool('line');
+        return;
+      case 'g':
+      case 'G':
+        sidebar.setTool('graph');
+        return;
+      case 'd':
+      case 'D':
+        sidebar.cycleDash();
+        return;
+      case 'b':
+      case 'B':
+        insertBlankAfterCurrent();
+        return;
+      case 'f':
+      case 'F':
+        toggleFullscreen();
+        return;
+      case 'Tab':
+        event.preventDefault();
+        sidebar.togglePin();
+        return;
+      case '[':
+        adjustWidth(-1);
+        return;
+      case ']':
+        adjustWidth(1);
+        return;
+      case 'ArrowLeft':
+      case 'PageUp':
+        event.preventDefault();
+        viewport.prevPage();
+        return;
+      case 'ArrowRight':
+      case 'PageDown':
+        event.preventDefault();
+        viewport.nextPage(currentPageCount());
+        return;
+      case ' ':
+        if (!spaceHeld) {
+          spaceHeld = true;
+          viewport.setPanMode(true);
+        }
+        event.preventDefault();
+        return;
+      default:
+        break;
+    }
+
+    if (key.length === 1 && key >= '1' && key <= '9') {
+      pickPaletteSlot(Number(key));
+    }
+  }
+
+  function handleKeyUp(event: KeyboardEvent): void {
+    if (event.key === ' ') {
+      spaceHeld = false;
+      viewport.setPanMode(false);
+    }
+  }
+
+  node.addEventListener('keydown', handleKeyDown);
+  node.addEventListener('keyup', handleKeyUp);
+
+  return {
+    destroy(): void {
+      node.removeEventListener('keydown', handleKeyDown);
+      node.removeEventListener('keyup', handleKeyUp);
+    },
+  };
+};

--- a/src/lib/app/shortcuts.ts
+++ b/src/lib/app/shortcuts.ts
@@ -6,13 +6,15 @@ import { viewport } from '$lib/store/viewport';
 import { isEditableTarget } from './shortcutParser';
 
 /**
- * Global keyboard shortcuts for the app shell. Mounted on the root so events
- * fire regardless of focused element, unless the target is a text input.
+ * Global keyboard shortcuts for the app shell. Listeners are attached to
+ * `window` so events fire regardless of focus, unless the target is a text
+ * input. The action's host element is only used as the action's lifecycle
+ * anchor.
  *
  * Space is tracked separately from the keydown routing to distinguish
  * hold-vs-tap for pan mode.
  */
-export const shortcuts: Action<HTMLElement> = (node) => {
+export const shortcuts: Action<HTMLElement> = () => {
   let spaceHeld = false;
 
   function pickPaletteSlot(slot: number): void {
@@ -164,13 +166,17 @@ export const shortcuts: Action<HTMLElement> = (node) => {
     }
   }
 
-  node.addEventListener('keydown', handleKeyDown);
-  node.addEventListener('keyup', handleKeyUp);
+  if (typeof window !== 'undefined') {
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
+  }
 
   return {
     destroy(): void {
-      node.removeEventListener('keydown', handleKeyDown);
-      node.removeEventListener('keyup', handleKeyUp);
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('keydown', handleKeyDown);
+        window.removeEventListener('keyup', handleKeyUp);
+      }
     },
   };
 };

--- a/src/lib/app/toolBridge.ts
+++ b/src/lib/app/toolBridge.ts
@@ -1,0 +1,15 @@
+import { currentStyle, sidebar } from '$lib/store/sidebar';
+import { setStyle, setTool } from '$lib/store/tool';
+
+/**
+ * One-way bridge: sidebar (UI source of truth) → tool store (read by ink engine).
+ * Returns an unsubscribe function.
+ */
+export function startToolBridge(): () => void {
+  const unsubTool = sidebar.subscribe((s) => setTool(s.activeTool));
+  const unsubStyle = currentStyle.subscribe((style) => setStyle(style));
+  return () => {
+    unsubTool();
+    unsubStyle();
+  };
+}

--- a/src/lib/app/toolBridge.ts
+++ b/src/lib/app/toolBridge.ts
@@ -1,4 +1,5 @@
 import { currentStyle, sidebar } from '$lib/store/sidebar';
+import type { ToolKind } from '$lib/types';
 import { setStyle, setTool } from '$lib/store/tool';
 
 /**
@@ -6,7 +7,13 @@ import { setStyle, setTool } from '$lib/store/tool';
  * Returns an unsubscribe function.
  */
 export function startToolBridge(): () => void {
-  const unsubTool = sidebar.subscribe((s) => setTool(s.activeTool));
+  let lastTool: ToolKind | null = null;
+  const unsubTool = sidebar.subscribe((s) => {
+    if (s.activeTool !== lastTool) {
+      lastTool = s.activeTool;
+      setTool(s.activeTool);
+    }
+  });
   const unsubStyle = currentStyle.subscribe((style) => setStyle(style));
   return () => {
     unsubTool();

--- a/src/lib/canvas/index.ts
+++ b/src/lib/canvas/index.ts
@@ -1,0 +1,5 @@
+export { default as CanvasStack } from './CanvasStack.svelte';
+export { default as PdfLayer } from './PdfLayer.svelte';
+export { default as HighlightLayer } from './HighlightLayer.svelte';
+export { default as InkLayer } from './InkLayer.svelte';
+export { default as LiveLayer } from './LiveLayer.svelte';

--- a/src/lib/store/document.ts
+++ b/src/lib/store/document.ts
@@ -11,7 +11,7 @@ export interface DocumentStore {
   removeObject(pageIndex: number, id: ObjectId): void;
   updateObject(pageIndex: number, id: ObjectId, patch: Partial<AnyObject>): void;
 
-  insertBlankPageAfter(pdfPageIndex: number, width: number, height: number): void;
+  insertBlankPageAfter(afterArrayIndex: number, width: number, height: number): void;
 
   undo(pageIndex: number): void;
   redo(pageIndex: number): void;
@@ -31,6 +31,33 @@ function replacePage(doc: EldrawDocument, pageIndex: number, next: Page): Eldraw
     ...doc,
     pages: doc.pages.map((p, i) => (i === pageIndex ? next : p)),
   };
+}
+
+/**
+ * Return the stable underlying PDF page index for the page at the given
+ * array position. Returns null for blank pages (which have no PDF to render).
+ */
+export function pdfPageIndexAt(pages: readonly Page[], arrayIndex: number): number | null {
+  const page = pages[arrayIndex];
+  if (!page || page.type !== 'pdf') return null;
+  let count = 0;
+  for (let i = 0; i < arrayIndex; i += 1) {
+    if (pages[i].type === 'pdf') count += 1;
+  }
+  return count;
+}
+
+/**
+ * Return the PDF page index that the page at arrayIndex follows. For a pdf
+ * page this is its own PDF index; for a blank page it is the last PDF page
+ * at or before it (or null if no PDF page precedes it).
+ */
+function lastPdfIndexAtOrBefore(pages: readonly Page[], arrayIndex: number): number | null {
+  let count = -1;
+  for (let i = 0; i <= arrayIndex && i < pages.length; i += 1) {
+    if (pages[i].type === 'pdf') count += 1;
+  }
+  return count < 0 ? null : count;
 }
 
 export function createDocumentStore(): DocumentStore {
@@ -89,14 +116,15 @@ export function createDocumentStore(): DocumentStore {
       pushAndApply(pageIndex, { type: 'update', objectId: id, before, after });
     },
 
-    insertBlankPageAfter(pdfPageIndex, width, height) {
+    insertBlankPageAfter(afterArrayIndex, width, height) {
       state.update((doc) => {
         if (!doc) return doc;
-        const insertIdx = pdfPageIndex + 1;
+        const insertIdx = afterArrayIndex + 1;
+        const insertedAfterPdfPage = lastPdfIndexAtOrBefore(doc.pages, afterArrayIndex);
         const blank: Page = {
           pageIndex: insertIdx,
           type: 'blank',
-          insertedAfterPdfPage: pdfPageIndex,
+          insertedAfterPdfPage,
           width,
           height,
           objects: [],

--- a/src/lib/store/viewport.ts
+++ b/src/lib/store/viewport.ts
@@ -1,0 +1,84 @@
+import { get, writable, type Readable } from 'svelte/store';
+
+export const MIN_SCALE = 0.25;
+export const MAX_SCALE = 4.0;
+const ZOOM_STEP = 1.1;
+
+export interface ViewportState {
+  scale: number;
+  offsetX: number;
+  offsetY: number;
+  currentPageIndex: number;
+  panMode: boolean;
+}
+
+function initial(): ViewportState {
+  return { scale: 1.5, offsetX: 0, offsetY: 0, currentPageIndex: 0, panMode: false };
+}
+
+function clampScale(n: number): number {
+  if (!Number.isFinite(n)) return 1;
+  return Math.min(MAX_SCALE, Math.max(MIN_SCALE, n));
+}
+
+function createViewport() {
+  const store = writable<ViewportState>(initial());
+  const { subscribe, update, set } = store;
+
+  return {
+    subscribe,
+    reset: () => set(initial()),
+
+    setScale(scale: number): void {
+      update((s) => ({ ...s, scale: clampScale(scale) }));
+    },
+
+    zoomIn(): void {
+      update((s) => ({ ...s, scale: clampScale(s.scale * ZOOM_STEP) }));
+    },
+
+    zoomOut(): void {
+      update((s) => ({ ...s, scale: clampScale(s.scale / ZOOM_STEP) }));
+    },
+
+    setOffset(offsetX: number, offsetY: number): void {
+      update((s) => ({ ...s, offsetX, offsetY }));
+    },
+
+    panBy(dx: number, dy: number): void {
+      update((s) => ({ ...s, offsetX: s.offsetX + dx, offsetY: s.offsetY + dy }));
+    },
+
+    setPanMode(panMode: boolean): void {
+      update((s) => (s.panMode === panMode ? s : { ...s, panMode }));
+    },
+
+    setPage(index: number, total: number): void {
+      update((s) => {
+        if (total <= 0) return { ...s, currentPageIndex: 0 };
+        const clamped = Math.max(0, Math.min(total - 1, index));
+        return { ...s, currentPageIndex: clamped };
+      });
+    },
+
+    nextPage(total: number): void {
+      update((s) => {
+        if (total <= 0) return { ...s, currentPageIndex: 0 };
+        const next = Math.min(total - 1, s.currentPageIndex + 1);
+        return { ...s, currentPageIndex: next };
+      });
+    },
+
+    prevPage(): void {
+      update((s) => ({ ...s, currentPageIndex: Math.max(0, s.currentPageIndex - 1) }));
+    },
+
+    snapshot(): ViewportState {
+      return get(store);
+    },
+  };
+}
+
+export const viewport = createViewport();
+
+export const viewportStore: Readable<ViewportState> = { subscribe: viewport.subscribe };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,7 +6,7 @@
   import { loadSidecar } from '$lib/ipc';
   import { pdf } from '$lib/store/pdf';
   import { sidebar } from '$lib/store/sidebar';
-  import { currentDocument, documentStore } from '$lib/store/document';
+  import { currentDocument, documentStore, pdfPageIndexAt } from '$lib/store/document';
   import { startAutosave } from '$lib/store/autosave';
   import { viewport, viewportStore, MIN_SCALE, MAX_SCALE } from '$lib/store/viewport';
   import { startToolBridge } from '$lib/app/toolBridge';
@@ -29,6 +29,7 @@
   const pageCount = $derived(doc?.pages.length ?? meta?.pageCount ?? 0);
   const pageIndex = $derived(Math.min(view.currentPageIndex, Math.max(0, pageCount - 1)));
   const currentPage = $derived(doc?.pages[pageIndex] ?? null);
+  const pdfPageIndex = $derived(doc ? pdfPageIndexAt(doc.pages, pageIndex) : pageIndex);
   const pageObjects = $derived<AnyObject[]>(currentPage?.objects ?? []);
   const pageStrokes = $derived<StrokeObject[]>(
     pageObjects.filter((o): o is StrokeObject => o.type === 'stroke'),
@@ -176,9 +177,9 @@
           class="page-frame"
           style="width: {size.width}px; height: {size.height}px; transform: translate({view.offsetX}px, {view.offsetY}px);"
         >
-          {#if meta && currentPage?.type !== 'blank'}
+          {#if meta && currentPage?.type !== 'blank' && pdfPageIndex !== null}
             <div class="pdf-slot">
-              <PdfLayer {pageIndex} scale={view.scale} />
+              <PdfLayer pageIndex={pdfPageIndex} scale={view.scale} />
             </div>
           {:else if currentPage?.type === 'blank'}
             <div class="blank-slot" style="width: {size.width}px; height: {size.height}px;"></div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,36 +1,209 @@
 <script lang="ts">
-  import PdfLayer from '$lib/canvas/PdfLayer.svelte';
-  import { pdf } from '$lib/store/pdf';
+  import { onDestroy, onMount } from 'svelte';
+  import { CanvasStack, PdfLayer } from '$lib/canvas';
+  import { Sidebar } from '$lib/sidebar';
   import { openAndLoadPdf } from '$lib/ipc/pdf';
+  import { loadSidecar } from '$lib/ipc';
+  import { pdf } from '$lib/store/pdf';
+  import { sidebar } from '$lib/store/sidebar';
+  import { currentDocument, documentStore } from '$lib/store/document';
+  import { startAutosave } from '$lib/store/autosave';
+  import { viewport, viewportStore, MIN_SCALE, MAX_SCALE } from '$lib/store/viewport';
+  import { startToolBridge } from '$lib/app/toolBridge';
+  import { shortcuts } from '$lib/app/shortcuts';
+  import { openPdfDialog } from '$lib/app/openPdfDialog';
+  import { hitTestStrokes } from '$lib/tools/eraser';
+  import type { AnyObject, EldrawDocument, PdfMeta, StrokeObject } from '$lib/types';
 
-  let pageIndex = $state(0);
-  const scale = 1.5;
+  const ERASER_RADIUS = 4;
 
-  async function onFileChosen(event: Event): Promise<void> {
-    const input = event.currentTarget as HTMLInputElement;
-    const file = input.files?.[0];
-    if (!file) return;
-    // In the Tauri runtime File.path is available; in a browser dev session
-    // we fall back to the plain name for debugging.
-    const path = (file as File & { path?: string }).path ?? file.name;
-    await openAndLoadPdf(path);
-    pageIndex = 0;
+  let stopBridge: (() => void) | null = null;
+  let stopAutosave: (() => void) | null = null;
+
+  const pdfState = $derived($pdf);
+  const meta = $derived<PdfMeta | null>(pdfState.meta);
+  const doc = $derived<EldrawDocument | null>($currentDocument);
+  const view = $derived($viewportStore);
+  const sidebarState = $derived($sidebar);
+
+  const pageCount = $derived(doc?.pages.length ?? meta?.pageCount ?? 0);
+  const pageIndex = $derived(Math.min(view.currentPageIndex, Math.max(0, pageCount - 1)));
+  const currentPage = $derived(doc?.pages[pageIndex] ?? null);
+  const pageObjects = $derived<AnyObject[]>(currentPage?.objects ?? []);
+  const pageStrokes = $derived<StrokeObject[]>(
+    pageObjects.filter((o): o is StrokeObject => o.type === 'stroke'),
+  );
+
+  const pageDimsPt = $derived(() => {
+    if (currentPage) return { width: currentPage.width, height: currentPage.height };
+    const pdfPage = meta?.pages[pageIndex];
+    if (pdfPage) return pdfPage;
+    return null;
+  });
+
+  const canvasSize = $derived(() => {
+    const dims = pageDimsPt();
+    if (!dims) return null;
+    return {
+      width: Math.round(dims.width * view.scale),
+      height: Math.round(dims.height * view.scale),
+      ptToPx: view.scale,
+    };
+  });
+
+  function buildEmptyDoc(m: PdfMeta): EldrawDocument {
+    return {
+      version: 1,
+      pdfHash: m.hash,
+      pdfPath: m.path,
+      pages: m.pages.map((p, i) => ({
+        pageIndex: i,
+        type: 'pdf',
+        insertedAfterPdfPage: null,
+        width: p.width,
+        height: p.height,
+        objects: [],
+      })),
+      palettes: [],
+      prefs: {
+        sidebarPinned: true,
+        defaultTool: 'pen',
+        toolDefaults: {
+          pen: { color: '#000000', width: 2, dash: 'solid', opacity: 1 },
+          highlighter: { color: '#fdd835', width: 14, dash: 'solid', opacity: 0.3 },
+          line: { color: '#000000', width: 2, dash: 'solid', opacity: 1 },
+        },
+      },
+    };
   }
+
+  async function openFromDialog(): Promise<void> {
+    const path = await openPdfDialog();
+    if (!path) return;
+    await loadPath(path);
+  }
+
+  async function loadPath(path: string): Promise<void> {
+    const loaded = await openAndLoadPdf(path);
+    if (!loaded) return;
+
+    let sidecar: EldrawDocument | null = null;
+    try {
+      sidecar = await loadSidecar(path);
+    } catch {
+      sidecar = null;
+    }
+
+    documentStore.load(sidecar ?? buildEmptyDoc(loaded));
+
+    stopAutosave?.();
+    stopAutosave = startAutosave(path);
+    viewport.setPage(0, loaded.pageCount);
+  }
+
+  function onCommitStroke(stroke: StrokeObject): void {
+    documentStore.addObject(pageIndex, stroke);
+  }
+
+  function onEraseAt(at: { x: number; y: number }): void {
+    const hits = hitTestStrokes(pageStrokes, at, ERASER_RADIUS);
+    for (const s of hits) {
+      documentStore.removeObject(pageIndex, s.id);
+    }
+  }
+
+  function onWheel(event: WheelEvent): void {
+    if (!(event.ctrlKey || event.metaKey)) return;
+    event.preventDefault();
+    if (event.deltaY < 0) viewport.zoomIn();
+    else if (event.deltaY > 0) viewport.zoomOut();
+  }
+
+  onMount(() => {
+    stopBridge = startToolBridge();
+  });
+
+  onDestroy(() => {
+    stopBridge?.();
+    stopAutosave?.();
+  });
 </script>
 
-<main class="app">
-  <aside class="sidebar" aria-label="Tool sidebar">
-    <p class="placeholder">sidebar (feat/sidebar-tools)</p>
-  </aside>
-  <section class="canvas-area" aria-label="Canvas area">
-    <p class="placeholder">canvas stack (feat/pdf-pipeline + feat/ink-engine)</p>
-    <label class="dev-open">
-      Open PDF
-      <input type="file" accept="application/pdf" onchange={onFileChosen} />
-    </label>
-    {#if $pdf.meta}
-      <PdfLayer {pageIndex} {scale} />
-    {/if}
+<svelte:window />
+
+<main class="app" class:pinned={sidebarState.pinned} use:shortcuts tabindex="-1" role="application">
+  <Sidebar />
+
+  <section class="main">
+    <header class="topbar">
+      <button type="button" class="open" onclick={openFromDialog}>Open PDF…</button>
+      <div class="pager">
+        <button
+          type="button"
+          aria-label="Previous page"
+          disabled={pageIndex <= 0}
+          onclick={() => viewport.prevPage()}
+        >
+          ‹
+        </button>
+        <span class="page-indicator">
+          {#if pageCount > 0}
+            Page {pageIndex + 1} / {pageCount}
+          {:else}
+            No PDF loaded
+          {/if}
+        </span>
+        <button
+          type="button"
+          aria-label="Next page"
+          disabled={pageIndex >= pageCount - 1}
+          onclick={() => viewport.nextPage(pageCount)}
+        >
+          ›
+        </button>
+      </div>
+      <div class="zoom">
+        <button type="button" aria-label="Zoom out" onclick={() => viewport.zoomOut()}>−</button>
+        <span class="zoom-indicator">{Math.round(view.scale * 100)}%</span>
+        <button type="button" aria-label="Zoom in" onclick={() => viewport.zoomIn()}>+</button>
+      </div>
+    </header>
+
+    <div class="canvas-area" onwheel={onWheel}>
+      {#if canvasSize()}
+        {@const size = canvasSize()!}
+        <div
+          class="page-frame"
+          style="width: {size.width}px; height: {size.height}px; transform: translate({view.offsetX}px, {view.offsetY}px);"
+        >
+          {#if meta && currentPage?.type !== 'blank'}
+            <div class="pdf-slot">
+              <PdfLayer {pageIndex} scale={view.scale} />
+            </div>
+          {:else if currentPage?.type === 'blank'}
+            <div class="blank-slot" style="width: {size.width}px; height: {size.height}px;"></div>
+          {/if}
+          <div class="stack-slot">
+            <CanvasStack
+              strokes={pageStrokes}
+              width={size.width}
+              height={size.height}
+              ptToPx={size.ptToPx}
+              oncommit={onCommitStroke}
+              onerase={onEraseAt}
+            />
+          </div>
+        </div>
+      {:else}
+        <div class="empty">
+          <p>No PDF loaded. Press <kbd>Open PDF…</kbd> to get started.</p>
+          <p class="dim">Zoom range: {MIN_SCALE.toFixed(2)}× – {MAX_SCALE.toFixed(2)}×</p>
+        </div>
+      {/if}
+      {#if view.panMode}
+        <div class="pan-indicator" aria-hidden="true">pan</div>
+      {/if}
+    </div>
   </section>
 </main>
 
@@ -45,34 +218,121 @@
   }
   .app {
     display: grid;
-    grid-template-columns: 220px 1fr;
+    grid-template-columns: 1fr;
     height: 100vh;
+    outline: none;
   }
-  .sidebar {
-    background: #252525;
-    border-right: 1px solid #333;
-    padding: 12px;
+  .app.pinned {
+    grid-template-columns: 220px 1fr;
+  }
+  .main {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    min-height: 0;
+  }
+  .topbar {
+    height: 36px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 0 12px;
+    background: #202020;
+    border-bottom: 1px solid #111;
+    font-size: 12px;
+  }
+  .open {
+    background: #2a2a2a;
+    border: 1px solid #3a3a3a;
+    color: #ddd;
+    border-radius: 4px;
+    padding: 4px 10px;
+    cursor: pointer;
+  }
+  .open:hover {
+    border-color: #666;
+  }
+  .pager,
+  .zoom {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .pager button,
+  .zoom button {
+    background: #2a2a2a;
+    border: 1px solid #3a3a3a;
+    color: #ddd;
+    width: 24px;
+    height: 22px;
+    border-radius: 3px;
+    cursor: pointer;
+  }
+  .pager button:disabled,
+  .zoom button:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+  .page-indicator,
+  .zoom-indicator {
+    min-width: 70px;
+    text-align: center;
+    color: #bbb;
+  }
+  .zoom {
+    margin-left: auto;
   }
   .canvas-area {
     position: relative;
-    overflow: hidden;
+    flex: 1 1 auto;
+    overflow: auto;
+    background: #121212;
   }
-  .placeholder {
-    color: #888;
-    font-size: 13px;
+  .page-frame {
+    position: relative;
+    margin: 24px auto;
+    background: #fff;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.6);
   }
-  .dev-open {
+  .pdf-slot,
+  .stack-slot {
     position: absolute;
-    top: 8px;
-    right: 8px;
-    font-size: 12px;
-    color: #aaa;
-    background: #2a2a2a;
-    padding: 4px 8px;
-    border-radius: 4px;
-    cursor: pointer;
+    inset: 0;
   }
-  .dev-open input {
-    display: none;
+  .blank-slot {
+    background: #fff;
+  }
+  .empty {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    justify-content: center;
+    align-items: center;
+    color: #888;
+  }
+  .dim {
+    font-size: 11px;
+    color: #555;
+  }
+  .pan-indicator {
+    position: absolute;
+    bottom: 12px;
+    left: 12px;
+    padding: 2px 8px;
+    background: rgba(0, 0, 0, 0.6);
+    border: 1px solid #333;
+    border-radius: 4px;
+    font-size: 11px;
+    color: #aaa;
+    pointer-events: none;
+  }
+  kbd {
+    font-family: inherit;
+    background: #2a2a2a;
+    border: 1px solid #3a3a3a;
+    padding: 1px 6px;
+    border-radius: 3px;
   }
 </style>

--- a/tests/document-store.test.ts
+++ b/tests/document-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { get } from 'svelte/store';
-import { createDocumentStore } from '$lib/store/document';
+import { createDocumentStore, pdfPageIndexAt } from '$lib/store/document';
 import type { EldrawDocument, Page, StrokeObject } from '$lib/types';
 
 function stroke(id: string, width = 2): StrokeObject {
@@ -94,6 +94,34 @@ describe('documentStore', () => {
     expect(pages[0].pageIndex).toBe(0);
     expect(pages[1].pageIndex).toBe(1);
     expect(pages[2].pageIndex).toBe(2);
+  });
+
+  it('insertBlankPageAfter with preceding blank records correct pdf index', () => {
+    const store = createDocumentStore();
+    store.load(docWithPages([pdfPage(0), pdfPage(1)]));
+    store.insertBlankPageAfter(0, 500, 700);
+    store.insertBlankPageAfter(1, 500, 700);
+    const pages = get(store)!.pages;
+    expect(pages).toHaveLength(4);
+    expect(pages[1].type).toBe('blank');
+    expect(pages[1].insertedAfterPdfPage).toBe(0);
+    expect(pages[2].type).toBe('blank');
+    expect(pages[2].insertedAfterPdfPage).toBe(0);
+    expect(pages[3].type).toBe('pdf');
+  });
+
+  it('pdfPageIndexAt maps array positions to underlying PDF indices', () => {
+    const pages: Page[] = [
+      pdfPage(0),
+      { ...pdfPage(1), type: 'blank', insertedAfterPdfPage: 0 },
+      pdfPage(1),
+      pdfPage(2),
+    ];
+    expect(pdfPageIndexAt(pages, 0)).toBe(0);
+    expect(pdfPageIndexAt(pages, 1)).toBeNull();
+    expect(pdfPageIndexAt(pages, 2)).toBe(1);
+    expect(pdfPageIndexAt(pages, 3)).toBe(2);
+    expect(pdfPageIndexAt(pages, 99)).toBeNull();
   });
 
   it('load clears history', () => {

--- a/tests/shortcut-parser.test.ts
+++ b/tests/shortcut-parser.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { isEditableTarget, matchesEvent, parseShortcut } from '../src/lib/app/shortcutParser';
+
+function kb(
+  key: string,
+  mods: Partial<{ ctrl: boolean; shift: boolean; alt: boolean; meta: boolean }> = {},
+): KeyboardEvent {
+  return {
+    key,
+    ctrlKey: mods.ctrl ?? false,
+    shiftKey: mods.shift ?? false,
+    altKey: mods.alt ?? false,
+    metaKey: mods.meta ?? false,
+  } as KeyboardEvent;
+}
+
+describe('parseShortcut', () => {
+  it('parses a single character as lowercase key', () => {
+    const p = parseShortcut('P');
+    expect(p).toEqual({ key: 'p', ctrl: false, shift: false, alt: false, meta: false });
+  });
+
+  it('parses Ctrl+Z', () => {
+    expect(parseShortcut('Ctrl+Z')).toEqual({
+      key: 'z',
+      ctrl: true,
+      shift: false,
+      alt: false,
+      meta: false,
+    });
+  });
+
+  it('parses Ctrl+Shift+Z', () => {
+    expect(parseShortcut('Ctrl+Shift+Z')).toEqual({
+      key: 'z',
+      ctrl: true,
+      shift: true,
+      alt: false,
+      meta: false,
+    });
+  });
+
+  it('preserves named keys like ArrowLeft', () => {
+    expect(parseShortcut('ArrowLeft').key).toBe('ArrowLeft');
+    expect(parseShortcut('PageUp').key).toBe('PageUp');
+  });
+
+  it('parses bracket keys', () => {
+    expect(parseShortcut('[').key).toBe('[');
+    expect(parseShortcut(']').key).toBe(']');
+  });
+
+  it('accepts Cmd as meta alias', () => {
+    const p = parseShortcut('Cmd+Z');
+    expect(p.meta).toBe(true);
+    expect(p.key).toBe('z');
+  });
+
+  it('throws on empty spec', () => {
+    expect(() => parseShortcut('')).toThrow();
+  });
+
+  it('throws when only modifiers given', () => {
+    expect(() => parseShortcut('Ctrl+Shift')).toThrow();
+  });
+});
+
+describe('matchesEvent', () => {
+  it('matches a bare key', () => {
+    expect(matchesEvent(parseShortcut('p'), kb('p'))).toBe(true);
+    expect(matchesEvent(parseShortcut('p'), kb('P'))).toBe(true);
+  });
+
+  it('requires modifiers to match exactly', () => {
+    expect(matchesEvent(parseShortcut('Ctrl+Z'), kb('z', { ctrl: true }))).toBe(true);
+    expect(matchesEvent(parseShortcut('Ctrl+Z'), kb('z'))).toBe(false);
+    expect(matchesEvent(parseShortcut('Ctrl+Z'), kb('z', { ctrl: true, shift: true }))).toBe(false);
+  });
+
+  it('matches named keys', () => {
+    expect(matchesEvent(parseShortcut('ArrowLeft'), kb('ArrowLeft'))).toBe(true);
+    expect(matchesEvent(parseShortcut('ArrowLeft'), kb('ArrowRight'))).toBe(false);
+  });
+});
+
+describe('isEditableTarget', () => {
+  it('returns true for input, textarea, select tagName', () => {
+    expect(isEditableTarget({ tagName: 'INPUT' } as unknown as EventTarget)).toBe(true);
+    expect(isEditableTarget({ tagName: 'TEXTAREA' } as unknown as EventTarget)).toBe(true);
+    expect(isEditableTarget({ tagName: 'SELECT' } as unknown as EventTarget)).toBe(true);
+  });
+
+  it('returns true for contenteditable', () => {
+    expect(
+      isEditableTarget({ tagName: 'DIV', isContentEditable: true } as unknown as EventTarget),
+    ).toBe(true);
+  });
+
+  it('returns false for plain elements and null', () => {
+    expect(isEditableTarget({ tagName: 'DIV' } as unknown as EventTarget)).toBe(false);
+    expect(isEditableTarget(null)).toBe(false);
+  });
+});

--- a/tests/viewport.test.ts
+++ b/tests/viewport.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+import { viewport, MIN_SCALE, MAX_SCALE } from '../src/lib/store/viewport';
+
+describe('viewport', () => {
+  beforeEach(() => viewport.reset());
+
+  it('clamps scale to [MIN_SCALE, MAX_SCALE]', () => {
+    viewport.setScale(100);
+    expect(get(viewport).scale).toBe(MAX_SCALE);
+    viewport.setScale(0.01);
+    expect(get(viewport).scale).toBe(MIN_SCALE);
+    viewport.setScale(1.0);
+    expect(get(viewport).scale).toBe(1.0);
+  });
+
+  it('zoomIn and zoomOut stay within bounds', () => {
+    viewport.setScale(MAX_SCALE);
+    viewport.zoomIn();
+    expect(get(viewport).scale).toBe(MAX_SCALE);
+    viewport.setScale(MIN_SCALE);
+    viewport.zoomOut();
+    expect(get(viewport).scale).toBe(MIN_SCALE);
+  });
+
+  it('setScale rejects non-finite values by falling back', () => {
+    viewport.setScale(Number.NaN);
+    expect(get(viewport).scale).toBeGreaterThanOrEqual(MIN_SCALE);
+    expect(get(viewport).scale).toBeLessThanOrEqual(MAX_SCALE);
+  });
+
+  it('nextPage clamps to total - 1', () => {
+    viewport.setPage(0, 3);
+    viewport.nextPage(3);
+    viewport.nextPage(3);
+    viewport.nextPage(3);
+    viewport.nextPage(3);
+    expect(get(viewport).currentPageIndex).toBe(2);
+  });
+
+  it('prevPage clamps to 0', () => {
+    viewport.setPage(1, 3);
+    viewport.prevPage();
+    viewport.prevPage();
+    viewport.prevPage();
+    expect(get(viewport).currentPageIndex).toBe(0);
+  });
+
+  it('handles empty document (total = 0)', () => {
+    viewport.setPage(5, 0);
+    expect(get(viewport).currentPageIndex).toBe(0);
+    viewport.nextPage(0);
+    expect(get(viewport).currentPageIndex).toBe(0);
+  });
+
+  it('panBy accumulates offset', () => {
+    viewport.panBy(10, 5);
+    viewport.panBy(-3, 2);
+    const s = get(viewport);
+    expect(s.offsetX).toBe(7);
+    expect(s.offsetY).toBe(7);
+  });
+
+  it('setPanMode toggles pan state', () => {
+    viewport.setPanMode(true);
+    expect(get(viewport).panMode).toBe(true);
+    viewport.setPanMode(false);
+    expect(get(viewport).panMode).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Final Phase 1 worktree. Turns the placeholder `+page.svelte` into the real app shell: pinned-or-overlay sidebar, 36px topbar with page indicator + prev/next + zoom controls, scrollable canvas area hosting `PdfLayer` + `CanvasStack` for the current page, global keyboard shortcuts, viewport/zoom store, native file dialog, and sidecar autosave.

## What's new

- `src/lib/store/viewport.ts` — scale clamped to `[0.25, 4.0]`, offset, current page index with boundary clamps, `panMode` flag.
- `src/lib/app/shortcutParser.ts` — pure `parseShortcut` + `matchesEvent` + `isEditableTarget`, unit tested.
- `src/lib/app/shortcuts.ts` — Svelte action binding the full Phase 1 shortcut table (P/H/E/L/G tools, 1–9 palette slots, `[`/`]` width, D dash cycle, arrows/PgUp/PgDn page nav, B insert blank, Ctrl/Cmd+Z undo/redo, F fullscreen, Tab toggle pin, Space-hold pan). No-ops when the target is an `<input>`/`<textarea>`/`<select>`/contenteditable.
- `src/lib/app/toolBridge.ts` — one-way sync from sidebar (UI source of truth) to the ink engine's tool store.
- `src/lib/app/openPdfDialog.ts` — wraps `@tauri-apps/plugin-dialog` `open()`.
- `src/lib/canvas/index.ts` — barrel for the canvas layer components.
- `src/routes/+page.svelte` — full rewrite wiring the pieces together: open PDF → `openPdf` → `loadSidecar` (fallback to empty doc from `PdfMeta`) → `documentStore.load` → `startAutosave(path)`. `CanvasStack` commits become `documentStore.addObject`; eraser pointer moves hit-test current-page strokes via `hitTestStrokes` and call `documentStore.removeObject`.
- Ctrl/Cmd + wheel on the canvas area zooms in/out through the viewport store.
- `src-tauri`: `tauri-plugin-dialog` added, registered in `lib.rs`, and `dialog:allow-open` capability enabled.

## Peer branch integration (⚠️ merge order)

This worktree was the last to land by design. To integrate against real peer code, the following branches were merged into this branch first:

- `origin/feat/pdf-pipeline`
- `origin/feat/ink-engine`
- `origin/feat/sidebar-tools`
- `origin/feat/storage-history` (had conflicts in `src-tauri/Cargo.toml` / `src-tauri/Cargo.lock` / `src-tauri/src/error.rs` — resolved by keeping all additions from both sides; `Cargo.lock` regenerated via `cargo check`)

**Merge order requirement:** this PR MUST only be merged after peer PRs #3, #4, #5, #6 (the four branches above) land on `main`. The supervising agent should rebase `feat/app-shell` onto the post-merge `main` to drop the four `merge(shell): …` integration commits before squash-merging.

## Testing

- `pnpm lint` — prettier, eslint, svelte-check: clean.
- `pnpm test` — 11 test files, **64 tests** pass (new: `tests/viewport.test.ts` 8 tests, `tests/shortcut-parser.test.ts` 14 tests).
- `cargo fmt --check` — clean.
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo test` — 10 tests pass.

## Follow-ups (out of scope here)

- Space+drag pan gesture (state flag is wired; drag translation intentionally stubbed).
- Palette slot picker UI hints / visual confirmation on 1–9 shortcut use.
- Wheel-to-zoom anchored on cursor (currently centered).