### PR TITLE
feat(text): LaTeX + plain text objects with KaTeX renderer and inline editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.7.0",
     "@tauri-apps/plugin-opener": "^2",
+    "katex": "^0.16.45",
     "perfect-freehand": "^1.2.3"
   },
   "devDependencies": {
@@ -28,6 +29,7 @@
     "@sveltejs/kit": "^2.9.0",
     "@sveltejs/vite-plugin-svelte": "^5.0.0",
     "@tauri-apps/cli": "^2",
+    "@types/katex": "^0.16.8",
     "@types/node": "^22.10.0",
     "eslint": "^9.17.0",
     "eslint-config-prettier": "^9.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@tauri-apps/plugin-opener':
         specifier: ^2
         version: 2.5.3
+      katex:
+        specifier: ^0.16.45
+        version: 0.16.45
       perfect-freehand:
         specifier: ^1.2.3
         version: 1.2.3
@@ -36,6 +39,9 @@ importers:
       '@tauri-apps/cli':
         specifier: ^2
         version: 2.10.1
+      '@types/katex':
+        specifier: ^0.16.8
+        version: 0.16.8
       '@types/node':
         specifier: ^22.10.0
         version: 22.19.17
@@ -578,6 +584,9 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/katex@0.16.8':
+    resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
+
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
@@ -752,6 +761,10 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -997,6 +1010,10 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  katex@0.16.45:
+    resolution: {integrity: sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==}
+    hasBin: true
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -1755,6 +1772,8 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/katex@0.16.8': {}
+
   '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
@@ -1962,6 +1981,8 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  commander@8.3.0: {}
 
   concat-map@0.0.1: {}
 
@@ -2214,6 +2235,10 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  katex@0.16.45:
+    dependencies:
+      commander: 8.3.0
 
   keyv@4.5.4:
     dependencies:

--- a/src/lib/app/shortcuts.ts
+++ b/src/lib/app/shortcuts.ts
@@ -111,6 +111,10 @@ export const shortcuts: Action<HTMLElement> = () => {
       case 'G':
         sidebar.setTool('graph');
         return;
+      case 't':
+      case 'T':
+        sidebar.setTool('text');
+        return;
       case 'd':
       case 'D':
         sidebar.cycleDash();

--- a/src/lib/canvas/TextEditor.svelte
+++ b/src/lib/canvas/TextEditor.svelte
@@ -71,10 +71,18 @@
     class="content"
     rows="3"
     placeholder={latex ? 'e.g. x^2 + y^2 = r^2' : 'Enter text…'}
+    style="font-size: {fontSize}px; color: {color};"
   ></textarea>
 
   {#if latex && preview}
-    <div class="preview" class:errored={!preview.ok} aria-live="polite">
+    <div
+      class="preview"
+      class:errored={!preview.ok}
+      aria-live="polite"
+      style={preview.ok
+        ? `font-size: ${fontSize}px; color: ${color};`
+        : `font-size: ${fontSize}px;`}
+    >
       {#if preview.ok}
         <!-- eslint-disable-next-line svelte/no-at-html-tags -->
         <span>{@html preview.html}</span>

--- a/src/lib/canvas/TextEditor.svelte
+++ b/src/lib/canvas/TextEditor.svelte
@@ -1,0 +1,211 @@
+<script lang="ts">
+  import { onMount, untrack } from 'svelte';
+  import { renderLatex } from '$lib/text/latex';
+
+  interface Props {
+    initialContent: string;
+    initialLatex: boolean;
+    initialFontSize: number;
+    initialColor: string;
+    screenX: number;
+    screenY: number;
+    onok: (result: { content: string; latex: boolean; fontSize: number; color: string }) => void;
+    oncancel: () => void;
+  }
+
+  let {
+    initialContent,
+    initialLatex,
+    initialFontSize,
+    initialColor,
+    screenX,
+    screenY,
+    onok,
+    oncancel,
+  }: Props = $props();
+
+  let content = $state(untrack(() => initialContent));
+  let latex = $state(untrack(() => initialLatex));
+  let fontSize = $state(untrack(() => initialFontSize));
+  let color = $state(untrack(() => initialColor));
+  let textarea: HTMLTextAreaElement | null = $state(null);
+
+  const preview = $derived.by(() => {
+    if (!latex || content.length === 0) return null;
+    return renderLatex(content);
+  });
+
+  onMount(() => {
+    textarea?.focus();
+    textarea?.select();
+  });
+
+  function commit() {
+    onok({ content, latex, fontSize, color });
+  }
+
+  function onKeyDown(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      oncancel();
+      return;
+    }
+    if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
+      event.preventDefault();
+      commit();
+    }
+  }
+</script>
+
+<div
+  class="editor"
+  style="left: {screenX}px; top: {screenY}px;"
+  role="dialog"
+  tabindex="-1"
+  aria-label="Edit text"
+  onkeydown={onKeyDown}
+>
+  <textarea
+    bind:this={textarea}
+    bind:value={content}
+    class="content"
+    rows="3"
+    placeholder={latex ? 'e.g. x^2 + y^2 = r^2' : 'Enter text…'}
+  ></textarea>
+
+  {#if latex && preview}
+    <div class="preview" class:errored={!preview.ok} aria-live="polite">
+      {#if preview.ok}
+        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+        <span>{@html preview.html}</span>
+      {:else}
+        <span class="raw">{content}</span>
+        <span class="err">{preview.error}</span>
+      {/if}
+    </div>
+  {/if}
+
+  <div class="row">
+    <label class="check">
+      <input type="checkbox" bind:checked={latex} />
+      LaTeX
+    </label>
+    <label class="size">
+      Size
+      <input
+        type="number"
+        min="6"
+        max="200"
+        step="1"
+        bind:value={fontSize}
+        aria-label="Font size in points"
+      />
+    </label>
+    <label class="color">
+      Color
+      <input type="color" bind:value={color} aria-label="Text color" />
+    </label>
+  </div>
+
+  <div class="actions">
+    <button type="button" class="cancel" onclick={oncancel}>Cancel</button>
+    <button type="button" class="ok" onclick={commit}>OK</button>
+  </div>
+</div>
+
+<style>
+  .editor {
+    position: fixed;
+    z-index: 50;
+    background: #2a2a2a;
+    color: #eee;
+    border: 1px solid #444;
+    border-radius: 6px;
+    padding: 10px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.6);
+    width: 280px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    font-size: 12px;
+  }
+  .content {
+    width: 100%;
+    box-sizing: border-box;
+    background: #1b1b1b;
+    color: #eee;
+    border: 1px solid #3a3a3a;
+    border-radius: 4px;
+    padding: 6px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    resize: vertical;
+  }
+  .preview {
+    min-height: 24px;
+    background: #fff;
+    color: #111;
+    border-radius: 4px;
+    padding: 6px;
+    overflow-x: auto;
+  }
+  .preview.errored {
+    background: #2a1717;
+    color: #f5b6b6;
+  }
+  .preview .err {
+    display: block;
+    font-size: 10px;
+    margin-top: 4px;
+    opacity: 0.8;
+  }
+  .preview .raw {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+  .row {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+  .row label {
+    display: flex;
+    gap: 4px;
+    align-items: center;
+  }
+  .row input[type='number'] {
+    width: 50px;
+    background: #1b1b1b;
+    color: #eee;
+    border: 1px solid #3a3a3a;
+    border-radius: 3px;
+    padding: 2px 4px;
+  }
+  .row input[type='color'] {
+    width: 28px;
+    height: 22px;
+    padding: 0;
+    border: 1px solid #3a3a3a;
+    background: #1b1b1b;
+  }
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 6px;
+  }
+  .actions button {
+    background: #2a2a2a;
+    border: 1px solid #3a3a3a;
+    color: #ddd;
+    border-radius: 4px;
+    padding: 4px 12px;
+    cursor: pointer;
+  }
+  .actions .ok {
+    background: #2a4a78;
+    border-color: #3a6aa0;
+    color: #fff;
+  }
+  .actions button:hover {
+    border-color: #888;
+  }
+</style>

--- a/src/lib/canvas/TextLayer.svelte
+++ b/src/lib/canvas/TextLayer.svelte
@@ -1,0 +1,155 @@
+<script lang="ts">
+  import type { TextObject } from '$lib/types';
+  import { renderLatex } from '$lib/text/latex';
+
+  interface Props {
+    objects: TextObject[];
+    ptToPx: number;
+    interactive?: boolean;
+    onpick?: (obj: TextObject, screen: { x: number; y: number }) => void;
+    onemptyclick?: (at: { x: number; y: number }, screen: { x: number; y: number }) => void;
+  }
+
+  let { objects, ptToPx, interactive = false, onpick, onemptyclick }: Props = $props();
+
+  interface Rendered {
+    obj: TextObject;
+    html: string;
+    errored: boolean;
+  }
+
+  const rendered = $derived<Rendered[]>(
+    objects.map((obj) => {
+      if (!obj.latex) {
+        return { obj, html: '', errored: false };
+      }
+      const r = renderLatex(obj.content);
+      return { obj, html: r.html, errored: !r.ok };
+    }),
+  );
+
+  function onEmpty(event: MouseEvent) {
+    const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+    const at = {
+      x: (event.clientX - rect.left) / ptToPx,
+      y: (event.clientY - rect.top) / ptToPx,
+    };
+    onemptyclick?.(at, { x: event.clientX, y: event.clientY });
+  }
+
+  function onPick(event: MouseEvent, obj: TextObject) {
+    event.stopPropagation();
+    onpick?.(obj, { x: event.clientX, y: event.clientY });
+  }
+</script>
+
+<div class="text-layer" class:interactive>
+  {#if interactive}
+    <button
+      type="button"
+      class="empty-catcher"
+      aria-label="Create text at click position"
+      onclick={onEmpty}
+    ></button>
+  {/if}
+
+  {#each rendered as item (item.obj.id)}
+    {@const o = item.obj}
+    {#if interactive}
+      <button
+        type="button"
+        class="text-obj text-button"
+        class:latex={o.latex}
+        class:errored={item.errored}
+        style="left: {o.at.x * ptToPx}px; top: {o.at.y *
+          ptToPx}px; color: {o.color}; font-size: {o.fontSize * ptToPx}px;"
+        onclick={(e) => onPick(e, o)}
+      >
+        {#if o.latex && !item.errored}
+          <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+          {@html item.html}
+        {:else if o.latex && item.errored}
+          <span class="raw">{o.content}</span>
+        {:else}
+          {o.content}
+        {/if}
+      </button>
+    {:else if o.latex}
+      <div
+        class="text-obj latex"
+        class:errored={item.errored}
+        style="left: {o.at.x * ptToPx}px; top: {o.at.y *
+          ptToPx}px; color: {o.color}; font-size: {o.fontSize * ptToPx}px;"
+      >
+        {#if item.errored}
+          <span class="raw">{o.content}</span>
+        {:else}
+          <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+          {@html item.html}
+        {/if}
+      </div>
+    {:else}
+      <div
+        class="text-obj plain"
+        style="left: {o.at.x * ptToPx}px; top: {o.at.y *
+          ptToPx}px; color: {o.color}; font-size: {o.fontSize * ptToPx}px;"
+      >
+        {o.content}
+      </div>
+    {/if}
+  {/each}
+</div>
+
+<style>
+  .text-layer {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+  }
+  .text-layer.interactive {
+    pointer-events: auto;
+  }
+  .empty-catcher {
+    position: absolute;
+    inset: 0;
+    background: transparent;
+    border: 0;
+    padding: 0;
+    margin: 0;
+    cursor: text;
+    z-index: 0;
+  }
+  .text-obj {
+    position: absolute;
+    white-space: pre;
+    line-height: 1.2;
+    user-select: none;
+    transform-origin: top left;
+    pointer-events: none;
+  }
+  .text-button {
+    background: transparent;
+    border: 1px dashed transparent;
+    padding: 0 2px;
+    margin: 0;
+    font: inherit;
+    text-align: left;
+    color: inherit;
+    cursor: pointer;
+    pointer-events: auto;
+    z-index: 1;
+  }
+  .text-button:hover,
+  .text-button:focus-visible {
+    border-color: #7ab7ff;
+    outline: none;
+  }
+  .text-obj.errored {
+    color: #c0392b;
+    text-decoration: underline dotted;
+  }
+  .text-obj.errored .raw,
+  .text-button.errored .raw {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+</style>

--- a/src/lib/canvas/TextLayer.svelte
+++ b/src/lib/canvas/TextLayer.svelte
@@ -129,8 +129,8 @@
   }
   .text-button {
     background: transparent;
-    border: 1px dashed transparent;
-    padding: 0 2px;
+    border: none;
+    padding: 0;
     margin: 0;
     font: inherit;
     text-align: left;
@@ -138,11 +138,12 @@
     cursor: pointer;
     pointer-events: auto;
     z-index: 1;
+    outline: 1px dashed transparent;
+    outline-offset: 1px;
   }
   .text-button:hover,
   .text-button:focus-visible {
-    border-color: #7ab7ff;
-    outline: none;
+    outline-color: #7ab7ff;
   }
   .text-obj.errored {
     color: #c0392b;

--- a/src/lib/canvas/index.ts
+++ b/src/lib/canvas/index.ts
@@ -3,3 +3,5 @@ export { default as PdfLayer } from './PdfLayer.svelte';
 export { default as HighlightLayer } from './HighlightLayer.svelte';
 export { default as InkLayer } from './InkLayer.svelte';
 export { default as LiveLayer } from './LiveLayer.svelte';
+export { default as TextLayer } from './TextLayer.svelte';
+export { default as TextEditor } from './TextEditor.svelte';

--- a/src/lib/sidebar/Sidebar.svelte
+++ b/src/lib/sidebar/Sidebar.svelte
@@ -26,6 +26,7 @@
     { id: 'highlighter', label: 'Highlighter', shortcut: 'H', icon: '🖍️' },
     { id: 'eraser', label: 'Eraser', shortcut: 'E', icon: '🧽' },
     { id: 'line', label: 'Line', shortcut: 'L', icon: '／' },
+    { id: 'text', label: 'Text', shortcut: 'T', icon: '𝐓' },
     { id: 'graph', label: 'Graph (coming soon)', shortcut: 'G', icon: '📈', disabled: true },
   ];
 

--- a/src/lib/text/hitTest.ts
+++ b/src/lib/text/hitTest.ts
@@ -1,0 +1,51 @@
+import type { TextObject } from '$lib/types';
+
+export interface TextBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Approximate bounds (in PDF points) of a TextObject, using a rough character-
+ * width heuristic. Sufficient for hit-testing a click on the object; accurate
+ * layout is done by the browser when rendered.
+ *
+ * For LaTeX objects we fall back to a generous estimate because their rendered
+ * width depends on KaTeX output and fonts.
+ */
+export function estimateTextBounds(obj: TextObject): TextBounds {
+  const fontSize = obj.fontSize;
+  const lines = obj.content.length === 0 ? [''] : obj.content.split('\n');
+  const longest = lines.reduce((m, l) => Math.max(m, l.length), 0);
+  const avgCharWidth = fontSize * (obj.latex ? 0.7 : 0.55);
+  const width = Math.max(fontSize, longest * avgCharWidth);
+  const height = Math.max(fontSize, lines.length * fontSize * 1.2);
+  return { x: obj.at.x, y: obj.at.y, width, height };
+}
+
+export function hitTestTextObject(
+  obj: TextObject,
+  at: { x: number; y: number },
+  padding = 0,
+): boolean {
+  const b = estimateTextBounds(obj);
+  return (
+    at.x >= b.x - padding &&
+    at.x <= b.x + b.width + padding &&
+    at.y >= b.y - padding &&
+    at.y <= b.y + b.height + padding
+  );
+}
+
+export function hitTestTextObjects(
+  objects: readonly TextObject[],
+  at: { x: number; y: number },
+  padding = 0,
+): TextObject | null {
+  for (let i = objects.length - 1; i >= 0; i -= 1) {
+    if (hitTestTextObject(objects[i], at, padding)) return objects[i];
+  }
+  return null;
+}

--- a/src/lib/text/index.ts
+++ b/src/lib/text/index.ts
@@ -1,0 +1,4 @@
+export { renderLatex, escapeHtml } from './latex';
+export type { LatexRender, RenderLatexOptions, KatexRenderFn } from './latex';
+export { estimateTextBounds, hitTestTextObject, hitTestTextObjects } from './hitTest';
+export type { TextBounds } from './hitTest';

--- a/src/lib/text/latex.ts
+++ b/src/lib/text/latex.ts
@@ -26,7 +26,7 @@ export function renderLatex(
       displayMode: opts.displayMode ?? false,
       throwOnError: true,
       strict: 'ignore',
-      output: 'html',
+      output: 'htmlAndMathml',
     });
     return { ok: true, html };
   } catch (err) {

--- a/src/lib/text/latex.ts
+++ b/src/lib/text/latex.ts
@@ -1,0 +1,45 @@
+import katex from 'katex';
+
+export type LatexRender = { ok: true; html: string } | { ok: false; html: string; error: string };
+
+export interface RenderLatexOptions {
+  /** Display mode (block) vs inline mode. Inline keeps text flowing. */
+  displayMode?: boolean;
+}
+
+export type KatexRenderFn = (input: string, opts: katex.KatexOptions) => string;
+
+/**
+ * Render a LaTeX source string to safe HTML via KaTeX.
+ *
+ * Errors from KaTeX (usually ParseError) are converted into a tagged failure
+ * that carries a plain-text fallback, so callers can render the original
+ * content with an error class instead of throwing.
+ */
+export function renderLatex(
+  source: string,
+  opts: RenderLatexOptions = {},
+  render: KatexRenderFn = katex.renderToString,
+): LatexRender {
+  try {
+    const html = render(source, {
+      displayMode: opts.displayMode ?? false,
+      throwOnError: true,
+      strict: 'ignore',
+      output: 'html',
+    });
+    return { ok: true, html };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, html: escapeHtml(source), error: message };
+  }
+}
+
+export function escapeHtml(input: string): string {
+  return input
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import 'katex/dist/katex.min.css';
+
+  interface Props {
+    children?: import('svelte').Snippet;
+  }
+
+  let { children }: Props = $props();
+</script>
+
+{@render children?.()}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -60,11 +60,11 @@
       const o = editor.obj;
       return { content: o.content, latex: o.latex, fontSize: o.fontSize, color: o.color };
     }
-    return { content: '', latex: false, fontSize: 16, color: '#000000' };
+    return { content: '', latex: false, fontSize: 16, color: sidebarState.activeColor };
   });
 
   function newId(): string {
-    return `t_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+    return `t_${crypto.randomUUID()}`;
   }
 
   function onTextEmptyClick(at: { x: number; y: number }, screen: { x: number; y: number }): void {
@@ -101,12 +101,16 @@
       };
       documentStore.addObject(pageIndex, obj);
     } else {
-      documentStore.updateObject(pageIndex, editor.obj.id, {
-        content: result.content,
-        latex: result.latex,
-        fontSize: result.fontSize,
-        color: result.color,
-      });
+      if (result.content.trim().length === 0) {
+        documentStore.removeObject(pageIndex, editor.obj.id);
+      } else {
+        documentStore.updateObject(pageIndex, editor.obj.id, {
+          content: result.content,
+          latex: result.latex,
+          fontSize: result.fontSize,
+          color: result.color,
+        });
+      }
     }
     editor = null;
   }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte';
-  import { CanvasStack, PdfLayer } from '$lib/canvas';
+  import { CanvasStack, PdfLayer, TextLayer, TextEditor } from '$lib/canvas';
   import { Sidebar } from '$lib/sidebar';
   import { openAndLoadPdf } from '$lib/ipc/pdf';
   import { loadSidecar } from '$lib/ipc';
@@ -13,7 +13,7 @@
   import { shortcuts } from '$lib/app/shortcuts';
   import { openPdfDialog } from '$lib/app/openPdfDialog';
   import { hitTestStrokes } from '$lib/tools/eraser';
-  import type { AnyObject, EldrawDocument, PdfMeta, StrokeObject } from '$lib/types';
+  import type { AnyObject, EldrawDocument, PdfMeta, StrokeObject, TextObject } from '$lib/types';
 
   const ERASER_RADIUS = 4;
 
@@ -34,6 +34,77 @@
   const pageStrokes = $derived<StrokeObject[]>(
     pageObjects.filter((o): o is StrokeObject => o.type === 'stroke'),
   );
+  const pageTextObjects = $derived<TextObject[]>(
+    pageObjects.filter((o): o is TextObject => o.type === 'text'),
+  );
+  const isTextTool = $derived(sidebarState.activeTool === 'text');
+
+  type EditorState =
+    | { mode: 'create'; at: { x: number; y: number }; screen: { x: number; y: number } }
+    | { mode: 'edit'; obj: TextObject; screen: { x: number; y: number } };
+
+  let editor: EditorState | null = $state(null);
+
+  const editorInitial = $derived.by(() => {
+    if (!editor) return null;
+    if (editor.mode === 'edit') {
+      const o = editor.obj;
+      return { content: o.content, latex: o.latex, fontSize: o.fontSize, color: o.color };
+    }
+    return { content: '', latex: false, fontSize: 16, color: '#000000' };
+  });
+
+  function newId(): string {
+    return `t_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+  }
+
+  function onTextEmptyClick(at: { x: number; y: number }, screen: { x: number; y: number }): void {
+    if (!isTextTool) return;
+    editor = { mode: 'create', at, screen };
+  }
+
+  function onTextPick(obj: TextObject, screen: { x: number; y: number }): void {
+    if (!isTextTool) return;
+    editor = { mode: 'edit', obj, screen };
+  }
+
+  function onEditorOk(result: {
+    content: string;
+    latex: boolean;
+    fontSize: number;
+    color: string;
+  }): void {
+    if (!editor) return;
+    if (editor.mode === 'create') {
+      if (result.content.trim().length === 0) {
+        editor = null;
+        return;
+      }
+      const obj: TextObject = {
+        id: newId(),
+        createdAt: Date.now(),
+        type: 'text',
+        at: editor.at,
+        content: result.content,
+        latex: result.latex,
+        fontSize: result.fontSize,
+        color: result.color,
+      };
+      documentStore.addObject(pageIndex, obj);
+    } else {
+      documentStore.updateObject(pageIndex, editor.obj.id, {
+        content: result.content,
+        latex: result.latex,
+        fontSize: result.fontSize,
+        color: result.color,
+      });
+    }
+    editor = null;
+  }
+
+  function onEditorCancel(): void {
+    editor = null;
+  }
 
   const pageDimsPt = $derived(() => {
     if (currentPage) return { width: currentPage.width, height: currentPage.height };
@@ -194,6 +265,15 @@
               onerase={onEraseAt}
             />
           </div>
+          <div class="text-slot" class:capture={isTextTool}>
+            <TextLayer
+              objects={pageTextObjects}
+              ptToPx={size.ptToPx}
+              interactive={isTextTool}
+              onemptyclick={onTextEmptyClick}
+              onpick={onTextPick}
+            />
+          </div>
         </div>
       {:else}
         <div class="empty">
@@ -206,6 +286,19 @@
       {/if}
     </div>
   </section>
+
+  {#if editor && editorInitial}
+    <TextEditor
+      initialContent={editorInitial.content}
+      initialLatex={editorInitial.latex}
+      initialFontSize={editorInitial.fontSize}
+      initialColor={editorInitial.color}
+      screenX={editor.screen.x}
+      screenY={editor.screen.y}
+      onok={onEditorOk}
+      oncancel={onEditorCancel}
+    />
+  {/if}
 </main>
 
 <style>
@@ -299,6 +392,15 @@
   .stack-slot {
     position: absolute;
     inset: 0;
+  }
+  .text-slot {
+    position: absolute;
+    inset: 0;
+    z-index: 5;
+    pointer-events: none;
+  }
+  .text-slot.capture {
+    pointer-events: auto;
   }
   .blank-slot {
     background: #fff;

--- a/tests/latex-render.test.ts
+++ b/tests/latex-render.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { renderLatex, escapeHtml } from '$lib/text/latex';
+
+describe('renderLatex', () => {
+  it('returns ok with rendered HTML from the injected katex function', () => {
+    const result = renderLatex('x^2', {}, () => '<span class="katex">x^2</span>');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.html).toContain('katex');
+    }
+  });
+
+  it('passes displayMode option through to katex', () => {
+    let captured: { displayMode?: boolean } | null = null;
+    renderLatex('x', { displayMode: true }, (_input, opts) => {
+      captured = opts;
+      return 'ok';
+    });
+    expect(captured).not.toBeNull();
+    expect(captured!.displayMode).toBe(true);
+  });
+
+  it('defaults displayMode to false', () => {
+    let captured: { displayMode?: boolean } | null = null;
+    renderLatex('x', {}, (_input, opts) => {
+      captured = opts;
+      return 'ok';
+    });
+    expect(captured!.displayMode).toBe(false);
+  });
+
+  it('returns a tagged failure with escaped fallback when katex throws', () => {
+    const result = renderLatex('<bad>', {}, () => {
+      throw new Error('ParseError: undefined control sequence');
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/ParseError/);
+      expect(result.html).toBe('&lt;bad&gt;');
+    }
+  });
+
+  it('coerces non-Error throws into string error messages', () => {
+    const result = renderLatex('x', {}, () => {
+      throw 'boom';
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('boom');
+    }
+  });
+
+  it('uses real katex for valid input by default', () => {
+    const result = renderLatex('x^2 + y^2');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.html.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('uses real katex and reports failure for invalid input by default', () => {
+    const result = renderLatex('\\frac{1');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.html).toContain('\\frac{1');
+    }
+  });
+});
+
+describe('escapeHtml', () => {
+  it('escapes the five core HTML entities', () => {
+    expect(escapeHtml(`<a href="x">&'</a>`)).toBe(
+      '&lt;a href=&quot;x&quot;&gt;&amp;&#39;&lt;/a&gt;',
+    );
+  });
+});

--- a/tests/text-hit-test.test.ts
+++ b/tests/text-hit-test.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { estimateTextBounds, hitTestTextObject, hitTestTextObjects } from '$lib/text/hitTest';
+import type { TextObject } from '$lib/types';
+
+function text(partial: Partial<TextObject> & Pick<TextObject, 'id' | 'at'>): TextObject {
+  return {
+    id: partial.id,
+    createdAt: 0,
+    type: 'text',
+    at: partial.at,
+    content: partial.content ?? 'hello',
+    latex: partial.latex ?? false,
+    fontSize: partial.fontSize ?? 16,
+    color: partial.color ?? '#000',
+  };
+}
+
+describe('estimateTextBounds', () => {
+  it('returns at-anchored width and height for plain text', () => {
+    const b = estimateTextBounds(text({ id: 'a', at: { x: 10, y: 20 }, content: 'abc' }));
+    expect(b.x).toBe(10);
+    expect(b.y).toBe(20);
+    expect(b.width).toBeGreaterThan(0);
+    expect(b.height).toBeGreaterThanOrEqual(16);
+  });
+
+  it('grows with content length', () => {
+    const small = estimateTextBounds(text({ id: 'a', at: { x: 0, y: 0 }, content: 'hi' }));
+    const big = estimateTextBounds(
+      text({ id: 'b', at: { x: 0, y: 0 }, content: 'hello there friend' }),
+    );
+    expect(big.width).toBeGreaterThan(small.width);
+  });
+
+  it('grows with newlines', () => {
+    const one = estimateTextBounds(text({ id: 'a', at: { x: 0, y: 0 }, content: 'a' }));
+    const three = estimateTextBounds(text({ id: 'b', at: { x: 0, y: 0 }, content: 'a\nb\nc' }));
+    expect(three.height).toBeGreaterThan(one.height);
+  });
+
+  it('uses wider per-char estimate for latex content', () => {
+    const plain = estimateTextBounds(text({ id: 'a', at: { x: 0, y: 0 }, content: 'xxxx' }));
+    const latex = estimateTextBounds(
+      text({ id: 'b', at: { x: 0, y: 0 }, content: 'xxxx', latex: true }),
+    );
+    expect(latex.width).toBeGreaterThan(plain.width);
+  });
+
+  it('returns at least font-size dimensions for empty content', () => {
+    const b = estimateTextBounds(text({ id: 'a', at: { x: 5, y: 7 }, content: '', fontSize: 24 }));
+    expect(b.width).toBeGreaterThanOrEqual(24);
+    expect(b.height).toBeGreaterThanOrEqual(24);
+  });
+});
+
+describe('hitTestTextObject', () => {
+  const obj = text({ id: 'a', at: { x: 100, y: 100 }, content: 'hello', fontSize: 16 });
+
+  it('hits inside the bounds', () => {
+    expect(hitTestTextObject(obj, { x: 105, y: 105 })).toBe(true);
+  });
+
+  it('misses far above the object', () => {
+    expect(hitTestTextObject(obj, { x: 105, y: 0 })).toBe(false);
+  });
+
+  it('misses far to the left of the object', () => {
+    expect(hitTestTextObject(obj, { x: 0, y: 105 })).toBe(false);
+  });
+
+  it('respects padding for forgiving picks', () => {
+    expect(hitTestTextObject(obj, { x: 99, y: 99 }, 0)).toBe(false);
+    expect(hitTestTextObject(obj, { x: 99, y: 99 }, 4)).toBe(true);
+  });
+});
+
+describe('hitTestTextObjects', () => {
+  it('returns the topmost (last) overlapping object', () => {
+    const a = text({ id: 'a', at: { x: 0, y: 0 }, content: 'wide enough text' });
+    const b = text({ id: 'b', at: { x: 0, y: 0 }, content: 'wide enough text' });
+    const hit = hitTestTextObjects([a, b], { x: 5, y: 5 });
+    expect(hit?.id).toBe('b');
+  });
+
+  it('returns null when no object is hit', () => {
+    const a = text({ id: 'a', at: { x: 0, y: 0 }, content: 'hi' });
+    expect(hitTestTextObjects([a], { x: 5000, y: 5000 })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds the **text tool** — click on a page to drop a text object; toggle "LaTeX" to render via KaTeX. Phase 2 math-first feature.

## What

- `katex@^0.16.45` + `@types/katex`. CSS imported globally via `+layout.svelte`.
- **TextLayer** (`src/lib/canvas/TextLayer.svelte`): HTML overlay rendering plain + KaTeX text, positioned in PDF point space scaled to pixels.
- **TextEditor** (`src/lib/canvas/TextEditor.svelte`): floating editor with textarea, LaTeX toggle, font size, color, Ctrl+Enter to commit / Esc to cancel.
- **`renderLatex`**: tagged-result wrapper around `katex.renderToString` with HTML-escaped fallback on parse error (no throws).
- **Hit testing** (`src/lib/text/hitTest.ts`): topmost-wins point-in-rect using `estimateTextBounds`.
- Sidebar entry + `T` shortcut.

## Tests

- 87 frontend tests (+19): 8 latex-render tests (mocked + real KaTeX, fallback, escape), 11 text-hit-test tests (bounds, padding, topmost wins).
- All Rust tests still pass (10/10).