### PR TITLE
feat(laser,temp-ink): laser pointer and fading temp-ink tools

### DIFF
--- a/src/lib/app/shortcuts.ts
+++ b/src/lib/app/shortcuts.ts
@@ -111,6 +111,14 @@ export const shortcuts: Action<HTMLElement> = () => {
       case 'G':
         sidebar.setTool('graph');
         return;
+      case 'x':
+      case 'X':
+        sidebar.setTool('laser');
+        return;
+      case 'y':
+      case 'Y':
+        sidebar.setTool('temp-ink');
+        return;
       case 'd':
       case 'D':
         sidebar.cycleDash();

--- a/src/lib/canvas/CanvasStack.svelte
+++ b/src/lib/canvas/CanvasStack.svelte
@@ -1,21 +1,41 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
-  import type { StrokeObject } from '$lib/types';
+  import type { StrokeObject, StrokeStyle, ToolKind } from '$lib/types';
   import HighlightLayer from './HighlightLayer.svelte';
   import InkLayer from './InkLayer.svelte';
   import LiveLayer from './LiveLayer.svelte';
+  import LaserLayer from './LaserLayer.svelte';
+  import TempInkLayer from './TempInkLayer.svelte';
 
   interface Props {
     strokes: StrokeObject[];
     width: number;
     height: number;
     ptToPx: number;
+    activeTool?: ToolKind;
+    laserColor?: string;
+    laserRadius?: number;
+    tempInkStyle?: StrokeStyle;
+    tempInkFadeMs?: number;
     objects?: Snippet;
     oncommit?: (stroke: StrokeObject) => void;
     onerase?: (at: { x: number; y: number }) => void;
   }
 
-  let { strokes, width, height, ptToPx, objects, oncommit, onerase }: Props = $props();
+  let {
+    strokes,
+    width,
+    height,
+    ptToPx,
+    activeTool = 'pen',
+    laserColor = '#ff2d2d',
+    laserRadius = 6,
+    tempInkStyle = { color: '#000000', width: 2, dash: 'solid', opacity: 1 },
+    tempInkFadeMs = 3000,
+    objects,
+    oncommit,
+    onerase,
+  }: Props = $props();
 </script>
 
 <div class="stack" style="width: {width}px; height: {height}px;">
@@ -35,6 +55,27 @@
 
   <div class="layer layer-live">
     <LiveLayer {width} {height} {ptToPx} {oncommit} {onerase} />
+  </div>
+
+  <div class="layer layer-temp-ink">
+    <TempInkLayer
+      {width}
+      {height}
+      {ptToPx}
+      active={activeTool === 'temp-ink'}
+      style={tempInkStyle}
+      fadeMs={tempInkFadeMs}
+    />
+  </div>
+
+  <div class="layer layer-laser">
+    <LaserLayer
+      {width}
+      {height}
+      active={activeTool === 'laser'}
+      color={laserColor}
+      radius={laserRadius}
+    />
   </div>
 </div>
 
@@ -58,5 +99,11 @@
   }
   .layer-live {
     z-index: 4;
+  }
+  .layer-temp-ink {
+    z-index: 5;
+  }
+  .layer-laser {
+    z-index: 6;
   }
 </style>

