### PR TITLE
feat(shapes): line, rect, ellipse, and number line objects

### DIFF
--- a/src/lib/app/shortcuts.ts
+++ b/src/lib/app/shortcuts.ts
@@ -107,6 +107,18 @@ export const shortcuts: Action<HTMLElement> = () => {
       case 'L':
         sidebar.setTool('line');
         return;
+      case 'r':
+      case 'R':
+        sidebar.setTool('rect');
+        return;
+      case 'o':
+      case 'O':
+        sidebar.setTool('ellipse');
+        return;
+      case 'n':
+      case 'N':
+        sidebar.setTool('numberline');
+        return;
       case 'g':
       case 'G':
         sidebar.setTool('graph');

--- a/src/lib/canvas/CanvasStack.svelte
+++ b/src/lib/canvas/CanvasStack.svelte
@@ -1,21 +1,41 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
-  import type { StrokeObject } from '$lib/types';
+  import type {
+    AnyObject,
+    LineObject,
+    NumberLineObject,
+    ShapeObject,
+    StrokeObject,
+  } from '$lib/types';
   import HighlightLayer from './HighlightLayer.svelte';
   import InkLayer from './InkLayer.svelte';
   import LiveLayer from './LiveLayer.svelte';
+  import ShapeLayer from './ShapeLayer.svelte';
+  import ShapeLiveLayer from './ShapeLiveLayer.svelte';
 
   interface Props {
     strokes: StrokeObject[];
+    objects: AnyObject[];
     width: number;
     height: number;
     ptToPx: number;
-    objects?: Snippet;
+    overlay?: Snippet;
     oncommit?: (stroke: StrokeObject) => void;
     onerase?: (at: { x: number; y: number }) => void;
+    oncommitobject?: (obj: LineObject | ShapeObject | NumberLineObject) => void;
   }
 
-  let { strokes, width, height, ptToPx, objects, oncommit, onerase }: Props = $props();
+  let {
+    strokes,
+    objects,
+    width,
+    height,
+    ptToPx,
+    overlay,
+    oncommit,
+    onerase,
+    oncommitobject,
+  }: Props = $props();
 </script>
 
 <div class="stack" style="width: {width}px; height: {height}px;">
@@ -23,11 +43,9 @@
     <HighlightLayer {strokes} {width} {height} {ptToPx} />
   </div>
 
-  {#if objects}
-    <div class="layer layer-objects">
-      {@render objects()}
-    </div>
-  {/if}
+  <div class="layer layer-objects">
+    <ShapeLayer {objects} {width} {height} {ptToPx} />
+  </div>
 
   <div class="layer layer-ink">
     <InkLayer {strokes} {width} {height} {ptToPx} />
@@ -36,6 +54,16 @@
   <div class="layer layer-live">
     <LiveLayer {width} {height} {ptToPx} {oncommit} {onerase} />
   </div>
+
+  <div class="layer layer-shape-live">
+    <ShapeLiveLayer {width} {height} {ptToPx} oncommit={oncommitobject} />
+  </div>
+
+  {#if overlay}
+    <div class="layer layer-overlay">
+      {@render overlay()}
+    </div>
+  {/if}
 </div>
 
 <style>
@@ -55,8 +83,16 @@
   }
   .layer-ink {
     z-index: 3;
+    pointer-events: none;
   }
   .layer-live {
     z-index: 4;
+  }
+  .layer-shape-live {
+    z-index: 5;
+  }
+  .layer-overlay {
+    z-index: 6;
+    pointer-events: none;
   }
 </style>

--- a/src/lib/canvas/NumberLineEditor.svelte
+++ b/src/lib/canvas/NumberLineEditor.svelte
@@ -1,0 +1,186 @@
+<script lang="ts">
+  import type { NumberLineMarkKind, NumberLineObject } from '$lib/types';
+
+  interface Props {
+    nl: NumberLineObject;
+    ptToPx: number;
+    onchange?: (patch: Partial<NumberLineObject>) => void;
+    onclose?: () => void;
+  }
+
+  let { nl, ptToPx, onchange, onclose }: Props = $props();
+
+  let newMarkValue = $state(0);
+  let newMarkKind: NumberLineMarkKind = $state('closed');
+
+  const left = $derived(nl.from.x * ptToPx);
+  const top = $derived(nl.from.y * ptToPx + 28);
+
+  function setField<K extends 'min' | 'max' | 'tickStep' | 'labelStep'>(key: K, value: number) {
+    if (!Number.isFinite(value)) return;
+    onchange?.({ [key]: value } as Partial<NumberLineObject>);
+  }
+
+  function addMark() {
+    onchange?.({ marks: [...nl.marks, { value: newMarkValue, kind: newMarkKind }] });
+  }
+
+  function removeMark(idx: number) {
+    onchange?.({ marks: nl.marks.filter((_, i) => i !== idx) });
+  }
+</script>
+
+<div class="editor" style="left: {left}px; top: {top}px;">
+  <div class="row">
+    <label
+      >min<input
+        type="number"
+        value={nl.min}
+        oninput={(e) => setField('min', Number(e.currentTarget.value))}
+      /></label
+    >
+    <label
+      >max<input
+        type="number"
+        value={nl.max}
+        oninput={(e) => setField('max', Number(e.currentTarget.value))}
+      /></label
+    >
+  </div>
+  <div class="row">
+    <label
+      >tick<input
+        type="number"
+        min="0"
+        step="0.1"
+        value={nl.tickStep}
+        oninput={(e) => setField('tickStep', Number(e.currentTarget.value))}
+      /></label
+    >
+    <label
+      >label<input
+        type="number"
+        min="0"
+        step="0.1"
+        value={nl.labelStep}
+        oninput={(e) => setField('labelStep', Number(e.currentTarget.value))}
+      /></label
+    >
+  </div>
+  <div class="marks">
+    <span class="head">Marks</span>
+    {#each nl.marks as m, i (i)}
+      <div class="mark-row">
+        <span>{m.value}</span>
+        <span class="kind">{m.kind}</span>
+        <button type="button" onclick={() => removeMark(i)} aria-label="Remove mark">×</button>
+      </div>
+    {/each}
+    <div class="add-row">
+      <input type="number" bind:value={newMarkValue} aria-label="Mark value" step="0.1" />
+      <select bind:value={newMarkKind} aria-label="Mark kind">
+        <option value="closed">closed</option>
+        <option value="open">open</option>
+        <option value="arrow-left">arrow ←</option>
+        <option value="arrow-right">arrow →</option>
+      </select>
+      <button type="button" onclick={addMark}>Add</button>
+    </div>
+  </div>
+  <div class="foot">
+    <button type="button" onclick={() => onclose?.()}>Done</button>
+  </div>
+</div>
+
+<style>
+  .editor {
+    position: absolute;
+    background: #2a2a2a;
+    border: 1px solid #444;
+    border-radius: 6px;
+    padding: 8px;
+    color: #eee;
+    font-size: 12px;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.5);
+    pointer-events: auto;
+    min-width: 220px;
+    z-index: 10;
+  }
+  .row {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 6px;
+  }
+  label {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    font-size: 10px;
+    color: #aaa;
+  }
+  input,
+  select {
+    background: #1c1c1c;
+    color: #eee;
+    border: 1px solid #444;
+    border-radius: 3px;
+    padding: 2px 4px;
+    width: 100%;
+    box-sizing: border-box;
+  }
+  .marks {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    border-top: 1px solid #333;
+    padding-top: 6px;
+  }
+  .head {
+    font-size: 10px;
+    color: #aaa;
+    text-transform: uppercase;
+  }
+  .mark-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .mark-row .kind {
+    color: #aaa;
+    font-size: 11px;
+    flex: 1;
+  }
+  .mark-row button {
+    background: transparent;
+    border: 1px solid #555;
+    color: #eee;
+    border-radius: 3px;
+    cursor: pointer;
+    padding: 0 6px;
+  }
+  .add-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr auto;
+    gap: 4px;
+  }
+  .add-row button {
+    background: #2f4a6e;
+    border: 1px solid #4a6a90;
+    color: #fff;
+    border-radius: 3px;
+    cursor: pointer;
+    padding: 2px 8px;
+  }
+  .foot {
+    margin-top: 6px;
+    text-align: right;
+  }
+  .foot button {
+    background: #1b1b1b;
+    border: 1px solid #444;
+    color: #eee;
+    padding: 2px 10px;
+    border-radius: 3px;
+    cursor: pointer;
+  }
+</style>

--- a/src/lib/canvas/ShapeLayer.svelte
+++ b/src/lib/canvas/ShapeLayer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import type { AnyObject, LineObject, NumberLineObject, ShapeObject } from '$lib/types';
+  import type { AnyObject } from '$lib/types';
   import { drawLine, drawNumberLine, drawShape } from './objectRenderer';
 
   interface Props {
@@ -20,9 +20,9 @@
     if (!ctx) return;
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     for (const o of objects) {
-      if (o.type === 'line') drawLine(ctx, o as LineObject, ptToPx);
-      else if (o.type === 'shape') drawShape(ctx, o as ShapeObject, ptToPx);
-      else if (o.type === 'numberline') drawNumberLine(ctx, o as NumberLineObject, ptToPx);
+      if (o.type === 'line') drawLine(ctx, o, ptToPx);
+      else if (o.type === 'shape') drawShape(ctx, o, ptToPx);
+      else if (o.type === 'numberline') drawNumberLine(ctx, o, ptToPx);
     }
   }
 

--- a/src/lib/canvas/ShapeLayer.svelte
+++ b/src/lib/canvas/ShapeLayer.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import type { AnyObject, LineObject, NumberLineObject, ShapeObject } from '$lib/types';
+  import { drawLine, drawNumberLine, drawShape } from './objectRenderer';
+
+  interface Props {
+    objects: AnyObject[];
+    width: number;
+    height: number;
+    ptToPx: number;
+  }
+
+  let { objects, width, height, ptToPx }: Props = $props();
+
+  let canvas: HTMLCanvasElement;
+
+  function redraw() {
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    for (const o of objects) {
+      if (o.type === 'line') drawLine(ctx, o as LineObject, ptToPx);
+      else if (o.type === 'shape') drawShape(ctx, o as ShapeObject, ptToPx);
+      else if (o.type === 'numberline') drawNumberLine(ctx, o as NumberLineObject, ptToPx);
+    }
+  }
+
+  onMount(redraw);
+
+  $effect(() => {
+    void objects;
+    void width;
+    void height;
+    void ptToPx;
+    redraw();
+  });
+</script>
+
+<canvas
+  bind:this={canvas}
+  {width}
+  {height}
+  class="shape-layer"
+  style="width: {width}px; height: {height}px;"
+></canvas>
+
+<style>
+  .shape-layer {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+  }
+</style>

--- a/src/lib/canvas/ShapeLiveLayer.svelte
+++ b/src/lib/canvas/ShapeLiveLayer.svelte
@@ -115,11 +115,7 @@
   function commit(): void {
     const obj = previewObject();
     if (!obj) return;
-    const id = (
-      typeof crypto !== 'undefined' && 'randomUUID' in crypto
-        ? crypto.randomUUID()
-        : `obj-${Date.now()}-${Math.random().toString(36).slice(2)}`
-    ) as string;
+    const id = crypto.randomUUID();
     if (obj.type === 'shape' && (obj.bounds.w < 1 || obj.bounds.h < 1)) return;
     if (obj.type === 'line') {
       const dx = obj.to.x - obj.from.x;

--- a/src/lib/canvas/ShapeLiveLayer.svelte
+++ b/src/lib/canvas/ShapeLiveLayer.svelte
@@ -1,0 +1,195 @@
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+  import type {
+    LineObject,
+    NumberLineObject,
+    ShapeObject,
+    StrokeStyle,
+    ToolKind,
+  } from '$lib/types';
+  import { toolStore } from '$lib/store/tool';
+  import { currentStyle } from '$lib/store/sidebar';
+  import { normalizeBounds } from '$lib/tools/shapes';
+  import { drawLine, drawNumberLine, drawShape } from './objectRenderer';
+
+  interface Props {
+    width: number;
+    height: number;
+    ptToPx: number;
+    oncommit?: (obj: LineObject | ShapeObject | NumberLineObject) => void;
+  }
+
+  let { width, height, ptToPx, oncommit }: Props = $props();
+
+  type DragKind = 'line' | 'rect' | 'ellipse' | 'numberline';
+  function isDragKind(t: ToolKind): t is DragKind {
+    return t === 'line' || t === 'rect' || t === 'ellipse' || t === 'numberline';
+  }
+
+  let canvas: HTMLCanvasElement;
+  let activePointerId: number | null = null;
+  let start = { x: 0, y: 0 };
+  let end = { x: 0, y: 0 };
+  let currentTool: ToolKind = 'pen';
+  let style: StrokeStyle = { color: '#000', width: 2, dash: 'solid', opacity: 1 };
+
+  const unsubTool = toolStore.subscribe((s) => {
+    currentTool = s.tool;
+  });
+  const unsubStyle = currentStyle.subscribe((s) => {
+    style = s;
+  });
+  onDestroy(() => {
+    unsubTool();
+    unsubStyle();
+  });
+
+  const isActive = $derived(isDragKind(currentTool));
+
+  function ctx(): CanvasRenderingContext2D | null {
+    return canvas?.getContext('2d') ?? null;
+  }
+
+  function clear() {
+    const c = ctx();
+    if (!c) return;
+    c.clearRect(0, 0, canvas.width, canvas.height);
+  }
+
+  function toPagePoint(e: PointerEvent): { x: number; y: number } {
+    const rect = canvas.getBoundingClientRect();
+    return { x: (e.clientX - rect.left) / ptToPx, y: (e.clientY - rect.top) / ptToPx };
+  }
+
+  function previewObject(): LineObject | ShapeObject | NumberLineObject | null {
+    if (!isDragKind(currentTool)) return null;
+    if (currentTool === 'line') {
+      return {
+        id: 'preview',
+        createdAt: 0,
+        type: 'line',
+        style,
+        from: { ...start },
+        to: { ...end },
+        arrow: { start: false, end: false },
+      };
+    }
+    if (currentTool === 'numberline') {
+      const length = end.x - start.x;
+      return {
+        id: 'preview',
+        createdAt: 0,
+        type: 'numberline',
+        style,
+        from: { x: Math.min(start.x, end.x), y: start.y },
+        length: Math.abs(length),
+        min: -5,
+        max: 5,
+        tickStep: 1,
+        labelStep: 1,
+        marks: [],
+      };
+    }
+    return {
+      id: 'preview',
+      createdAt: 0,
+      type: 'shape',
+      kind: currentTool,
+      style,
+      fill: null,
+      bounds: normalizeBounds(start, end),
+    };
+  }
+
+  function redraw() {
+    const c = ctx();
+    if (!c) return;
+    clear();
+    const obj = previewObject();
+    if (!obj) return;
+    if (obj.type === 'line') drawLine(c, obj, ptToPx);
+    else if (obj.type === 'shape') drawShape(c, obj, ptToPx);
+    else drawNumberLine(c, obj, ptToPx);
+  }
+
+  function commit(): void {
+    const obj = previewObject();
+    if (!obj) return;
+    const id = (
+      typeof crypto !== 'undefined' && 'randomUUID' in crypto
+        ? crypto.randomUUID()
+        : `obj-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    ) as string;
+    if (obj.type === 'shape' && (obj.bounds.w < 1 || obj.bounds.h < 1)) return;
+    if (obj.type === 'line') {
+      const dx = obj.to.x - obj.from.x;
+      const dy = obj.to.y - obj.from.y;
+      if (Math.hypot(dx, dy) < 1) return;
+    }
+    if (obj.type === 'numberline' && obj.length < 4) return;
+    oncommit?.({ ...obj, id, createdAt: Date.now() });
+  }
+
+  function onPointerDown(e: PointerEvent) {
+    if (!isActive) return;
+    if (e.pointerType === 'touch') return;
+    canvas.setPointerCapture(e.pointerId);
+    activePointerId = e.pointerId;
+    start = toPagePoint(e);
+    end = { ...start };
+    redraw();
+    e.preventDefault();
+  }
+
+  function onPointerMove(e: PointerEvent) {
+    if (activePointerId !== e.pointerId) return;
+    end = toPagePoint(e);
+    redraw();
+    e.preventDefault();
+  }
+
+  function finish(e: PointerEvent, doCommit: boolean) {
+    if (activePointerId !== e.pointerId) return;
+    try {
+      canvas.releasePointerCapture(e.pointerId);
+    } catch {
+      // not captured
+    }
+    activePointerId = null;
+    if (doCommit) commit();
+    clear();
+  }
+
+  function onPointerUp(e: PointerEvent) {
+    finish(e, true);
+  }
+
+  function onPointerCancel(e: PointerEvent) {
+    finish(e, false);
+  }
+</script>
+
+<canvas
+  bind:this={canvas}
+  {width}
+  {height}
+  class="shape-live"
+  class:inactive={!isActive}
+  style="width: {width}px; height: {height}px;"
+  onpointerdown={onPointerDown}
+  onpointermove={onPointerMove}
+  onpointerup={onPointerUp}
+  onpointercancel={onPointerCancel}
+></canvas>
+
+<style>
+  .shape-live {
+    position: absolute;
+    inset: 0;
+    touch-action: none;
+    cursor: crosshair;
+  }
+  .shape-live.inactive {
+    pointer-events: none;
+  }
+</style>

--- a/src/lib/canvas/index.ts
+++ b/src/lib/canvas/index.ts
@@ -3,3 +3,6 @@ export { default as PdfLayer } from './PdfLayer.svelte';
 export { default as HighlightLayer } from './HighlightLayer.svelte';
 export { default as InkLayer } from './InkLayer.svelte';
 export { default as LiveLayer } from './LiveLayer.svelte';
+export { default as ShapeLayer } from './ShapeLayer.svelte';
+export { default as ShapeLiveLayer } from './ShapeLiveLayer.svelte';
+export { default as NumberLineEditor } from './NumberLineEditor.svelte';

--- a/src/lib/canvas/objectRenderer.ts
+++ b/src/lib/canvas/objectRenderer.ts
@@ -82,7 +82,7 @@ export function drawShape(ctx: CanvasRenderingContext2D, shape: ShapeObject, ptT
   } else {
     ctx.ellipse(x + w / 2, y + h / 2, Math.abs(w / 2), Math.abs(h / 2), 0, 0, Math.PI * 2);
   }
-  if (shape.fill) {
+  if (shape.fill !== null) {
     ctx.fillStyle = shape.fill;
     ctx.fill();
   }

--- a/src/lib/canvas/objectRenderer.ts
+++ b/src/lib/canvas/objectRenderer.ts
@@ -1,0 +1,177 @@
+import type { LineObject, NumberLineObject, ShapeObject, StrokeStyle } from '$lib/types';
+import { numberLineValueToX } from '$lib/tools/shapes';
+
+function dashPattern(dash: StrokeStyle['dash'], widthPx: number): number[] {
+  switch (dash) {
+    case 'dashed':
+      return [widthPx * 3, widthPx * 2];
+    case 'dotted':
+      return [widthPx, widthPx * 1.5];
+    case 'solid':
+    default:
+      return [];
+  }
+}
+
+function applyStrokeStyle(
+  ctx: CanvasRenderingContext2D,
+  style: StrokeStyle,
+  ptToPx: number,
+): number {
+  const widthPx = Math.max(0.5, style.width * ptToPx);
+  ctx.lineWidth = widthPx;
+  ctx.strokeStyle = style.color;
+  ctx.globalAlpha = style.opacity;
+  ctx.lineCap = 'round';
+  ctx.lineJoin = 'round';
+  ctx.setLineDash(dashPattern(style.dash, widthPx));
+  return widthPx;
+}
+
+function drawArrowHead(
+  ctx: CanvasRenderingContext2D,
+  tipX: number,
+  tipY: number,
+  fromX: number,
+  fromY: number,
+  sizePx: number,
+  color: string,
+): void {
+  const angle = Math.atan2(tipY - fromY, tipX - fromX);
+  const wing = Math.PI / 6;
+  ctx.save();
+  ctx.beginPath();
+  ctx.moveTo(tipX, tipY);
+  ctx.lineTo(tipX - sizePx * Math.cos(angle - wing), tipY - sizePx * Math.sin(angle - wing));
+  ctx.lineTo(tipX - sizePx * Math.cos(angle + wing), tipY - sizePx * Math.sin(angle + wing));
+  ctx.closePath();
+  ctx.fillStyle = color;
+  ctx.setLineDash([]);
+  ctx.fill();
+  ctx.restore();
+}
+
+export function drawLine(ctx: CanvasRenderingContext2D, line: LineObject, ptToPx: number): void {
+  ctx.save();
+  const widthPx = applyStrokeStyle(ctx, line.style, ptToPx);
+  const ax = line.from.x * ptToPx;
+  const ay = line.from.y * ptToPx;
+  const bx = line.to.x * ptToPx;
+  const by = line.to.y * ptToPx;
+  ctx.beginPath();
+  ctx.moveTo(ax, ay);
+  ctx.lineTo(bx, by);
+  ctx.stroke();
+  ctx.setLineDash([]);
+  const head = Math.max(6, widthPx * 4);
+  if (line.arrow.end) drawArrowHead(ctx, bx, by, ax, ay, head, line.style.color);
+  if (line.arrow.start) drawArrowHead(ctx, ax, ay, bx, by, head, line.style.color);
+  ctx.restore();
+}
+
+export function drawShape(ctx: CanvasRenderingContext2D, shape: ShapeObject, ptToPx: number): void {
+  ctx.save();
+  applyStrokeStyle(ctx, shape.style, ptToPx);
+  const x = shape.bounds.x * ptToPx;
+  const y = shape.bounds.y * ptToPx;
+  const w = shape.bounds.w * ptToPx;
+  const h = shape.bounds.h * ptToPx;
+  ctx.beginPath();
+  if (shape.kind === 'rect') {
+    ctx.rect(x, y, w, h);
+  } else {
+    ctx.ellipse(x + w / 2, y + h / 2, Math.abs(w / 2), Math.abs(h / 2), 0, 0, Math.PI * 2);
+  }
+  if (shape.fill) {
+    ctx.fillStyle = shape.fill;
+    ctx.fill();
+  }
+  ctx.stroke();
+  ctx.setLineDash([]);
+  ctx.restore();
+}
+
+export function drawNumberLine(
+  ctx: CanvasRenderingContext2D,
+  nl: NumberLineObject,
+  ptToPx: number,
+): void {
+  ctx.save();
+  const widthPx = applyStrokeStyle(ctx, nl.style, ptToPx);
+  const y = nl.from.y * ptToPx;
+  const x0 = nl.from.x * ptToPx;
+  const x1 = (nl.from.x + nl.length) * ptToPx;
+
+  ctx.beginPath();
+  ctx.moveTo(x0, y);
+  ctx.lineTo(x1, y);
+  ctx.stroke();
+  ctx.setLineDash([]);
+
+  const head = Math.max(6, widthPx * 4);
+  drawArrowHead(ctx, x1, y, x0, y, head, nl.style.color);
+  drawArrowHead(ctx, x0, y, x1, y, head, nl.style.color);
+
+  if (nl.tickStep > 0) {
+    const tickHalf = Math.max(4, widthPx * 2);
+    ctx.beginPath();
+    const start = Math.ceil(nl.min / nl.tickStep) * nl.tickStep;
+    for (let v = start; v <= nl.max + 1e-9; v += nl.tickStep) {
+      const tx = numberLineValueToX(nl, v) * ptToPx;
+      ctx.moveTo(tx, y - tickHalf);
+      ctx.lineTo(tx, y + tickHalf);
+    }
+    ctx.stroke();
+  }
+
+  if (nl.labelStep > 0) {
+    ctx.fillStyle = nl.style.color;
+    const fontPx = Math.max(9, 10 * ptToPx);
+    ctx.font = `${fontPx}px system-ui, sans-serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'top';
+    const start = Math.ceil(nl.min / nl.labelStep) * nl.labelStep;
+    for (let v = start; v <= nl.max + 1e-9; v += nl.labelStep) {
+      const tx = numberLineValueToX(nl, v) * ptToPx;
+      const label = Number.isInteger(v) ? v.toFixed(0) : v.toFixed(2).replace(/\.?0+$/, '');
+      ctx.fillText(label, tx, y + Math.max(6, widthPx * 2) + 2);
+    }
+  }
+
+  for (const m of nl.marks) {
+    const mx = numberLineValueToX(nl, m.value) * ptToPx;
+    const r = Math.max(4, widthPx * 2.2);
+    if (m.kind === 'closed') {
+      ctx.beginPath();
+      ctx.fillStyle = nl.style.color;
+      ctx.arc(mx, y, r, 0, Math.PI * 2);
+      ctx.fill();
+    } else if (m.kind === 'open') {
+      ctx.beginPath();
+      ctx.fillStyle = '#ffffff';
+      ctx.arc(mx, y, r, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.lineWidth = Math.max(1, widthPx * 0.8);
+      ctx.strokeStyle = nl.style.color;
+      ctx.stroke();
+    } else if (m.kind === 'arrow-left') {
+      ctx.lineWidth = widthPx;
+      ctx.strokeStyle = nl.style.color;
+      ctx.beginPath();
+      ctx.moveTo(mx, y);
+      ctx.lineTo(x0, y);
+      ctx.stroke();
+      drawArrowHead(ctx, x0, y, mx, y, Math.max(8, widthPx * 4), nl.style.color);
+    } else if (m.kind === 'arrow-right') {
+      ctx.lineWidth = widthPx;
+      ctx.strokeStyle = nl.style.color;
+      ctx.beginPath();
+      ctx.moveTo(mx, y);
+      ctx.lineTo(x1, y);
+      ctx.stroke();
+      drawArrowHead(ctx, x1, y, mx, y, Math.max(8, widthPx * 4), nl.style.color);
+    }
+  }
+
+  ctx.restore();
+}

--- a/src/lib/sidebar/Sidebar.svelte
+++ b/src/lib/sidebar/Sidebar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { currentStyle, sidebar } from '$lib/store/sidebar';
+  import { currentStyle, sidebar, styleKeyFor } from '$lib/store/sidebar';
   import type { DashStyle, StrokeStyle, ToolKind } from '$lib/types';
   import ColorPalette from './ColorPalette.svelte';
   import WidthPicker from './WidthPicker.svelte';
@@ -41,9 +41,8 @@
     if (disabled) return;
     sidebar.setTool(tool);
     onToolChange?.(tool);
-    if (tool === 'pen' || tool === 'highlighter' || tool === 'line') {
-      onStyleChange?.(sidebar.snapshot().toolStyles[tool]);
-    }
+    const key = styleKeyFor(tool);
+    if (key) onStyleChange?.(sidebar.snapshot().toolStyles[key]);
   }
 
   function onLaserRadius(e: Event) {

--- a/src/lib/sidebar/Sidebar.svelte
+++ b/src/lib/sidebar/Sidebar.svelte
@@ -26,6 +26,9 @@
     { id: 'highlighter', label: 'Highlighter', shortcut: 'H', icon: '🖍️' },
     { id: 'eraser', label: 'Eraser', shortcut: 'E', icon: '🧽' },
     { id: 'line', label: 'Line', shortcut: 'L', icon: '／' },
+    { id: 'rect', label: 'Rectangle', shortcut: 'R', icon: '▭' },
+    { id: 'ellipse', label: 'Ellipse', shortcut: 'O', icon: '◯' },
+    { id: 'numberline', label: 'Number line', shortcut: 'N', icon: '↔' },
     { id: 'graph', label: 'Graph (coming soon)', shortcut: 'G', icon: '📈', disabled: true },
   ];
 

--- a/src/lib/store/sidebar.ts
+++ b/src/lib/store/sidebar.ts
@@ -64,8 +64,10 @@ function initialState(): SidebarState {
   };
 }
 
-function isStyledTool(tool: ToolKind): tool is StyledTool {
-  return tool === 'pen' || tool === 'highlighter' || tool === 'line';
+export function styleKeyFor(tool: ToolKind): StyledTool | null {
+  if (tool === 'pen' || tool === 'highlighter' || tool === 'line') return tool;
+  if (tool === 'rect' || tool === 'ellipse' || tool === 'numberline') return 'line';
+  return null;
 }
 
 function nextDash(current: DashStyle): DashStyle {
@@ -98,8 +100,9 @@ function createSidebarStore() {
       update((s) => {
         if (s.activeTool === tool) return s;
         const next: SidebarState = { ...s, activeTool: tool };
-        if (isStyledTool(tool)) {
-          next.activeColor = s.toolStyles[tool].color;
+        const key = styleKeyFor(tool);
+        if (key) {
+          next.activeColor = s.toolStyles[key].color;
         } else if (tool === 'laser') {
           next.activeColor = s.laser.color;
         }
@@ -110,10 +113,11 @@ function createSidebarStore() {
     setActiveColor(color: string) {
       update((s) => {
         const next: SidebarState = { ...s, activeColor: color };
-        if (isStyledTool(s.activeTool)) {
+        const key = styleKeyFor(s.activeTool);
+        if (key) {
           next.toolStyles = {
             ...s.toolStyles,
-            [s.activeTool]: { ...s.toolStyles[s.activeTool], color },
+            [key]: { ...s.toolStyles[key], color },
           };
         } else if (s.activeTool === 'laser') {
           next.laser = { ...s.laser, color };
@@ -137,12 +141,13 @@ function createSidebarStore() {
 
     setWidth(width: number) {
       update((s) => {
-        if (!isStyledTool(s.activeTool)) return s;
+        const key = styleKeyFor(s.activeTool);
+        if (!key) return s;
         return {
           ...s,
           toolStyles: {
             ...s.toolStyles,
-            [s.activeTool]: { ...s.toolStyles[s.activeTool], width },
+            [key]: { ...s.toolStyles[key], width },
           },
         };
       });
@@ -150,12 +155,13 @@ function createSidebarStore() {
 
     setDash(dash: DashStyle) {
       update((s) => {
-        if (!isStyledTool(s.activeTool)) return s;
+        const key = styleKeyFor(s.activeTool);
+        if (!key) return s;
         return {
           ...s,
           toolStyles: {
             ...s.toolStyles,
-            [s.activeTool]: { ...s.toolStyles[s.activeTool], dash },
+            [key]: { ...s.toolStyles[key], dash },
           },
         };
       });
@@ -163,13 +169,14 @@ function createSidebarStore() {
 
     cycleDash() {
       update((s) => {
-        if (!isStyledTool(s.activeTool)) return s;
-        const current = s.toolStyles[s.activeTool];
+        const key = styleKeyFor(s.activeTool);
+        if (!key) return s;
+        const current = s.toolStyles[key];
         return {
           ...s,
           toolStyles: {
             ...s.toolStyles,
-            [s.activeTool]: { ...current, dash: nextDash(current.dash) },
+            [key]: { ...current, dash: nextDash(current.dash) },
           },
         };
       });
@@ -197,8 +204,9 @@ function createSidebarStore() {
 export const sidebar = createSidebarStore();
 
 export const currentStyle: Readable<StrokeStyle> = derived(sidebar, (s) => {
-  const base = isStyledTool(s.activeTool)
-    ? s.toolStyles[s.activeTool]
+  const key = styleKeyFor(s.activeTool);
+  const base = key
+    ? s.toolStyles[key]
     : { color: s.activeColor, width: 2, dash: 'solid' as DashStyle, opacity: 1 };
   return { ...base, color: s.activeColor };
 });

--- a/src/lib/tools/shapes.ts
+++ b/src/lib/tools/shapes.ts
@@ -1,0 +1,96 @@
+import type { LineObject, NumberLineObject, ShapeObject } from '$lib/types';
+
+export interface Bounds {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface Point2 {
+  x: number;
+  y: number;
+}
+
+/** Normalize a drag (start, end) into positive-width/height bounds. */
+export function normalizeBounds(a: Point2, b: Point2): Bounds {
+  const x = Math.min(a.x, b.x);
+  const y = Math.min(a.y, b.y);
+  const w = Math.abs(b.x - a.x);
+  const h = Math.abs(b.y - a.y);
+  return { x, y, w, h };
+}
+
+function distanceToSegment(p: Point2, a: Point2, b: Point2): number {
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  const lenSq = dx * dx + dy * dy;
+  if (lenSq === 0) return Math.hypot(p.x - a.x, p.y - a.y);
+  let t = ((p.x - a.x) * dx + (p.y - a.y) * dy) / lenSq;
+  t = Math.max(0, Math.min(1, t));
+  const cx = a.x + t * dx;
+  const cy = a.y + t * dy;
+  return Math.hypot(p.x - cx, p.y - cy);
+}
+
+export function hitTestLine(line: LineObject, p: Point2, radius: number): boolean {
+  const half = line.style.width / 2;
+  return distanceToSegment(p, line.from, line.to) <= half + radius;
+}
+
+export function hitTestShape(shape: ShapeObject, p: Point2, radius: number): boolean {
+  const { x, y, w, h } = shape.bounds;
+  const half = shape.style.width / 2;
+  if (shape.kind === 'rect') {
+    if (shape.fill !== null) {
+      return (
+        p.x >= x - radius && p.x <= x + w + radius && p.y >= y - radius && p.y <= y + h + radius
+      );
+    }
+    const onEdge = (() => {
+      const insideX = p.x >= x - half - radius && p.x <= x + w + half + radius;
+      const insideY = p.y >= y - half - radius && p.y <= y + h + half + radius;
+      if (!insideX || !insideY) return false;
+      const nearLeft = Math.abs(p.x - x) <= half + radius;
+      const nearRight = Math.abs(p.x - (x + w)) <= half + radius;
+      const nearTop = Math.abs(p.y - y) <= half + radius;
+      const nearBottom = Math.abs(p.y - (y + h)) <= half + radius;
+      return nearLeft || nearRight || nearTop || nearBottom;
+    })();
+    return onEdge;
+  }
+  const cx = x + w / 2;
+  const cy = y + h / 2;
+  const rx = w / 2;
+  const ry = h / 2;
+  if (rx <= 0 || ry <= 0) return false;
+  const nx = (p.x - cx) / rx;
+  const ny = (p.y - cy) / ry;
+  const dist = Math.hypot(nx, ny);
+  if (shape.fill !== null) {
+    return dist <= 1 + radius / Math.min(rx, ry);
+  }
+  const ringTol = (half + radius) / Math.min(rx, ry);
+  return Math.abs(dist - 1) <= ringTol;
+}
+
+/** x-position (in page coords) of a numeric value along the number line. */
+export function numberLineValueToX(nl: NumberLineObject, value: number): number {
+  if (nl.max === nl.min) return nl.from.x;
+  const t = (value - nl.min) / (nl.max - nl.min);
+  return nl.from.x + t * nl.length;
+}
+
+/** Numeric value at a given x-position along the number line. */
+export function numberLineXToValue(nl: NumberLineObject, x: number): number {
+  if (nl.length === 0) return nl.min;
+  const t = (x - nl.from.x) / nl.length;
+  return nl.min + t * (nl.max - nl.min);
+}
+
+export function hitTestNumberLine(nl: NumberLineObject, p: Point2, radius: number): boolean {
+  const a = nl.from;
+  const b = { x: nl.from.x + nl.length, y: nl.from.y };
+  const half = nl.style.width / 2;
+  return distanceToSegment(p, a, b) <= half + radius + 6;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -14,10 +14,22 @@ export type ToolKind =
   | 'highlighter'
   | 'eraser'
   | 'line'
+  | 'rect'
+  | 'ellipse'
+  | 'numberline'
   | 'graph'
   | 'text'
   | 'select'
   | 'pan';
+
+export type ShapeKind = 'rect' | 'ellipse';
+
+export type NumberLineMarkKind = 'open' | 'closed' | 'arrow-left' | 'arrow-right';
+
+export interface NumberLineMark {
+  value: number;
+  kind: NumberLineMarkKind;
+}
 
 export interface Point {
   x: number;
@@ -55,6 +67,26 @@ export interface LineObject extends ObjectBase {
   arrow: { start: boolean; end: boolean };
 }
 
+export interface ShapeObject extends ObjectBase {
+  type: 'shape';
+  kind: ShapeKind;
+  style: StrokeStyle;
+  fill: string | null;
+  bounds: { x: number; y: number; w: number; h: number };
+}
+
+export interface NumberLineObject extends ObjectBase {
+  type: 'numberline';
+  style: StrokeStyle;
+  from: { x: number; y: number };
+  length: number;
+  min: number;
+  max: number;
+  tickStep: number;
+  labelStep: number;
+  marks: NumberLineMark[];
+}
+
 export interface GraphFunction {
   id: string;
   expr: string;
@@ -84,7 +116,13 @@ export interface TextObject extends ObjectBase {
   color: string;
 }
 
-export type AnyObject = StrokeObject | LineObject | GraphObject | TextObject;
+export type AnyObject =
+  | StrokeObject
+  | LineObject
+  | ShapeObject
+  | NumberLineObject
+  | GraphObject
+  | TextObject;
 
 export type PageKind = 'pdf' | 'blank';
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte';
-  import { CanvasStack, PdfLayer } from '$lib/canvas';
+  import { CanvasStack, NumberLineEditor, PdfLayer } from '$lib/canvas';
   import { Sidebar } from '$lib/sidebar';
   import { openAndLoadPdf } from '$lib/ipc/pdf';
   import { loadSidecar } from '$lib/ipc';
@@ -13,7 +13,15 @@
   import { shortcuts } from '$lib/app/shortcuts';
   import { openPdfDialog } from '$lib/app/openPdfDialog';
   import { hitTestStrokes } from '$lib/tools/eraser';
-  import type { AnyObject, EldrawDocument, PdfMeta, StrokeObject } from '$lib/types';
+  import type {
+    AnyObject,
+    EldrawDocument,
+    LineObject,
+    NumberLineObject,
+    PdfMeta,
+    ShapeObject,
+    StrokeObject,
+  } from '$lib/types';
 
   const ERASER_RADIUS = 4;
 
@@ -106,6 +114,26 @@
     documentStore.addObject(pageIndex, stroke);
   }
 
+  let editingNumberLineId = $state<string | null>(null);
+
+  function onCommitObject(obj: LineObject | ShapeObject | NumberLineObject): void {
+    documentStore.addObject(pageIndex, obj);
+    if (obj.type === 'numberline') editingNumberLineId = obj.id;
+  }
+
+  const editingNumberLine = $derived<NumberLineObject | null>(
+    editingNumberLineId
+      ? (pageObjects.find(
+          (o): o is NumberLineObject => o.type === 'numberline' && o.id === editingNumberLineId,
+        ) ?? null)
+      : null,
+  );
+
+  function patchEditingNumberLine(patch: Partial<NumberLineObject>): void {
+    if (!editingNumberLineId) return;
+    documentStore.updateObject(pageIndex, editingNumberLineId, patch);
+  }
+
   function onEraseAt(at: { x: number; y: number }): void {
     const hits = hitTestStrokes(pageStrokes, at, ERASER_RADIUS);
     for (const s of hits) {
@@ -187,12 +215,25 @@
           <div class="stack-slot">
             <CanvasStack
               strokes={pageStrokes}
+              objects={pageObjects}
               width={size.width}
               height={size.height}
               ptToPx={size.ptToPx}
               oncommit={onCommitStroke}
               onerase={onEraseAt}
-            />
+              oncommitobject={onCommitObject}
+            >
+              {#snippet overlay()}
+                {#if editingNumberLine}
+                  <NumberLineEditor
+                    nl={editingNumberLine}
+                    ptToPx={size.ptToPx}
+                    onchange={patchEditingNumberLine}
+                    onclose={() => (editingNumberLineId = null)}
+                  />
+                {/if}
+              {/snippet}
+            </CanvasStack>
           </div>
         </div>
       {:else}

--- a/tests/shapes.test.ts
+++ b/tests/shapes.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from 'vitest';
+import {
+  hitTestLine,
+  hitTestNumberLine,
+  hitTestShape,
+  normalizeBounds,
+  numberLineValueToX,
+  numberLineXToValue,
+} from '$lib/tools/shapes';
+import type { LineObject, NumberLineObject, ShapeObject, StrokeStyle } from '$lib/types';
+
+const STYLE: StrokeStyle = { color: '#000', width: 2, dash: 'solid', opacity: 1 };
+
+function mkLine(from: { x: number; y: number }, to: { x: number; y: number }): LineObject {
+  return {
+    id: 'l',
+    createdAt: 0,
+    type: 'line',
+    style: STYLE,
+    from,
+    to,
+    arrow: { start: false, end: false },
+  };
+}
+
+function mkShape(
+  kind: 'rect' | 'ellipse',
+  bounds: { x: number; y: number; w: number; h: number },
+  fill: string | null = null,
+): ShapeObject {
+  return {
+    id: 's',
+    createdAt: 0,
+    type: 'shape',
+    kind,
+    style: STYLE,
+    fill,
+    bounds,
+  };
+}
+
+function mkNumberLine(overrides: Partial<NumberLineObject> = {}): NumberLineObject {
+  return {
+    id: 'n',
+    createdAt: 0,
+    type: 'numberline',
+    style: STYLE,
+    from: { x: 0, y: 100 },
+    length: 200,
+    min: -5,
+    max: 5,
+    tickStep: 1,
+    labelStep: 1,
+    marks: [],
+    ...overrides,
+  };
+}
+
+describe('normalizeBounds', () => {
+  it('returns positive size for positive drag', () => {
+    expect(normalizeBounds({ x: 1, y: 2 }, { x: 11, y: 22 })).toEqual({ x: 1, y: 2, w: 10, h: 20 });
+  });
+
+  it('flips negative drags to positive bounds', () => {
+    expect(normalizeBounds({ x: 11, y: 22 }, { x: 1, y: 2 })).toEqual({ x: 1, y: 2, w: 10, h: 20 });
+  });
+
+  it('handles mixed-sign drag', () => {
+    expect(normalizeBounds({ x: 0, y: 30 }, { x: 30, y: 0 })).toEqual({ x: 0, y: 0, w: 30, h: 30 });
+  });
+
+  it('returns zero size for identical points', () => {
+    expect(normalizeBounds({ x: 5, y: 5 }, { x: 5, y: 5 })).toEqual({ x: 5, y: 5, w: 0, h: 0 });
+  });
+});
+
+describe('hitTestLine', () => {
+  it('hits along the segment', () => {
+    expect(hitTestLine(mkLine({ x: 0, y: 0 }, { x: 100, y: 0 }), { x: 50, y: 0 }, 0)).toBe(true);
+  });
+
+  it('misses far above', () => {
+    expect(hitTestLine(mkLine({ x: 0, y: 0 }, { x: 100, y: 0 }), { x: 50, y: 50 }, 1)).toBe(false);
+  });
+
+  it('uses radius to widen hit area', () => {
+    const l = mkLine({ x: 0, y: 0 }, { x: 100, y: 0 });
+    expect(hitTestLine(l, { x: 50, y: 5 }, 0)).toBe(false);
+    expect(hitTestLine(l, { x: 50, y: 5 }, 5)).toBe(true);
+  });
+});
+
+describe('hitTestShape (rect)', () => {
+  it('outline-only rect hits the edge', () => {
+    const s = mkShape('rect', { x: 10, y: 10, w: 100, h: 50 });
+    expect(hitTestShape(s, { x: 10, y: 30 }, 0)).toBe(true);
+    expect(hitTestShape(s, { x: 60, y: 30 }, 0)).toBe(false);
+  });
+
+  it('filled rect hits inside', () => {
+    const s = mkShape('rect', { x: 10, y: 10, w: 100, h: 50 }, '#f00');
+    expect(hitTestShape(s, { x: 60, y: 30 }, 0)).toBe(true);
+  });
+
+  it('rect misses far outside', () => {
+    const s = mkShape('rect', { x: 0, y: 0, w: 10, h: 10 });
+    expect(hitTestShape(s, { x: 100, y: 100 }, 1)).toBe(false);
+  });
+});
+
+describe('hitTestShape (ellipse)', () => {
+  it('outline ellipse hits on the rim', () => {
+    const s = mkShape('ellipse', { x: 0, y: 0, w: 100, h: 100 });
+    expect(hitTestShape(s, { x: 100, y: 50 }, 0)).toBe(true);
+  });
+
+  it('filled ellipse hits inside the center', () => {
+    const s = mkShape('ellipse', { x: 0, y: 0, w: 100, h: 100 }, '#0f0');
+    expect(hitTestShape(s, { x: 50, y: 50 }, 0)).toBe(true);
+  });
+
+  it('outline ellipse misses center', () => {
+    const s = mkShape('ellipse', { x: 0, y: 0, w: 100, h: 100 });
+    expect(hitTestShape(s, { x: 50, y: 50 }, 0)).toBe(false);
+  });
+});
+
+describe('numberLine value/x mapping', () => {
+  const nl = mkNumberLine();
+
+  it('maps min to from.x', () => {
+    expect(numberLineValueToX(nl, -5)).toBeCloseTo(0);
+  });
+
+  it('maps max to from.x + length', () => {
+    expect(numberLineValueToX(nl, 5)).toBeCloseTo(200);
+  });
+
+  it('maps midpoint correctly', () => {
+    expect(numberLineValueToX(nl, 0)).toBeCloseTo(100);
+  });
+
+  it('inverse mapping recovers the value', () => {
+    expect(numberLineXToValue(nl, 100)).toBeCloseTo(0);
+    expect(numberLineXToValue(nl, 200)).toBeCloseTo(5);
+    expect(numberLineXToValue(nl, 50)).toBeCloseTo(-2.5);
+  });
+
+  it('handles offset origins', () => {
+    const offset = mkNumberLine({ from: { x: 50, y: 100 }, length: 100, min: 0, max: 10 });
+    expect(numberLineValueToX(offset, 0)).toBeCloseTo(50);
+    expect(numberLineValueToX(offset, 10)).toBeCloseTo(150);
+    expect(numberLineXToValue(offset, 100)).toBeCloseTo(5);
+  });
+
+  it('degenerate range maps to start', () => {
+    const flat = mkNumberLine({ min: 3, max: 3 });
+    expect(numberLineValueToX(flat, 3)).toBeCloseTo(flat.from.x);
+  });
+});
+
+describe('hitTestNumberLine', () => {
+  it('hits points on or near the axis', () => {
+    const nl = mkNumberLine();
+    expect(hitTestNumberLine(nl, { x: 100, y: 100 }, 0)).toBe(true);
+    expect(hitTestNumberLine(nl, { x: 100, y: 105 }, 0)).toBe(true);
+  });
+
+  it('misses points far from the axis', () => {
+    const nl = mkNumberLine();
+    expect(hitTestNumberLine(nl, { x: 100, y: 200 }, 0)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds drag-to-create **line / rect / ellipse / number line** tools. Phase 2 math-first feature.

## What

- **Type additions** (`src/lib/types.ts`): `ShapeObject` (rect | ellipse, optional fill) and `NumberLineObject` (min/max/tickStep/labelStep + open/closed/arrow marks). `AnyObject` union and `ToolKind` extended.
- **ShapeLayer** + **ShapeLiveLayer**: render committed objects and the live drag preview. Arrowheads supported on `LineObject`.
- **NumberLineEditor**: inline popover for min/max/tick/label and add/remove marks.
- **Geometry** (`src/lib/tools/shapes.ts`): `normalizeBounds`, hit-tests for line/shape/numberline, value↔x mapping.
- Sidebar entries + `R` (rect), `O` (ellipse), `N` (number line) shortcuts. Line keeps `L`.

## Tests

- 89 frontend tests (+21 in `shapes.test.ts`): bounds normalization, hit-tests, numberline value↔x mapping.
- All Rust tests still pass (10/10).