### PR TITLE
feat(geometry): protractor and ruler overlays

### DIFF
--- a/src/lib/app/shortcuts.ts
+++ b/src/lib/app/shortcuts.ts
@@ -132,6 +132,14 @@ export const shortcuts: Action<HTMLElement> = () => {
       case 'Y':
         sidebar.setTool('temp-ink');
         return;
+      case 'a':
+      case 'A':
+        sidebar.setTool('protractor');
+        return;
+      case 'u':
+      case 'U':
+        sidebar.setTool('ruler');
+        return;
       case 'd':
       case 'D':
         sidebar.cycleDash();

--- a/src/lib/canvas/ProtractorOverlay.svelte
+++ b/src/lib/canvas/ProtractorOverlay.svelte
@@ -53,12 +53,11 @@
         y: p.y - drag.offset.y,
       });
     } else {
-      const startAngle = Math.atan2(
-        drag.startPointer.y - proto.center.y,
-        drag.startPointer.x - proto.center.x,
-      );
-      const currentAngle = Math.atan2(p.y - proto.center.y, p.x - proto.center.x);
-      const delta = ((currentAngle - startAngle) * 180) / Math.PI;
+      const ax = drag.startPointer.x - proto.center.x;
+      const ay = drag.startPointer.y - proto.center.y;
+      const bx = p.x - proto.center.x;
+      const by = p.y - proto.center.y;
+      const delta = (Math.atan2(ax * by - ay * bx, ax * bx + ay * by) * 180) / Math.PI;
       overlays.rotateProtractor(drag.startRotation + delta);
     }
   }