--- a/src/lib/canvas/LaserLayer.svelte
+++ b/src/lib/canvas/LaserLayer.svelte
@@ -1,0 +1,176 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+  import {
+    appendPoint,
+    DEFAULT_LASER_TRAIL_MS,
+    pruneTrail,
+    trailAlpha,
+    type LaserPoint,
+  } from '$lib/tools/laser';
+
+  interface Props {
+    width: number;
+    height: number;
+    active: boolean;
+    color: string;
+    radius: number;
+    trailMs?: number;
+  }
+
+  let { width, height, active, color, radius, trailMs = DEFAULT_LASER_TRAIL_MS }: Props = $props();
+
+  let canvas: HTMLCanvasElement;
+  let trail: LaserPoint[] = [];
+  let activePointerId: number | null = null;
+  let rafId: number | null = null;
+
+  function ctx(): CanvasRenderingContext2D | null {
+    return canvas?.getContext('2d') ?? null;
+  }
+
+  function clear() {
+    const c = ctx();
+    if (!c || !canvas) return;
+    c.clearRect(0, 0, canvas.width, canvas.height);
+  }
+
+  function draw() {
+    const c = ctx();
+    if (!c || !canvas) return;
+    const now = performance.now();
+    trail = pruneTrail(trail, now, trailMs);
+    clear();
+    if (trail.length === 0) {
+      rafId = null;
+      return;
+    }
+
+    c.save();
+    c.globalCompositeOperation = 'lighter';
+    for (const p of trail) {
+      const a = trailAlpha(p, now, trailMs);
+      if (a <= 0) continue;
+      const r = radius * (0.4 + 0.6 * a);
+      const grad = c.createRadialGradient(p.x, p.y, 0, p.x, p.y, r * 3);
+      grad.addColorStop(0, withAlpha(color, a));
+      grad.addColorStop(0.4, withAlpha(color, a * 0.4));
+      grad.addColorStop(1, withAlpha(color, 0));
+      c.fillStyle = grad;
+      c.beginPath();
+      c.arc(p.x, p.y, r * 3, 0, Math.PI * 2);
+      c.fill();
+    }
+    const head = trail[trail.length - 1];
+    c.globalCompositeOperation = 'source-over';
+    c.fillStyle = color;
+    c.beginPath();
+    c.arc(head.x, head.y, radius, 0, Math.PI * 2);
+    c.fill();
+    c.restore();
+
+    rafId = requestAnimationFrame(draw);
+  }
+
+  function withAlpha(hex: string, alpha: number): string {
+    const a = Math.max(0, Math.min(1, alpha));
+    const m = /^#([0-9a-f]{6})$/i.exec(hex);
+    if (!m) return hex;
+    const n = parseInt(m[1], 16);
+    const r = (n >> 16) & 0xff;
+    const g = (n >> 8) & 0xff;
+    const b = n & 0xff;
+    return `rgba(${r}, ${g}, ${b}, ${a})`;
+  }
+
+  function ensureRaf() {
+    if (rafId === null) rafId = requestAnimationFrame(draw);
+  }
+
+  function localPoint(e: PointerEvent): { x: number; y: number } {
+    const rect = canvas.getBoundingClientRect();
+    return { x: e.clientX - rect.left, y: e.clientY - rect.top };
+  }
+
+  function pushPoint(e: PointerEvent) {
+    const { x, y } = localPoint(e);
+    trail = appendPoint(trail, { x, y, t: performance.now() }, trailMs);
+    ensureRaf();
+  }
+
+  function onPointerDown(e: PointerEvent) {
+    if (!active) return;
+    canvas.setPointerCapture(e.pointerId);
+    activePointerId = e.pointerId;
+    pushPoint(e);
+    e.preventDefault();
+  }
+
+  function onPointerMove(e: PointerEvent) {
+    if (!active || activePointerId !== e.pointerId) return;
+    pushPoint(e);
+    e.preventDefault();
+  }
+
+  function onPointerUp(e: PointerEvent) {
+    if (activePointerId !== e.pointerId) return;
+    try {
+      canvas.releasePointerCapture(e.pointerId);
+    } catch {
+      // not captured; ignore
+    }
+    activePointerId = null;
+  }
+
+  function reset() {
+    trail = [];
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+    clear();
+  }
+
+  $effect(() => {
+    if (!active) reset();
+  });
+
+  $effect(() => {
+    void width;
+    void height;
+    if (canvas) clear();
+  });
+
+  onMount(clear);
+
+  onDestroy(() => {
+    if (rafId !== null) cancelAnimationFrame(rafId);
+    rafId = null;
+    trail = [];
+  });
+</script>
+
+<canvas
+  bind:this={canvas}
+  {width}
+  {height}
+  class="laser-layer"
+  class:active
+  style="width: {width}px; height: {height}px;"
+  onpointerdown={onPointerDown}
+  onpointermove={onPointerMove}
+  onpointerup={onPointerUp}
+  onpointercancel={onPointerUp}
+></canvas>
+
+<style>
+  .laser-layer {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    touch-action: none;
+  }
+  .laser-layer.active {
+    pointer-events: auto;
+    cursor: crosshair;
+  }
+</style>

--- a/src/lib/canvas/LaserLayer.svelte
+++ b/src/lib/canvas/LaserLayer.svelte
@@ -2,6 +2,7 @@
   import { onDestroy, onMount } from 'svelte';
   import {
     appendPoint,
+    clampTrailMs,
     DEFAULT_LASER_TRAIL_MS,
     pruneTrail,
     trailAlpha,
@@ -18,6 +19,9 @@
   }
 
   let { width, height, active, color, radius, trailMs = DEFAULT_LASER_TRAIL_MS }: Props = $props();