--- a/src/lib/canvas/ProtractorOverlay.svelte
+++ b/src/lib/canvas/ProtractorOverlay.svelte
@@ -1,0 +1,175 @@
+<script lang="ts">
+  import { overlays } from '$lib/store/overlays';
+  import { angleAtPoint, protractorTicks, type Vec2 } from '$lib/geometry';
+
+  interface Props {
+    ptToPx: number;
+    width: number;
+    height: number;
+  }
+
+  let { ptToPx, width, height }: Props = $props();
+
+  const proto = $derived($overlays.protractor);
+  const ticks = $derived(protractorTicks(proto));
+
+  let svgEl: SVGSVGElement | undefined = $state();
+  let cursorAngle = $state<number | null>(null);
+
+  type Drag =
+    | { kind: 'move'; offset: Vec2 }
+    | { kind: 'rotate'; startPointer: Vec2; startRotation: number };
+  let drag: Drag | null = null;
+
+  function toPtSpace(e: PointerEvent): Vec2 {
+    const rect = svgEl!.getBoundingClientRect();
+    return {
+      x: (e.clientX - rect.left) / ptToPx,
+      y: (e.clientY - rect.top) / ptToPx,
+    };
+  }
+
+  function onCenterPointerDown(e: PointerEvent) {
+    const p = toPtSpace(e);
+    drag = { kind: 'move', offset: { x: p.x - proto.center.x, y: p.y - proto.center.y } };
+    (e.target as Element).setPointerCapture(e.pointerId);
+    e.stopPropagation();
+  }
+
+  function onRimPointerDown(e: PointerEvent) {
+    const p = toPtSpace(e);
+    drag = { kind: 'rotate', startPointer: p, startRotation: proto.rotation };
+    (e.target as Element).setPointerCapture(e.pointerId);
+    e.stopPropagation();
+  }
+
+  function onPointerMove(e: PointerEvent) {
+    const p = toPtSpace(e);
+    cursorAngle = angleAtPoint(proto, p);
+    if (!drag) return;
+    if (drag.kind === 'move') {
+      overlays.moveProtractor({
+        x: p.x - drag.offset.x,
+        y: p.y - drag.offset.y,
+      });
+    } else {
+      const startAngle = Math.atan2(
+        drag.startPointer.y - proto.center.y,
+        drag.startPointer.x - proto.center.x,
+      );
+      const currentAngle = Math.atan2(p.y - proto.center.y, p.x - proto.center.x);
+      const delta = ((currentAngle - startAngle) * 180) / Math.PI;
+      overlays.rotateProtractor(drag.startRotation + delta);
+    }
+  }
+
+  function onPointerUp() {
+    drag = null;
+  }
+
+  const cx = $derived(proto.center.x * ptToPx);
+  const cy = $derived(proto.center.y * ptToPx);
+  const r = $derived(proto.radius * ptToPx);
+  const arcPath = $derived.by(() => {
+    const start = {
+      x: cx + r * Math.cos((proto.rotation * Math.PI) / 180),
+      y: cy + r * Math.sin((proto.rotation * Math.PI) / 180),
+    };
+    const endRad = ((proto.rotation + (proto.shape === 'semi' ? 180 : 360)) * Math.PI) / 180;
+    const end = { x: cx + r * Math.cos(endRad), y: cy + r * Math.sin(endRad) };
+    if (proto.shape === 'full') {
+      const mid = {
+        x: cx - r * Math.cos((proto.rotation * Math.PI) / 180),
+        y: cy - r * Math.sin((proto.rotation * Math.PI) / 180),
+      };
+      return `M ${start.x} ${start.y} A ${r} ${r} 0 1 1 ${mid.x} ${mid.y} A ${r} ${r} 0 1 1 ${start.x} ${start.y} Z`;
+    }
+    return `M ${start.x} ${start.y} A ${r} ${r} 0 0 1 ${end.x} ${end.y} Z`;
+  });
+</script>
+
+<svg
+  bind:this={svgEl}
+  class="protractor"
+  {width}
+  {height}
+  role="application"
+  aria-label="Protractor overlay"
+  onpointermove={onPointerMove}
+  onpointerup={onPointerUp}
+  onpointercancel={onPointerUp}
+>
+  <path d={arcPath} fill="rgba(255, 220, 80, 0.12)" stroke="#b38600" stroke-width="1" />
+
+  {#each ticks as t (t.angle)}
+    <line
+      x1={t.outer.x * ptToPx}
+      y1={t.outer.y * ptToPx}
+      x2={t.inner.x * ptToPx}
+      y2={t.inner.y * ptToPx}
+      stroke="#b38600"
+      stroke-width={t.label ? 1.2 : 0.6}
+    />
+    {#if t.label}
+      <text
+        x={(t.outer.x * 0.78 + proto.center.x * 0.22) * ptToPx}
+        y={(t.outer.y * 0.78 + proto.center.y * 0.22) * ptToPx}
+        font-size="10"
+        fill="#8a6600"
+        text-anchor="middle"
+        dominant-baseline="middle"
+      >
+        {t.label}
+      </text>
+    {/if}
+  {/each}
+
+  <circle
+    class="rim"
+    {cx}
+    {cy}
+    {r}
+    fill="transparent"
+    stroke="transparent"
+    role="slider"
+    tabindex="0"
+    aria-label="Rotate protractor"
+    aria-valuenow={Math.round(proto.rotation)}
+    onpointerdown={onRimPointerDown}
+  />
+  <circle
+    class="center"
+    {cx}
+    {cy}
+    r={8}
+    fill="#b38600"
+    stroke="#fff"
+    stroke-width="1.5"
+    role="button"
+    tabindex="0"
+    aria-label="Move protractor"
+    onpointerdown={onCenterPointerDown}
+  />
+
+  {#if cursorAngle !== null}
+    <text x={cx} y={cy - 14} font-size="11" fill="#333" text-anchor="middle">
+      {cursorAngle.toFixed(1)}°
+    </text>
+  {/if}
+</svg>
+
+<style>
+  .protractor {
+    position: absolute;
+    inset: 0;
+    pointer-events: auto;
+  }
+  .rim {
+    pointer-events: stroke;
+    stroke-width: 16;
+    cursor: grab;
+  }
+  .center {
+    cursor: grab;
+  }
+</style>

--- a/src/lib/canvas/RulerOverlay.svelte
+++ b/src/lib/canvas/RulerOverlay.svelte
@@ -49,12 +49,11 @@
     if (drag.kind === 'move') {
       overlays.moveRuler({ x: p.x - drag.offset.x, y: p.y - drag.offset.y });
     } else {
-      const startAngle = Math.atan2(
-        drag.startPointer.y - ruler.from.y,
-        drag.startPointer.x - ruler.from.x,
-      );
-      const currentAngle = Math.atan2(p.y - ruler.from.y, p.x - ruler.from.x);
-      const delta = ((currentAngle - startAngle) * 180) / Math.PI;
+      const ax = drag.startPointer.x - ruler.from.x;
+      const ay = drag.startPointer.y - ruler.from.y;
+      const bx = p.x - ruler.from.x;
+      const by = p.y - ruler.from.y;
+      const delta = (Math.atan2(ax * by - ay * bx, ax * bx + ay * by) * 180) / Math.PI;
       overlays.rotateRuler(drag.startRotation + delta);
     }
   }
@@ -94,22 +93,29 @@
       aria-label="Move ruler"
       onpointerdown={onBodyPointerDown}
     />
-    {#each ticks as t (t.along)}
-      <line
-        x1={t.along * ptToPx}
-        y1={0}
-        x2={t.along * ptToPx}
-        y2={(t.isMajor ? 10 : 4) * (ptToPx / 72) * 72 * 0.5}
-        stroke="#1e88e5"
-        stroke-width={t.isMajor ? 1.2 : 0.6}
-      />
-      {#if t.label}
-        <text x={t.along * ptToPx} y={18} font-size="9" fill="#1565c0" text-anchor="middle">
-          {t.label}
-        </text>
-      {/if}
-    {/each}
   </g>
+
+  {#each ticks as t (t.along)}
+    <line
+      x1={t.root.x * ptToPx}
+      y1={t.root.y * ptToPx}
+      x2={t.tip.x * ptToPx}
+      y2={t.tip.y * ptToPx}
+      stroke="#1e88e5"
+      stroke-width={t.isMajor ? 1.2 : 0.6}
+    />
+    {#if t.label}
+      <text
+        x={t.tip.x * ptToPx}
+        y={t.tip.y * ptToPx + 10}
+        font-size="9"
+        fill="#1565c0"
+        text-anchor="middle"
+      >
+        {t.label}
+      </text>
+    {/if}
+  {/each}
 
   <circle
     class="end-handle"

--- a/src/lib/canvas/RulerOverlay.svelte
+++ b/src/lib/canvas/RulerOverlay.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+  import { overlays } from '$lib/store/overlays';
+  import { rulerEnd, rulerTicks, type Vec2 } from '$lib/geometry';
+
+  interface Props {
+    ptToPx: number;
+    width: number;
+    height: number;
+  }
+
+  let { ptToPx, width, height }: Props = $props();
+
+  const ruler = $derived($overlays.ruler);
+  const ticks = $derived(rulerTicks(ruler));
+  const end = $derived(rulerEnd(ruler));
+
+  let svgEl: SVGSVGElement | undefined = $state();
+
+  type Drag =
+    | { kind: 'move'; offset: Vec2 }
+    | { kind: 'rotate'; startPointer: Vec2; startRotation: number };
+  let drag: Drag | null = null;
+
+  function toPtSpace(e: PointerEvent): Vec2 {
+    const rect = svgEl!.getBoundingClientRect();
+    return {
+      x: (e.clientX - rect.left) / ptToPx,
+      y: (e.clientY - rect.top) / ptToPx,
+    };
+  }
+
+  function onBodyPointerDown(e: PointerEvent) {
+    const p = toPtSpace(e);
+    drag = { kind: 'move', offset: { x: p.x - ruler.from.x, y: p.y - ruler.from.y } };
+    (e.target as Element).setPointerCapture(e.pointerId);
+    e.stopPropagation();
+  }
+
+  function onEndPointerDown(e: PointerEvent) {
+    const p = toPtSpace(e);
+    drag = { kind: 'rotate', startPointer: p, startRotation: ruler.rotation };
+    (e.target as Element).setPointerCapture(e.pointerId);
+    e.stopPropagation();
+  }
+
+  function onPointerMove(e: PointerEvent) {
+    if (!drag) return;
+    const p = toPtSpace(e);
+    if (drag.kind === 'move') {
+      overlays.moveRuler({ x: p.x - drag.offset.x, y: p.y - drag.offset.y });
+    } else {
+      const startAngle = Math.atan2(
+        drag.startPointer.y - ruler.from.y,
+        drag.startPointer.x - ruler.from.x,
+      );
+      const currentAngle = Math.atan2(p.y - ruler.from.y, p.x - ruler.from.x);
+      const delta = ((currentAngle - startAngle) * 180) / Math.PI;
+      overlays.rotateRuler(drag.startRotation + delta);
+    }
+  }
+
+  function onPointerUp() {
+    drag = null;
+  }
+
+  const bodyHeight = 24;
+</script>
+
+<svg
+  bind:this={svgEl}
+  class="ruler"
+  {width}
+  {height}
+  role="application"
+  aria-label="Ruler overlay"
+  onpointermove={onPointerMove}
+  onpointerup={onPointerUp}
+  onpointercancel={onPointerUp}
+>
+  <g
+    transform="translate({ruler.from.x * ptToPx} {ruler.from.y * ptToPx}) rotate({ruler.rotation})"
+  >
+    <rect
+      class="body"
+      x="0"
+      y="0"
+      width={ruler.length * ptToPx}
+      height={bodyHeight}
+      fill="rgba(100, 180, 255, 0.15)"
+      stroke="#1e88e5"
+      stroke-width="1"
+      role="button"
+      tabindex="0"
+      aria-label="Move ruler"
+      onpointerdown={onBodyPointerDown}
+    />
+    {#each ticks as t (t.along)}
+      <line
+        x1={t.along * ptToPx}
+        y1={0}
+        x2={t.along * ptToPx}
+        y2={(t.isMajor ? 10 : 4) * (ptToPx / 72) * 72 * 0.5}
+        stroke="#1e88e5"
+        stroke-width={t.isMajor ? 1.2 : 0.6}
+      />
+      {#if t.label}
+        <text x={t.along * ptToPx} y={18} font-size="9" fill="#1565c0" text-anchor="middle">
+          {t.label}
+        </text>
+      {/if}
+    {/each}
+  </g>
+
+  <circle
+    class="end-handle"
+    cx={end.x * ptToPx}
+    cy={end.y * ptToPx}
+    r={6}
+    fill="#1e88e5"
+    stroke="#fff"
+    stroke-width="1.5"
+    role="slider"
+    tabindex="0"
+    aria-label="Rotate ruler"
+    aria-valuenow={Math.round(ruler.rotation)}
+    onpointerdown={onEndPointerDown}
+  />
+</svg>
+
+<style>
+  .ruler {
+    position: absolute;
+    inset: 0;
+    pointer-events: auto;
+  }
+  .body {
+    cursor: grab;
+  }
+  .end-handle {
+    cursor: grab;
+  }
+</style>

--- a/src/lib/canvas/index.ts
+++ b/src/lib/canvas/index.ts
@@ -11,3 +11,5 @@ export { default as ShapeLiveLayer } from './ShapeLiveLayer.svelte';
 export { default as NumberLineEditor } from './NumberLineEditor.svelte';
 export { default as LaserLayer } from './LaserLayer.svelte';
 export { default as TempInkLayer } from './TempInkLayer.svelte';
+export { default as ProtractorOverlay } from './ProtractorOverlay.svelte';
+export { default as RulerOverlay } from './RulerOverlay.svelte';

--- a/src/lib/geometry/index.ts
+++ b/src/lib/geometry/index.ts
@@ -1,0 +1,19 @@
+export { rotate, translate, distance, angleDeg, normalizeDeg, type Vec2 } from './transform';
+export {
+  protractorTicks,
+  angleAtPoint,
+  type ProtractorState,
+  type ProtractorTick,
+  type TickOptions,
+} from './protractor';
+export {
+  rulerTicks,
+  rulerEnd,
+  ptPerUnit,
+  PT_PER_INCH,
+  PT_PER_CM,
+  type RulerState,
+  type RulerTick,
+  type RulerTickOptions,
+  type RulerUnit,
+} from './ruler';

--- a/src/lib/geometry/protractor.ts
+++ b/src/lib/geometry/protractor.ts
@@ -1,0 +1,80 @@
+import { rotate, type Vec2 } from './transform';
+
+export interface ProtractorState {
+  center: Vec2;
+  radius: number;
+  /** Rotation in degrees, CCW from the protractor's 0° axis to screen-right. */
+  rotation: number;
+  /** 'semi' = 180° half-disc, 'full' = 360° disc. */
+  shape: 'semi' | 'full';
+}
+
+export interface ProtractorTick {
+  angle: number;
+  outer: Vec2;
+  inner: Vec2;
+  label: string | null;
+}
+
+export interface TickOptions {
+  /** Degrees between minor ticks. Default 1. */
+  minor: number;
+  /** Degrees between major (labelled) ticks. Default 10. */
+  major: number;
+  /** Inner radius factor for minor ticks (0..1). Default 0.92. */
+  minorInner: number;
+  /** Inner radius factor for major ticks (0..1). Default 0.84. */
+  majorInner: number;
+}
+
+const DEFAULT_OPTS: TickOptions = {
+  minor: 1,
+  major: 10,
+  minorInner: 0.92,
+  majorInner: 0.84,
+};
+
+export function protractorTicks(
+  state: ProtractorState,
+  opts: Partial<TickOptions> = {},
+): ProtractorTick[] {
+  const o = { ...DEFAULT_OPTS, ...opts };
+  const sweep = state.shape === 'semi' ? 180 : 360;
+  const ticks: ProtractorTick[] = [];
+  for (let a = 0; a <= sweep; a += o.minor) {
+    const isMajor = a % o.major === 0;
+    const innerR = state.radius * (isMajor ? o.majorInner : o.minorInner);
+    const outer = rotate(
+      { x: state.center.x + state.radius, y: state.center.y },
+      a + state.rotation,
+      state.center,
+    );
+    const inner = rotate(
+      { x: state.center.x + innerR, y: state.center.y },
+      a + state.rotation,
+      state.center,
+    );
+    ticks.push({
+      angle: a,
+      outer,
+      inner,
+      label: isMajor ? String(a) : null,
+    });
+    if (a === sweep && state.shape === 'full') break;
+  }
+  return ticks;
+}
+
+/**
+ * Angle at the protractor's scale given a screen point, in [0, 360). The
+ * caller is responsible for hiding readings outside the visible sweep on a
+ * semicircular protractor.
+ */
+export function angleAtPoint(state: ProtractorState, p: Vec2): number {
+  const dx = p.x - state.center.x;
+  const dy = p.y - state.center.y;
+  const raw = (Math.atan2(dy, dx) * 180) / Math.PI - state.rotation;
+  let a = raw % 360;
+  if (a < 0) a += 360;
+  return a;
+}

--- a/src/lib/geometry/ruler.ts
+++ b/src/lib/geometry/ruler.ts
@@ -52,13 +52,13 @@ function defaultOptsFor(unit: RulerUnit): RulerTickOptions {
 export function rulerTicks(state: RulerState, opts: Partial<RulerTickOptions> = {}): RulerTick[] {
   const base = defaultOptsFor(state.unit);
   const o = { ...base, ...opts };
-  const pxPerUnit = ptPerUnit(state.unit);
-  const totalUnits = state.length / pxPerUnit;
+  const ptPerUnitValue = ptPerUnit(state.unit);
+  const totalUnits = state.length / ptPerUnitValue;
   const ticks: RulerTick[] = [];
   const majorStep = Math.round(o.major / o.minor);
   const count = Math.floor(totalUnits / o.minor);
   for (let i = 0; i <= count; i += 1) {
-    const along = i * o.minor * pxPerUnit;
+    const along = i * o.minor * ptPerUnitValue;
     const isMajor = majorStep > 0 && i % majorStep === 0;
     const len = isMajor ? o.majorLen : o.minorLen;
     const root = rotate({ x: state.from.x + along, y: state.from.y }, state.rotation, state.from);
@@ -80,7 +80,6 @@ export function rulerTicks(state: RulerState, opts: Partial<RulerTickOptions> = 
 
 function formatMajorLabel(valueInUnit: number, unit: RulerUnit): string {
   if (unit === 'pt') return String(Math.round(valueInUnit));
-  if (unit === 'cm') return `${Math.round(valueInUnit / 10)}`;
   return `${Math.round(valueInUnit)}`;
 }
 

--- a/src/lib/geometry/ruler.ts
+++ b/src/lib/geometry/ruler.ts
@@ -1,0 +1,90 @@
+import { rotate, type Vec2 } from './transform';
+
+export type RulerUnit = 'pt' | 'in' | 'cm';
+
+export interface RulerState {
+  from: Vec2;
+  /** Rotation in degrees from horizontal, CCW. */
+  rotation: number;
+  /** Ruler length in PDF points. */
+  length: number;
+  unit: RulerUnit;
+}
+
+export interface RulerTick {
+  along: number;
+  isMajor: boolean;
+  label: string | null;
+  root: Vec2;
+  tip: Vec2;
+}
+
+export interface RulerTickOptions {
+  /** Minor tick spacing in the unit. Default unit-specific. */
+  minor: number;
+  /** Major (labelled) tick spacing in the unit. Default unit-specific. */
+  major: number;
+  /** Minor tick length in PDF points. Default 4. */
+  minorLen: number;
+  /** Major tick length in PDF points. Default 10. */
+  majorLen: number;
+}
+
+export const PT_PER_INCH = 72;
+export const PT_PER_CM = 72 / 2.54;
+
+export function ptPerUnit(unit: RulerUnit): number {
+  if (unit === 'in') return PT_PER_INCH;
+  if (unit === 'cm') return PT_PER_CM;
+  return 1;
+}
+
+function defaultOptsFor(unit: RulerUnit): RulerTickOptions {
+  if (unit === 'in') return { minor: 1 / 16, major: 1, minorLen: 4, majorLen: 10 };
+  if (unit === 'cm') return { minor: 1, major: 10, minorLen: 4, majorLen: 10 };
+  return { minor: 10, major: 50, minorLen: 4, majorLen: 10 };
+}
+
+/**
+ * Evenly-spaced ruler ticks along the long edge. Returns root/tip positions in
+ * PDF-space coordinates after applying the ruler's rotation around `from`.
+ */
+export function rulerTicks(state: RulerState, opts: Partial<RulerTickOptions> = {}): RulerTick[] {
+  const base = defaultOptsFor(state.unit);
+  const o = { ...base, ...opts };
+  const pxPerUnit = ptPerUnit(state.unit);
+  const totalUnits = state.length / pxPerUnit;
+  const ticks: RulerTick[] = [];
+  const majorStep = Math.round(o.major / o.minor);
+  const count = Math.floor(totalUnits / o.minor);
+  for (let i = 0; i <= count; i += 1) {
+    const along = i * o.minor * pxPerUnit;
+    const isMajor = majorStep > 0 && i % majorStep === 0;
+    const len = isMajor ? o.majorLen : o.minorLen;
+    const root = rotate({ x: state.from.x + along, y: state.from.y }, state.rotation, state.from);
+    const tip = rotate(
+      { x: state.from.x + along, y: state.from.y + len },
+      state.rotation,
+      state.from,
+    );
+    ticks.push({
+      along,
+      isMajor,
+      label: isMajor ? formatMajorLabel(i * o.minor, state.unit) : null,
+      root,
+      tip,
+    });
+  }
+  return ticks;
+}
+
+function formatMajorLabel(valueInUnit: number, unit: RulerUnit): string {
+  if (unit === 'pt') return String(Math.round(valueInUnit));
+  if (unit === 'cm') return `${Math.round(valueInUnit / 10)}`;
+  return `${Math.round(valueInUnit)}`;
+}
+
+/** End point of the ruler in PDF-space after rotation. */
+export function rulerEnd(state: RulerState): Vec2 {
+  return rotate({ x: state.from.x + state.length, y: state.from.y }, state.rotation, state.from);
+}

--- a/src/lib/geometry/transform.ts
+++ b/src/lib/geometry/transform.ts
@@ -27,7 +27,7 @@ export function distance(a: Vec2, b: Vec2): number {
 
 /**
  * Screen-space angle in degrees from `origin` to `p`, measured CCW from the
- * positive x-axis. Result is in (-180, 180].
+ * positive x-axis. Result is in [-180, 180].
  */
 export function angleDeg(origin: Vec2, p: Vec2): number {
   return (Math.atan2(p.y - origin.y, p.x - origin.x) * 180) / Math.PI;

--- a/src/lib/geometry/transform.ts
+++ b/src/lib/geometry/transform.ts
@@ -1,0 +1,40 @@
+export interface Vec2 {
+  x: number;
+  y: number;
+}
+
+export function rotate(p: Vec2, angleDeg: number, origin: Vec2 = { x: 0, y: 0 }): Vec2 {
+  const r = (angleDeg * Math.PI) / 180;
+  const cos = Math.cos(r);
+  const sin = Math.sin(r);
+  const dx = p.x - origin.x;
+  const dy = p.y - origin.y;
+  return {
+    x: origin.x + dx * cos - dy * sin,
+    y: origin.y + dx * sin + dy * cos,
+  };
+}
+
+export function translate(p: Vec2, dx: number, dy: number): Vec2 {
+  return { x: p.x + dx, y: p.y + dy };
+}
+
+export function distance(a: Vec2, b: Vec2): number {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
+/**
+ * Screen-space angle in degrees from `origin` to `p`, measured CCW from the
+ * positive x-axis. Result is in (-180, 180].
+ */
+export function angleDeg(origin: Vec2, p: Vec2): number {
+  return (Math.atan2(p.y - origin.y, p.x - origin.x) * 180) / Math.PI;
+}
+
+export function normalizeDeg(deg: number): number {
+  let d = deg % 360;
+  if (d < 0) d += 360;
+  return d;
+}

--- a/src/lib/sidebar/Sidebar.svelte
+++ b/src/lib/sidebar/Sidebar.svelte
@@ -31,6 +31,8 @@
     { id: 'ellipse', label: 'Ellipse', shortcut: 'O', icon: '◯' },
     { id: 'numberline', label: 'Number line', shortcut: 'N', icon: '↔' },
     { id: 'graph', label: 'Graph', shortcut: 'G', icon: '📈' },
+    { id: 'protractor', label: 'Protractor', shortcut: 'A', icon: '◠' },
+    { id: 'ruler', label: 'Ruler', shortcut: 'U', icon: '📏' },
     { id: 'laser', label: 'Laser', shortcut: 'X', icon: '🔴' },
     { id: 'temp-ink', label: 'Temp Ink', shortcut: 'Y', icon: '💧' },
   ];

--- a/src/lib/store/overlays.ts
+++ b/src/lib/store/overlays.ts
@@ -1,0 +1,66 @@
+import { writable } from 'svelte/store';
+import type { ProtractorState } from '$lib/geometry/protractor';
+import type { RulerState } from '$lib/geometry/ruler';
+
+export interface OverlaysState {
+  protractor: ProtractorState;
+  ruler: RulerState;
+}
+
+function initial(): OverlaysState {
+  return {
+    protractor: {
+      center: { x: 200, y: 200 },
+      radius: 140,
+      rotation: 0,
+      shape: 'semi',
+    },
+    ruler: {
+      from: { x: 60, y: 60 },
+      rotation: 0,
+      length: 360,
+      unit: 'cm',
+    },
+  };
+}
+
+function createOverlaysStore() {
+  const store = writable<OverlaysState>(initial());
+  const { subscribe, update, set } = store;
+
+  return {
+    subscribe,
+    set,
+    reset: () => set(initial()),
+
+    moveProtractor(center: ProtractorState['center']) {
+      update((s) => ({ ...s, protractor: { ...s.protractor, center } }));
+    },
+    rotateProtractor(rotation: number) {
+      update((s) => ({ ...s, protractor: { ...s.protractor, rotation } }));
+    },
+    setProtractorShape(shape: ProtractorState['shape']) {
+      update((s) => ({ ...s, protractor: { ...s.protractor, shape } }));
+    },
+    setProtractorRadius(radius: number) {
+      const clamped = Math.max(40, Math.min(600, radius));
+      update((s) => ({ ...s, protractor: { ...s.protractor, radius: clamped } }));
+    },
+
+    moveRuler(from: RulerState['from']) {
+      update((s) => ({ ...s, ruler: { ...s.ruler, from } }));
+    },
+    rotateRuler(rotation: number) {
+      update((s) => ({ ...s, ruler: { ...s.ruler, rotation } }));
+    },
+    setRulerLength(length: number) {
+      const clamped = Math.max(60, Math.min(2400, length));
+      update((s) => ({ ...s, ruler: { ...s.ruler, length: clamped } }));
+    },
+    setRulerUnit(unit: RulerState['unit']) {
+      update((s) => ({ ...s, ruler: { ...s.ruler, unit } }));
+    },
+  };
+}
+
+export const overlays = createOverlaysStore();

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -22,7 +22,9 @@ export type ToolKind =
   | 'select'
   | 'pan'
   | 'laser'
-  | 'temp-ink';
+  | 'temp-ink'
+  | 'protractor'
+  | 'ruler';
 
 export type ShapeKind = 'rect' | 'ellipse';
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,6 +5,8 @@
     GraphLayer,
     NumberLineEditor,
     PdfLayer,
+    ProtractorOverlay,
+    RulerOverlay,
     TextLayer,
     TextEditor,
   } from '$lib/canvas';
@@ -385,6 +387,16 @@
               />
             </div>
           {/if}
+          {#if sidebarState.activeTool === 'protractor'}
+            <div class="overlay-slot">
+              <ProtractorOverlay ptToPx={size.ptToPx} width={size.width} height={size.height} />
+            </div>
+          {/if}
+          {#if sidebarState.activeTool === 'ruler'}
+            <div class="overlay-slot">
+              <RulerOverlay ptToPx={size.ptToPx} width={size.width} height={size.height} />
+            </div>
+          {/if}
         </div>
       {:else}
         <div class="empty">
@@ -507,6 +519,15 @@
   .graph-editor-slot {
     position: absolute;
     z-index: 20;
+  }
+  .overlay-slot {
+    position: absolute;
+    inset: 0;
+    z-index: 15;
+    pointer-events: none;
+  }
+  .overlay-slot :global(svg) {
+    pointer-events: auto;
   }
   .text-slot {
     position: absolute;

--- a/tests/protractor.test.ts
+++ b/tests/protractor.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { angleAtPoint, protractorTicks, type ProtractorState } from '$lib/geometry/protractor';
+
+const baseState: ProtractorState = {
+  center: { x: 0, y: 0 },
+  radius: 100,
+  rotation: 0,
+  shape: 'semi',
+};
+
+describe('protractor ticks', () => {
+  it('semi protractor has 181 minor ticks at 1° default step', () => {
+    const ticks = protractorTicks(baseState);
+    expect(ticks.length).toBe(181);
+  });
+
+  it('full protractor has 361 minor ticks', () => {
+    const ticks = protractorTicks({ ...baseState, shape: 'full' });
+    expect(ticks.length).toBe(361);
+  });
+
+  it('major ticks carry labels every 10°', () => {
+    const ticks = protractorTicks(baseState);
+    const labelled = ticks.filter((t) => t.label !== null);
+    expect(labelled.length).toBe(19);
+    expect(labelled[0].label).toBe('0');
+    expect(labelled.at(-1)?.label).toBe('180');
+  });
+
+  it('0° tick sits on +x at outer radius', () => {
+    const ticks = protractorTicks(baseState);
+    expect(ticks[0].outer.x).toBeCloseTo(100);
+    expect(ticks[0].outer.y).toBeCloseTo(0);
+  });
+
+  it('rotation shifts tick positions', () => {
+    const ticks = protractorTicks({ ...baseState, rotation: 90 });
+    expect(ticks[0].outer.x).toBeCloseTo(0);
+    expect(ticks[0].outer.y).toBeCloseTo(100);
+  });
+});
+
+describe('angleAtPoint', () => {
+  it('returns 0 along +x from center', () => {
+    expect(angleAtPoint(baseState, { x: 10, y: 0 })).toBeCloseTo(0);
+  });
+
+  it('returns 90 along +y', () => {
+    expect(angleAtPoint(baseState, { x: 0, y: 10 })).toBeCloseTo(90);
+  });
+
+  it('accounts for rotation', () => {
+    const rotated: ProtractorState = { ...baseState, rotation: 45 };
+    expect(angleAtPoint(rotated, { x: 10, y: 0 })).toBeCloseTo(315);
+  });
+
+  it('always returns a value in [0, 360)', () => {
+    const a = angleAtPoint(baseState, { x: -10, y: -10 });
+    expect(a).toBeGreaterThanOrEqual(0);
+    expect(a).toBeLessThan(360);
+  });
+});

--- a/tests/ruler.test.ts
+++ b/tests/ruler.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PT_PER_CM,
+  PT_PER_INCH,
+  ptPerUnit,
+  rulerEnd,
+  rulerTicks,
+  type RulerState,
+} from '$lib/geometry/ruler';
+
+const base: RulerState = {
+  from: { x: 0, y: 0 },
+  rotation: 0,
+  length: PT_PER_CM * 10,
+  unit: 'cm',
+};
+
+describe('ptPerUnit', () => {
+  it('knows inches and centimetres', () => {
+    expect(ptPerUnit('pt')).toBe(1);
+    expect(ptPerUnit('in')).toBe(PT_PER_INCH);
+    expect(ptPerUnit('cm')).toBeCloseTo(PT_PER_CM);
+  });
+});
+
+describe('rulerTicks', () => {
+  it('emits 11 cm ticks (0..10 inclusive) for a 10cm ruler', () => {
+    const ticks = rulerTicks(base);
+    expect(ticks.length).toBe(11);
+  });
+
+  it('marks every 10cm tick as major by default', () => {
+    const ticks = rulerTicks(base);
+    const majors = ticks.filter((t) => t.isMajor);
+    expect(majors.length).toBe(2);
+    expect(majors[0].along).toBe(0);
+  });
+
+  it('labels major ticks with the cm count', () => {
+    const ticks = rulerTicks(base);
+    const majors = ticks.filter((t) => t.isMajor);
+    expect(majors[0].label).toBe('0');
+    expect(majors.at(-1)?.label).toBe('1');
+  });
+
+  it('rotation shifts tick root positions', () => {
+    const ticks = rulerTicks({ ...base, rotation: 90 });
+    expect(ticks[1].root.x).toBeCloseTo(0);
+    expect(ticks[1].root.y).toBeCloseTo(PT_PER_CM);
+  });
+
+  it('inch ruler emits 16 minor ticks per inch', () => {
+    const inchRuler: RulerState = {
+      from: { x: 0, y: 0 },
+      rotation: 0,
+      length: PT_PER_INCH * 2,
+      unit: 'in',
+    };
+    const ticks = rulerTicks(inchRuler);
+    expect(ticks.length).toBe(33);
+    const majors = ticks.filter((t) => t.isMajor);
+    expect(majors.length).toBe(3);
+  });
+});
+
+describe('rulerEnd', () => {
+  it('returns from + length along +x for zero rotation', () => {
+    const end = rulerEnd({ from: { x: 5, y: 7 }, rotation: 0, length: 100, unit: 'pt' });
+    expect(end).toEqual({ x: 105, y: 7 });
+  });
+
+  it('applies rotation around from', () => {
+    const end = rulerEnd({ from: { x: 0, y: 0 }, rotation: 90, length: 100, unit: 'pt' });
+    expect(end.x).toBeCloseTo(0);
+    expect(end.y).toBeCloseTo(100);
+  });
+});

--- a/tests/ruler.test.ts
+++ b/tests/ruler.test.ts
@@ -40,7 +40,7 @@ describe('rulerTicks', () => {
     const ticks = rulerTicks(base);
     const majors = ticks.filter((t) => t.isMajor);
     expect(majors[0].label).toBe('0');
-    expect(majors.at(-1)?.label).toBe('1');
+    expect(majors.at(-1)?.label).toBe('10');
   });
 
   it('rotation shifts tick root positions', () => {

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { angleDeg, distance, normalizeDeg, rotate, translate } from '$lib/geometry/transform';
+
+describe('transform', () => {
+  it('rotates a point 90° CCW around origin', () => {
+    const p = rotate({ x: 1, y: 0 }, 90);
+    expect(p.x).toBeCloseTo(0);
+    expect(p.y).toBeCloseTo(1);
+  });
+
+  it('rotates around non-origin center', () => {
+    const p = rotate({ x: 2, y: 1 }, 180, { x: 1, y: 1 });
+    expect(p.x).toBeCloseTo(0);
+    expect(p.y).toBeCloseTo(1);
+  });
+
+  it('translate shifts coordinates', () => {
+    const p = translate({ x: 1, y: 2 }, 3, -4);
+    expect(p).toEqual({ x: 4, y: -2 });
+  });
+
+  it('distance is Euclidean', () => {
+    expect(distance({ x: 0, y: 0 }, { x: 3, y: 4 })).toBe(5);
+  });
+
+  it('angleDeg returns 0 for +x, 90 for +y', () => {
+    expect(angleDeg({ x: 0, y: 0 }, { x: 1, y: 0 })).toBe(0);
+    expect(angleDeg({ x: 0, y: 0 }, { x: 0, y: 1 })).toBe(90);
+    expect(angleDeg({ x: 0, y: 0 }, { x: -1, y: 0 })).toBe(180);
+  });
+
+  it('normalizeDeg wraps into [0, 360)', () => {
+    expect(normalizeDeg(0)).toBe(0);
+    expect(normalizeDeg(360)).toBe(0);
+    expect(normalizeDeg(-10)).toBe(350);
+    expect(normalizeDeg(725)).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary
Adds protractor and ruler overlays as new transient tools. No committed objects yet — overlays are purely UI so the scope stays tight and the object/history pipeline is untouched.

## What
- **Tools**: `protractor` (`A`) and `ruler` (`U`) added to `ToolKind`, sidebar, and shortcuts.
- **Geometry helpers** in `src/lib/geometry/`:
  - `transform.ts` — rotate/translate/angle/distance/normalize helpers.
  - `protractor.ts` — semi/full protractor tick generation + cursor-angle readout.
  - `ruler.ts` — tick generation in `pt`/`in`/`cm` with PDF-point conversion.
- **Overlay store** (`src/lib/store/overlays.ts`) tracks center/rotation/radius for the protractor and from/rotation/length/unit for the ruler.
- **Components**: `ProtractorOverlay.svelte` (SVG, draggable center + rotatable rim, live angle readout) and `RulerOverlay.svelte` (SVG, draggable body + rotatable end handle).
- **Wiring**: `+page.svelte` shows each overlay only while its tool is active, above the canvas stack.

## Why
Math teaching needs classroom-grade geometry overlays. Keeping them transient (non-committed) for this PR lets us land the visual + interaction layer without expanding the object model or undo history yet.

## Testing
- `pnpm lint` clean, `pnpm test` 161/161 pass.
- 24 new tests cover rotation, angle-at-point math, and tick generation in all three ruler units.

## Follow-ups
- Angle-mark objects (click-drag from vertex to commit an arc + degree label).
- Stroke-to-ruler-edge snapping while ruler is active.
- Protractor shape toggle UI (semi ↔ full) in the sidebar.