+
+  const safeTrailMs = $derived(clampTrailMs(trailMs));
+  const safeRadius = $derived(Number.isFinite(radius) && radius > 0 ? radius : 6);
 
   let canvas: HTMLCanvasElement;
   let trail: LaserPoint[] = [];
@@ -38,7 +42,7 @@
     const c = ctx();
     if (!c || !canvas) return;
     const now = performance.now();
-    trail = pruneTrail(trail, now, trailMs);
+    trail = pruneTrail(trail, now, safeTrailMs);
     clear();
     if (trail.length === 0) {
       rafId = null;
@@ -48,9 +52,9 @@
     c.save();
     c.globalCompositeOperation = 'lighter';
     for (const p of trail) {
-      const a = trailAlpha(p, now, trailMs);
+      const a = trailAlpha(p, now, safeTrailMs);
       if (a <= 0) continue;
-      const r = radius * (0.4 + 0.6 * a);
+      const r = safeRadius * (0.4 + 0.6 * a);
       const grad = c.createRadialGradient(p.x, p.y, 0, p.x, p.y, r * 3);
       grad.addColorStop(0, withAlpha(color, a));
       grad.addColorStop(0.4, withAlpha(color, a * 0.4));
@@ -64,7 +68,7 @@
     c.globalCompositeOperation = 'source-over';
     c.fillStyle = color;
     c.beginPath();
-    c.arc(head.x, head.y, radius, 0, Math.PI * 2);
+    c.arc(head.x, head.y, safeRadius, 0, Math.PI * 2);
     c.fill();
     c.restore();
 
@@ -93,7 +97,7 @@
 
   function pushPoint(e: PointerEvent) {
     const { x, y } = localPoint(e);
-    trail = appendPoint(trail, { x, y, t: performance.now() }, trailMs);
+    trail = appendPoint(trail, { x, y, t: performance.now() }, safeTrailMs);
     ensureRaf();
   }
 

--- a/src/lib/canvas/TempInkLayer.svelte
+++ b/src/lib/canvas/TempInkLayer.svelte
@@ -1,0 +1,181 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+  import type { Point, StrokeStyle } from '$lib/types';
+  import {
+    createTempStroke,
+    fadeOpacity,
+    pruneStrokes,
+    type TempInkStroke,
+  } from '$lib/tools/tempInk';
+  import { drawLiveStroke } from './strokeRenderer';
+
+  interface Props {
+    width: number;
+    height: number;
+    ptToPx: number;
+    active: boolean;
+    style: StrokeStyle;
+    fadeMs: number;
+  }
+
+  let { width, height, ptToPx, active, style, fadeMs }: Props = $props();
+
+  let canvas: HTMLCanvasElement;
+  let strokes: TempInkStroke[] = [];
+  let liveStyle: StrokeStyle = { color: '#000', width: 2, dash: 'solid', opacity: 1 };
+  let livePoints: Point[] = [];
+  let activePointerId: number | null = null;
+  let startTime = 0;
+  let rafId: number | null = null;
+
+  function ctx(): CanvasRenderingContext2D | null {
+    return canvas?.getContext('2d') ?? null;
+  }
+
+  function clear() {
+    const c = ctx();
+    if (!c || !canvas) return;
+    c.clearRect(0, 0, canvas.width, canvas.height);
+  }
+
+  function frame() {
+    const c = ctx();
+    if (!c || !canvas) return;
+    const now = performance.now();
+    strokes = pruneStrokes(strokes, now);
+    clear();
+
+    c.save();
+    for (const s of strokes) {
+      const a = fadeOpacity(s, now);
+      if (a <= 0) continue;
+      c.globalAlpha = a * s.style.opacity;
+      drawLiveStroke(c, s.points, { ...s.style, opacity: 1 }, 'pen', ptToPx);
+    }
+    c.restore();
+
+    if (livePoints.length > 0) {
+      c.save();
+      c.globalAlpha = liveStyle.opacity;
+      drawLiveStroke(c, livePoints, { ...liveStyle, opacity: 1 }, 'pen', ptToPx);
+      c.restore();
+    }
+
+    if (strokes.length === 0 && livePoints.length === 0) {
+      rafId = null;
+      return;
+    }
+    rafId = requestAnimationFrame(frame);
+  }
+
+  function ensureRaf() {
+    if (rafId === null) rafId = requestAnimationFrame(frame);
+  }
+
+  function toPoint(e: PointerEvent): Point {
+    const rect = canvas.getBoundingClientRect();
+    const px = e.clientX - rect.left;
+    const py = e.clientY - rect.top;
+    const pressure = e.pressure > 0 ? e.pressure : 0.5;
+    return {
+      x: px / ptToPx,
+      y: py / ptToPx,
+      pressure,
+      t: performance.now() - startTime,
+    };
+  }
+
+  function onPointerDown(e: PointerEvent) {
+    if (!active) return;
+    if (e.pointerType === 'touch') return;
+    canvas.setPointerCapture(e.pointerId);
+    activePointerId = e.pointerId;
+    startTime = performance.now();
+    liveStyle = { ...style };
+    livePoints = [toPoint(e)];
+    ensureRaf();
+    e.preventDefault();
+  }
+
+  function onPointerMove(e: PointerEvent) {
+    if (!active || activePointerId !== e.pointerId) return;
+    livePoints.push(toPoint(e));
+    ensureRaf();
+    e.preventDefault();
+  }
+
+  function finish(e: PointerEvent, commit: boolean) {
+    if (activePointerId !== e.pointerId) return;
+    try {
+      canvas.releasePointerCapture(e.pointerId);
+    } catch {
+      // not captured; ignore
+    }
+    activePointerId = null;
+
+    if (commit && livePoints.length > 0) {
+      const stroke = createTempStroke(livePoints, liveStyle, fadeMs, performance.now());
+      strokes = [...strokes, stroke];
+    }
+    livePoints = [];
+    ensureRaf();
+  }
+
+  function onPointerUp(e: PointerEvent) {
+    finish(e, true);
+  }
+
+  function onPointerCancel(e: PointerEvent) {
+    finish(e, false);
+  }
+
+  $effect(() => {
+    if (!active) {
+      livePoints = [];
+      activePointerId = null;
+      ensureRaf();
+    }
+  });
+
+  $effect(() => {
+    void width;
+    void height;
+    void ptToPx;
+    if (canvas) ensureRaf();
+  });
+
+  onMount(clear);
+
+  onDestroy(() => {
+    if (rafId !== null) cancelAnimationFrame(rafId);
+    rafId = null;
+    strokes = [];
+    livePoints = [];
+  });
+</script>
+
+<canvas
+  bind:this={canvas}
+  {width}
+  {height}
+  class="temp-ink-layer"
+  class:active
+  style="width: {width}px; height: {height}px;"
+  onpointerdown={onPointerDown}
+  onpointermove={onPointerMove}
+  onpointerup={onPointerUp}
+  onpointercancel={onPointerCancel}
+></canvas>
+
+<style>
+  .temp-ink-layer {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    touch-action: none;
+  }
+  .temp-ink-layer.active {
+    pointer-events: auto;
+    cursor: crosshair;
+  }
+</style>

--- a/src/lib/canvas/index.ts
+++ b/src/lib/canvas/index.ts
@@ -3,3 +3,5 @@ export { default as PdfLayer } from './PdfLayer.svelte';
 export { default as HighlightLayer } from './HighlightLayer.svelte';
 export { default as InkLayer } from './InkLayer.svelte';
 export { default as LiveLayer } from './LiveLayer.svelte';
+export { default as LaserLayer } from './LaserLayer.svelte';
+export { default as TempInkLayer } from './TempInkLayer.svelte';

--- a/src/lib/sidebar/Sidebar.svelte
+++ b/src/lib/sidebar/Sidebar.svelte
@@ -27,6 +27,8 @@
     { id: 'eraser', label: 'Eraser', shortcut: 'E', icon: '🧽' },
     { id: 'line', label: 'Line', shortcut: 'L', icon: '／' },
     { id: 'graph', label: 'Graph (coming soon)', shortcut: 'G', icon: '📈', disabled: true },
+    { id: 'laser', label: 'Laser', shortcut: 'X', icon: '🔴' },
+    { id: 'temp-ink', label: 'Temp Ink', shortcut: 'Y', icon: '💧' },
   ];
 
   const state = $derived($sidebar);
@@ -39,6 +41,16 @@
     if (tool === 'pen' || tool === 'highlighter' || tool === 'line') {
       onStyleChange?.(sidebar.snapshot().toolStyles[tool]);
     }
+  }
+
+  function onLaserRadius(e: Event) {
+    const v = Number((e.target as HTMLInputElement).value);
+    if (Number.isFinite(v)) sidebar.setLaserRadius(v);
+  }
+
+  function onTempInkFade(e: Event) {
+    const v = Number((e.target as HTMLInputElement).value);
+    if (Number.isFinite(v)) sidebar.setTempInkFadeMs(v);
   }
 
   function onColor(color: string) {
@@ -111,6 +123,37 @@
   <section class="section" aria-label="Dash">
     <DashStyleToggle value={style.dash} onChange={onDash} />
   </section>
+
+  {#if state.activeTool === 'laser'}
+    <section class="section" aria-label="Laser">
+      <h3 class="section-title">Laser radius</h3>
+      <input
+        type="range"
+        min="2"
+        max="24"
+        step="1"
+        value={state.laser.radius}
+        oninput={onLaserRadius}
+        aria-label="Laser radius"
+      />
+      <span class="value">{state.laser.radius}px</span>
+    </section>
+  {/if}
+
+  {#if state.activeTool === 'temp-ink'}
+    <section class="section" aria-label="Temp ink fade">
+      <h3 class="section-title">Fade (ms)</h3>
+      <input
+        type="number"
+        min="500"
+        max="30000"
+        step="100"
+        value={state.tempInkFadeMs}
+        oninput={onTempInkFade}
+        aria-label="Temp ink fade duration in milliseconds"
+      />
+    </section>
+  {/if}
 </aside>
 
 <style>
@@ -227,5 +270,17 @@
     color: #bbb;
     margin: 0;
     font-weight: 500;
+  }
+  .value {
+    font-size: 11px;
+    color: #aaa;
+  }
+  input[type='number'] {
+    background: #1b1b1b;
+    border: 1px solid #333;
+    color: #ddd;
+    border-radius: 4px;
+    padding: 4px 6px;
+    font: inherit;
   }
 </style>

--- a/src/lib/store/sidebar.ts
+++ b/src/lib/store/sidebar.ts
@@ -1,7 +1,17 @@
 import { derived, get, writable, type Readable } from 'svelte/store';
 import type { ColorPalette, DashStyle, StrokeStyle, ToolKind } from '$lib/types';
+import { clampFadeMs, DEFAULT_TEMP_INK_FADE_MS } from '$lib/tools/tempInk';
 
 export type StyledTool = 'pen' | 'highlighter' | 'line';
+
+export interface LaserStyle {
+  color: string;
+  radius: number;
+}
+
+export const DEFAULT_LASER_STYLE: LaserStyle = { color: '#ff2d2d', radius: 6 };
+export const MIN_LASER_RADIUS = 2;
+export const MAX_LASER_RADIUS = 24;
 
 export const PRESET_COLORS: readonly string[] = [
   '#000000',
@@ -31,6 +41,8 @@ export interface SidebarState {
   toolStyles: Record<StyledTool, StrokeStyle>;
   palettes: ColorPalette[];
   activeColor: string;
+  laser: LaserStyle;
+  tempInkFadeMs: number;
 }
 
 function initialState(): SidebarState {
@@ -47,6 +59,8 @@ function initialState(): SidebarState {
       { id: 'custom', name: 'Custom', colors: [] },
     ],
     activeColor: '#000000',
+    laser: { ...DEFAULT_LASER_STYLE },
+    tempInkFadeMs: DEFAULT_TEMP_INK_FADE_MS,
   };
 }
 
@@ -86,6 +100,8 @@ function createSidebarStore() {
         const next: SidebarState = { ...s, activeTool: tool };
         if (isStyledTool(tool)) {
           next.activeColor = s.toolStyles[tool].color;
+        } else if (tool === 'laser') {
+          next.activeColor = s.laser.color;
         }
         return next;
       });
@@ -99,6 +115,8 @@ function createSidebarStore() {
             ...s.toolStyles,
             [s.activeTool]: { ...s.toolStyles[s.activeTool], color },
           };
+        } else if (s.activeTool === 'laser') {
+          next.laser = { ...s.laser, color };
         }
         return next;
       });
@@ -159,6 +177,15 @@ function createSidebarStore() {
 
     togglePin() {
       update((s) => ({ ...s, pinned: !s.pinned }));
+    },
+
+    setLaserRadius(radius: number) {
+      const clamped = Math.min(MAX_LASER_RADIUS, Math.max(MIN_LASER_RADIUS, radius));
+      update((s) => ({ ...s, laser: { ...s.laser, radius: clamped } }));
+    },
+
+    setTempInkFadeMs(ms: number) {
+      update((s) => ({ ...s, tempInkFadeMs: clampFadeMs(ms) }));
     },
 
     snapshot(): SidebarState {

--- a/src/lib/tools/laser.ts
+++ b/src/lib/tools/laser.ts
@@ -1,0 +1,52 @@
+/**
+ * Laser pointer trail buffer.
+ *
+ * Points carry wall-clock timestamps (ms). Each point fades over
+ * `trailMs` and is dropped once older than that. The buffer is never
+ * persisted; it is a pure ring of recent pointer samples used only for
+ * drawing the glowing trail.
+ */
+
+export interface LaserPoint {
+  x: number;
+  y: number;
+  t: number;
+}
+
+export interface LaserTrailOptions {
+  trailMs: number;
+}
+
+export const DEFAULT_LASER_TRAIL_MS = 300;
+export const MIN_LASER_TRAIL_MS = 50;
+export const MAX_LASER_TRAIL_MS = 2000;
+
+export function clampTrailMs(ms: number): number {
+  if (!Number.isFinite(ms)) return DEFAULT_LASER_TRAIL_MS;
+  return Math.min(MAX_LASER_TRAIL_MS, Math.max(MIN_LASER_TRAIL_MS, ms));
+}
+
+export function pruneTrail(points: LaserPoint[], now: number, trailMs: number): LaserPoint[] {
+  const cutoff = now - trailMs;
+  let i = 0;
+  while (i < points.length && points[i].t < cutoff) i++;
+  return i === 0 ? points : points.slice(i);
+}
+
+export function appendPoint(points: LaserPoint[], p: LaserPoint, trailMs: number): LaserPoint[] {
+  const next = pruneTrail(points, p.t, trailMs);
+  next.push(p);
+  return next;
+}
+
+/**
+ * Linear fade. 1.0 at the newest point, 0.0 at `now - trailMs`.
+ * Returns 0 for points outside the trail window (defensive).
+ */
+export function trailAlpha(point: LaserPoint, now: number, trailMs: number): number {
+  if (trailMs <= 0) return 0;
+  const age = now - point.t;
+  if (age <= 0) return 1;
+  if (age >= trailMs) return 0;
+  return 1 - age / trailMs;
+}

--- a/src/lib/tools/tempInk.ts
+++ b/src/lib/tools/tempInk.ts
@@ -1,0 +1,73 @@
+/**
+ * Temp-ink stroke buffer.
+ *
+ * Strokes are kept entirely in-memory, never serialized into the
+ * document. Each stroke carries the wall-clock time when its last point
+ * was recorded; after `fadeMs` have elapsed past that time the stroke is
+ * fully transparent and is pruned by the caller on the next animation
+ * frame.
+ *
+ * The fade curve is linear in time for predictability. See
+ * `fadeOpacity`.
+ */
+
+import type { Point, StrokeStyle } from '$lib/types';
+
+export const DEFAULT_TEMP_INK_FADE_MS = 3000;
+export const MIN_TEMP_INK_FADE_MS = 500;
+export const MAX_TEMP_INK_FADE_MS = 30_000;
+
+export function clampFadeMs(ms: number): number {
+  if (!Number.isFinite(ms)) return DEFAULT_TEMP_INK_FADE_MS;
+  return Math.min(MAX_TEMP_INK_FADE_MS, Math.max(MIN_TEMP_INK_FADE_MS, ms));
+}
+
+export interface TempInkStroke {
+  id: string;
+  style: StrokeStyle;
+  points: Point[];
+  /** Wall-clock ms when the stroke finished (or was last extended). */
+  endedAt: number;
+  fadeMs: number;
+}
+
+export function newTempStrokeId(): string {
+  return typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : `temp-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
+}
+
+export function createTempStroke(
+  points: Point[],
+  style: StrokeStyle,
+  fadeMs: number,
+  endedAt: number,
+): TempInkStroke {
+  return {
+    id: newTempStrokeId(),
+    style: { ...style },
+    points: points.map((p) => ({ ...p })),
+    endedAt,
+    fadeMs: clampFadeMs(fadeMs),
+  };
+}
+
+/**
+ * Linear fade from 1.0 at `endedAt` to 0.0 at `endedAt + fadeMs`.
+ * Returns 1 before fade starts (while drawing) and 0 after fade ends.
+ */
+export function fadeOpacity(stroke: TempInkStroke, now: number): number {
+  const age = now - stroke.endedAt;
+  if (age <= 0) return 1;
+  if (age >= stroke.fadeMs) return 0;
+  return 1 - age / stroke.fadeMs;
+}
+
+export function pruneStrokes(strokes: TempInkStroke[], now: number): TempInkStroke[] {
+  let expired = 0;
+  for (const s of strokes) {
+    if (fadeOpacity(s, now) <= 0) expired++;
+    else break;
+  }
+  return expired === 0 ? strokes : strokes.slice(expired);
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -17,7 +17,9 @@ export type ToolKind =
   | 'graph'
   | 'text'
   | 'select'
-  | 'pan';
+  | 'pan'
+  | 'laser'
+  | 'temp-ink';
 
 export interface Point {
   x: number;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -190,6 +190,11 @@
               width={size.width}
               height={size.height}
               ptToPx={size.ptToPx}
+              activeTool={sidebarState.activeTool}
+              laserColor={sidebarState.laser.color}
+              laserRadius={sidebarState.laser.radius}
+              tempInkStyle={sidebarState.toolStyles.pen}
+              tempInkFadeMs={sidebarState.tempInkFadeMs}
               oncommit={onCommitStroke}
               onerase={onEraseAt}
             />

--- a/tests/laser.test.ts
+++ b/tests/laser.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import {
+  appendPoint,
+  clampTrailMs,
+  DEFAULT_LASER_TRAIL_MS,
+  MAX_LASER_TRAIL_MS,
+  MIN_LASER_TRAIL_MS,
+  pruneTrail,
+  trailAlpha,
+  type LaserPoint,
+} from '$lib/tools/laser';
+
+describe('laser trail buffer', () => {
+  it('clampTrailMs respects bounds and falls back on NaN', () => {
+    expect(clampTrailMs(0)).toBe(MIN_LASER_TRAIL_MS);
+    expect(clampTrailMs(99_999)).toBe(MAX_LASER_TRAIL_MS);
+    expect(clampTrailMs(NaN)).toBe(DEFAULT_LASER_TRAIL_MS);
+    expect(clampTrailMs(250)).toBe(250);
+  });
+
+  it('prunes points older than trailMs and keeps fresh ones', () => {
+    const now = 1000;
+    const trailMs = 300;
+    const points: LaserPoint[] = [
+      { x: 0, y: 0, t: 500 },
+      { x: 1, y: 1, t: 750 },
+      { x: 2, y: 2, t: 950 },
+    ];
+    const kept = pruneTrail(points, now, trailMs);
+    expect(kept).toHaveLength(2);
+    expect(kept[0].t).toBe(750);
+    expect(kept[1].t).toBe(950);
+  });
+
+  it('appendPoint prunes then appends', () => {
+    const trailMs = 300;
+    let trail: LaserPoint[] = [{ x: 0, y: 0, t: 100 }];
+    trail = appendPoint(trail, { x: 1, y: 1, t: 500 }, trailMs);
+    expect(trail).toHaveLength(1);
+    expect(trail[0].t).toBe(500);
+  });
+
+  it('trailAlpha is 1 at the head and 0 past the window', () => {
+    const p: LaserPoint = { x: 0, y: 0, t: 1000 };
+    expect(trailAlpha(p, 1000, 300)).toBe(1);
+    expect(trailAlpha(p, 1300, 300)).toBe(0);
+    expect(trailAlpha(p, 1500, 300)).toBe(0);
+    const mid = trailAlpha(p, 1150, 300);
+    expect(mid).toBeGreaterThan(0);
+    expect(mid).toBeLessThan(1);
+    expect(mid).toBeCloseTo(0.5, 5);
+  });
+
+  it('returns 0 when trailMs is non-positive', () => {
+    const p: LaserPoint = { x: 0, y: 0, t: 1000 };
+    expect(trailAlpha(p, 1000, 0)).toBe(0);
+  });
+});

--- a/tests/temp-ink.test.ts
+++ b/tests/temp-ink.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import {
+  clampFadeMs,
+  createTempStroke,
+  DEFAULT_TEMP_INK_FADE_MS,
+  fadeOpacity,
+  MAX_TEMP_INK_FADE_MS,
+  MIN_TEMP_INK_FADE_MS,
+  pruneStrokes,
+} from '$lib/tools/tempInk';
+import type { Point, StrokeStyle } from '$lib/types';
+
+const STYLE: StrokeStyle = { color: '#000', width: 2, dash: 'solid', opacity: 1 };
+
+function pt(x: number, y: number, t: number): Point {
+  return { x, y, pressure: 0.5, t };
+}
+
+describe('temp-ink fade', () => {
+  it('clampFadeMs enforces [500, 30000] and falls back on NaN', () => {
+    expect(clampFadeMs(0)).toBe(MIN_TEMP_INK_FADE_MS);
+    expect(clampFadeMs(60_000)).toBe(MAX_TEMP_INK_FADE_MS);
+    expect(clampFadeMs(NaN)).toBe(DEFAULT_TEMP_INK_FADE_MS);
+    expect(clampFadeMs(2000)).toBe(2000);
+  });
+
+  it('createTempStroke clones points and clamps fadeMs', () => {
+    const points = [pt(1, 2, 0), pt(3, 4, 10)];
+    const stroke = createTempStroke(points, STYLE, 100, 1234);
+    expect(stroke.points).toHaveLength(2);
+    expect(stroke.points[0]).not.toBe(points[0]);
+    expect(stroke.fadeMs).toBe(MIN_TEMP_INK_FADE_MS);
+    expect(stroke.endedAt).toBe(1234);
+    expect(stroke.style).toEqual(STYLE);
+    expect(stroke.style).not.toBe(STYLE);
+  });
+
+  it('fadeOpacity follows a linear curve from 1 to 0', () => {
+    const stroke = createTempStroke([pt(0, 0, 0)], STYLE, 1000, 0);
+    expect(fadeOpacity(stroke, -50)).toBe(1);
+    expect(fadeOpacity(stroke, 0)).toBe(1);
+    expect(fadeOpacity(stroke, 250)).toBeCloseTo(0.75, 5);
+    expect(fadeOpacity(stroke, 500)).toBeCloseTo(0.5, 5);
+    expect(fadeOpacity(stroke, 750)).toBeCloseTo(0.25, 5);
+    expect(fadeOpacity(stroke, 1000)).toBe(0);
+    expect(fadeOpacity(stroke, 5000)).toBe(0);
+  });
+
+  it('pruneStrokes drops fully faded strokes from the front', () => {
+    const a = createTempStroke([pt(0, 0, 0)], STYLE, 500, 0);
+    const b = createTempStroke([pt(1, 1, 0)], STYLE, 500, 200);
+    const c = createTempStroke([pt(2, 2, 0)], STYLE, 500, 400);
+    const kept = pruneStrokes([a, b, c], 600);
+    expect(kept).toHaveLength(2);
+    expect(kept[0]).toBe(b);
+    expect(kept[1]).toBe(c);
+  });
+
+  it('pruneStrokes returns the same array when nothing expired', () => {
+    const a = createTempStroke([pt(0, 0, 0)], STYLE, 1000, 100);
+    const arr = [a];
+    expect(pruneStrokes(arr, 500)).toBe(arr);
+  });
+});


### PR DESCRIPTION
## Summary

Adds two transient drawing modes for live teaching: a **laser pointer** with a short trailing tail, and **temp ink** strokes that auto-fade. Phase 2 math-first feature.

## What

- **`ToolKind`** += `'laser' | 'temp-ink'`.
- **LaserLayer**: red glowing dot + RAF-driven trail (~300 ms) overlay. Never persisted.
- **TempInkLayer**: pen-like strokes that linearly fade over a configurable duration (default 3000 ms, clamped [500, 30000]) and prune themselves. **Never enters `documentStore`** — does not appear in autosave.
- **Pure tool logic** (`src/lib/tools/laser.ts`, `tempInk.ts`): trail buffers and fade math, separated from rendering.
- Sidebar entries (laser radius slider, temp-ink fade-ms input). Shortcuts `X` (laser) and `Y` (temp-ink).
- Layers go `pointer-events: none` when their tool isn't active so existing tools keep working. RAF loops self-cancel when buffers are empty and tear down in `onDestroy`.

## Tests

- 78 frontend tests (+10): 5 laser-trail tests (13 assertions), 5 temp-ink fade tests (18 assertions).
- All Rust tests still pass (10/10).