### PR TITLE
feat(page-ops): reorder, duplicate, and delete pages

### DIFF
--- a/src/lib/sidebar/ThumbnailStrip.svelte
+++ b/src/lib/sidebar/ThumbnailStrip.svelte
@@ -6,28 +6,36 @@
     pages: Page[];
     currentIndex: number;
     onpick: (index: number) => void;
+    onmove?: (from: number, to: number) => void;
+    onduplicate?: (index: number) => void;
+    ondelete?: (index: number) => void;
     maxWidth?: number;
   }
 
-  const { pages, currentIndex, onpick, maxWidth = 140 }: Props = $props();
+  const {
+    pages,
+    currentIndex,
+    onpick,
+    onmove,
+    onduplicate,
+    ondelete,
+    maxWidth = 140,
+  }: Props = $props();
 
-  function pick(i: number): void {
-    onpick(i);
-  }
+  const canDelete = $derived(pages.length > 1);
 </script>
 
 <aside class="strip" aria-label="Page thumbnails">
   <ul>
     {#each pages as page, i (page.pageIndex)}
       {@const size = thumbnailSize(page.width, page.height, maxWidth)}
-      <li>
+      <li class="row" class:active={i === currentIndex}>
         <button
           type="button"
           class="thumb"
-          class:active={i === currentIndex}
           aria-label={`Go to page ${i + 1}`}
           aria-current={i === currentIndex ? 'page' : undefined}
-          onclick={() => pick(i)}
+          onclick={() => onpick(i)}
         >
           <span
             class="preview"
@@ -36,6 +44,44 @@
           ></span>
           <span class="label">{i + 1}</span>
         </button>
+        <div class="actions" role="toolbar" aria-label={`Page ${i + 1} actions`}>
+          <button
+            type="button"
+            class="action"
+            aria-label={`Move page ${i + 1} up`}
+            disabled={!onmove || i === 0}
+            onclick={() => onmove?.(i, i - 1)}
+          >
+            ↑
+          </button>
+          <button
+            type="button"
+            class="action"
+            aria-label={`Move page ${i + 1} down`}
+            disabled={!onmove || i === pages.length - 1}
+            onclick={() => onmove?.(i, i + 1)}
+          >
+            ↓
+          </button>
+          <button
+            type="button"
+            class="action"
+            aria-label={`Duplicate page ${i + 1}`}
+            disabled={!onduplicate}
+            onclick={() => onduplicate?.(i)}
+          >
+            ⧉
+          </button>
+          <button
+            type="button"
+            class="action danger"
+            aria-label={`Delete page ${i + 1}`}
+            disabled={!ondelete || !canDelete}
+            onclick={() => ondelete?.(i)}
+          >
+            ✕
+          </button>
+        </div>
       </li>
     {/each}
   </ul>
@@ -59,22 +105,31 @@
     gap: 8px;
     align-items: center;
   }
-  .thumb {
-    background: transparent;
+  .row {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
     border: 2px solid transparent;
     border-radius: 4px;
     padding: 4px;
+  }
+  .row:hover,
+  .row:focus-within {
+    border-color: #444;
+  }
+  .row.active {
+    border-color: #4a9eff;
+  }
+  .thumb {
+    background: transparent;
+    border: none;
     cursor: pointer;
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: 4px;
-  }
-  .thumb:hover {
-    border-color: #444;
-  }
-  .thumb.active {
-    border-color: #4a9eff;
+    padding: 0;
   }
   .preview {
     display: block;
@@ -88,7 +143,39 @@
     font-size: 11px;
     color: #bbb;
   }
-  .thumb.active .label {
+  .row.active .label {
     color: #4a9eff;
+  }
+  .actions {
+    display: flex;
+    gap: 2px;
+    opacity: 0;
+    transition: opacity 80ms;
+  }
+  .row:hover .actions,
+  .row:focus-within .actions {
+    opacity: 1;
+  }
+  .action {
+    background: #2a2a2a;
+    border: 1px solid #3a3a3a;
+    color: #ddd;
+    width: 22px;
+    height: 20px;
+    border-radius: 3px;
+    font-size: 11px;
+    cursor: pointer;
+    padding: 0;
+  }
+  .action:hover:not(:disabled) {
+    border-color: #666;
+  }
+  .action.danger:hover:not(:disabled) {
+    border-color: #c44;
+    color: #f88;
+  }
+  .action:disabled {
+    opacity: 0.35;
+    cursor: default;
   }
 </style>

--- a/src/lib/store/document.ts
+++ b/src/lib/store/document.ts
@@ -84,6 +84,23 @@ function reindex(pages: Page[]): Page[] {
   return pages.map((p, i) => (p.pageIndex === i ? p : { ...p, pageIndex: i }));
 }
 
+/**
+ * After a structural op (move/duplicate/delete), each blank page's
+ * `insertedAfterPdfPage` may disagree with its new neighbors. Rebind each
+ * blank to the PDF page that now immediately precedes it, or null if no
+ * PDF page precedes it.
+ */
+function recomputeBlankAnchors(pages: Page[]): Page[] {
+  let lastPdf: number | null = null;
+  return pages.map((p) => {
+    if (p.type === 'pdf') {
+      if (typeof p.pdfSourceIndex === 'number') lastPdf = p.pdfSourceIndex;
+      return p;
+    }
+    return p.insertedAfterPdfPage === lastPdf ? p : { ...p, insertedAfterPdfPage: lastPdf };
+  });
+}
+
 function cloneObjectWithNewId<T extends AnyObject>(o: T): T {
   return { ...o, id: crypto.randomUUID() };
 }
@@ -181,7 +198,7 @@ export function createDocumentStore(): DocumentStore {
         const [moved] = pages.splice(from, 1);
         pages.splice(clamped, 0, moved);
         history.onPageMove(from, clamped);
-        return { ...doc, pages: reindex(pages) };
+        return { ...doc, pages: reindex(recomputeBlankAnchors(pages)) };
       });
     },
 
@@ -194,7 +211,7 @@ export function createDocumentStore(): DocumentStore {
         const pages = [...doc.pages];
         pages.splice(index + 1, 0, copy);
         history.shiftPageIndicesFrom(index + 1);
-        return { ...doc, pages: reindex(pages) };
+        return { ...doc, pages: reindex(recomputeBlankAnchors(pages)) };
       });
     },
 
@@ -206,7 +223,7 @@ export function createDocumentStore(): DocumentStore {
         const pages = [...doc.pages];
         pages.splice(index, 1);
         history.onPageDelete(index);
-        return { ...doc, pages: reindex(pages) };
+        return { ...doc, pages: reindex(recomputeBlankAnchors(pages)) };
       });
     },
 

--- a/src/lib/store/document.ts
+++ b/src/lib/store/document.ts
@@ -12,6 +12,9 @@ export interface DocumentStore {
   updateObject(pageIndex: number, id: ObjectId, patch: Partial<AnyObject>): void;
 
   insertBlankPageAfter(afterArrayIndex: number, width: number, height: number): void;
+  movePage(from: number, to: number): void;
+  duplicatePage(index: number): void;
+  deletePage(index: number): void;
 
   undo(pageIndex: number): void;
   redo(pageIndex: number): void;
@@ -35,11 +38,15 @@ function replacePage(doc: EldrawDocument, pageIndex: number, next: Page): Eldraw
 
 /**
  * Return the stable underlying PDF page index for the page at the given
- * array position. Returns null for blank pages (which have no PDF to render).
+ * array position. Honors the explicit `pdfSourceIndex` field when present
+ * (so reordered/duplicated pages keep rendering the original PDF page);
+ * falls back to counting preceding pdf slots for sidecars written before
+ * the field was introduced.
  */
 export function pdfPageIndexAt(pages: readonly Page[], arrayIndex: number): number | null {
   const page = pages[arrayIndex];
   if (!page || page.type !== 'pdf') return null;
+  if (typeof page.pdfSourceIndex === 'number') return page.pdfSourceIndex;
   let count = 0;
   for (let i = 0; i < arrayIndex; i += 1) {
     if (pages[i].type === 'pdf') count += 1;
@@ -47,17 +54,45 @@ export function pdfPageIndexAt(pages: readonly Page[], arrayIndex: number): numb
   return count;
 }
 
-/**
- * Return the PDF page index that the page at arrayIndex follows. For a pdf
- * page this is its own PDF index; for a blank page it is the last PDF page
- * at or before it (or null if no PDF page precedes it).
- */
 function lastPdfIndexAtOrBefore(pages: readonly Page[], arrayIndex: number): number | null {
-  let count = -1;
+  let last: number | null = null;
   for (let i = 0; i <= arrayIndex && i < pages.length; i += 1) {
-    if (pages[i].type === 'pdf') count += 1;
+    const idx = pdfPageIndexAt(pages, i);
+    if (idx !== null) last = idx;
   }
-  return count < 0 ? null : count;
+  return last;
+}
+
+function normalizeLoaded(doc: EldrawDocument): EldrawDocument {
+  let nextDerived = 0;
+  const pages = doc.pages.map((p, i) => {
+    const base = p.pageIndex === i ? p : { ...p, pageIndex: i };
+    if (base.type === 'pdf' && typeof base.pdfSourceIndex !== 'number') {
+      const withSource = { ...base, pdfSourceIndex: nextDerived };
+      nextDerived += 1;
+      return withSource;
+    }
+    if (base.type === 'pdf' && typeof base.pdfSourceIndex === 'number') {
+      nextDerived = Math.max(nextDerived, base.pdfSourceIndex + 1);
+    }
+    return base;
+  });
+  return { ...doc, pages };
+}
+
+function reindex(pages: Page[]): Page[] {
+  return pages.map((p, i) => (p.pageIndex === i ? p : { ...p, pageIndex: i }));
+}
+
+function cloneObjectWithNewId<T extends AnyObject>(o: T): T {
+  return { ...o, id: crypto.randomUUID() };
+}
+
+function clonePageForDuplicate(p: Page): Page {
+  return {
+    ...p,
+    objects: p.objects.map(cloneObjectWithNewId),
+  };
 }
 
 export function createDocumentStore(): DocumentStore {
@@ -82,7 +117,7 @@ export function createDocumentStore(): DocumentStore {
     subscribe: state.subscribe,
 
     load(doc) {
-      state.set(doc);
+      state.set(normalizeLoaded(doc));
       history.clear();
     },
 
@@ -131,9 +166,47 @@ export function createDocumentStore(): DocumentStore {
         };
         const pages = [...doc.pages];
         pages.splice(insertIdx, 0, blank);
-        const reindexed = pages.map((p, i) => ({ ...p, pageIndex: i }));
         history.shiftPageIndicesFrom(insertIdx);
-        return { ...doc, pages: reindexed };
+        return { ...doc, pages: reindex(pages) };
+      });
+    },
+
+    movePage(from, to) {
+      state.update((doc) => {
+        if (!doc) return doc;
+        const pages = [...doc.pages];
+        if (from < 0 || from >= pages.length) return doc;
+        const clamped = Math.max(0, Math.min(pages.length - 1, to));
+        if (clamped === from) return doc;
+        const [moved] = pages.splice(from, 1);
+        pages.splice(clamped, 0, moved);
+        history.onPageMove(from, clamped);
+        return { ...doc, pages: reindex(pages) };
+      });
+    },
+
+    duplicatePage(index) {
+      state.update((doc) => {
+        if (!doc) return doc;
+        const src = doc.pages[index];
+        if (!src) return doc;
+        const copy = clonePageForDuplicate(src);
+        const pages = [...doc.pages];
+        pages.splice(index + 1, 0, copy);
+        history.shiftPageIndicesFrom(index + 1);
+        return { ...doc, pages: reindex(pages) };
+      });
+    },
+
+    deletePage(index) {
+      state.update((doc) => {
+        if (!doc) return doc;
+        if (doc.pages.length <= 1) return doc;
+        if (index < 0 || index >= doc.pages.length) return doc;
+        const pages = [...doc.pages];
+        pages.splice(index, 1);
+        history.onPageDelete(index);
+        return { ...doc, pages: reindex(pages) };
       });
     },
 

--- a/src/lib/store/history.ts
+++ b/src/lib/store/history.ts
@@ -60,6 +60,10 @@ export interface History {
   /** Shift all page stacks at index >= `from` up by one to keep them
    *  aligned with document pages after an insert at `from`. */
   shiftPageIndicesFrom(from: number): void;
+  /** Drop the stack at `index` and shift stacks at higher indices down by one. */
+  onPageDelete(index: number): void;
+  /** Move the stack at `from` to `to`, preserving relative order of the others. */
+  onPageMove(from: number, to: number): void;
   clear(): void;
   /** For tests. */
   _stacks: Readable<Record<number, PageStack>>;
@@ -129,6 +133,41 @@ export function createHistory(): History {
           const idx = Number(k);
           next[idx >= from ? idx + 1 : idx] = v;
         }
+        return next;
+      });
+    },
+
+    onPageDelete(index) {
+      stacks.update((all) => {
+        const next: Record<number, PageStack> = {};
+        for (const [k, v] of Object.entries(all)) {
+          const idx = Number(k);
+          if (idx === index) continue;
+          next[idx > index ? idx - 1 : idx] = v;
+        }
+        return next;
+      });
+    },
+
+    onPageMove(from, to) {
+      if (from === to) return;
+      stacks.update((all) => {
+        const moved = all[from];
+        const next: Record<number, PageStack> = {};
+        const lo = Math.min(from, to);
+        const hi = Math.max(from, to);
+        for (const [k, v] of Object.entries(all)) {
+          const idx = Number(k);
+          if (idx === from) continue;
+          if (idx < lo || idx > hi) {
+            next[idx] = v;
+          } else if (from < to) {
+            next[idx - 1] = v;
+          } else {
+            next[idx + 1] = v;
+          }
+        }
+        if (moved) next[to] = moved;
         return next;
       });
     },

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -138,6 +138,13 @@ export interface Page {
   type: PageKind;
   /** For inserted blank pages: the PDF page they follow. Null for pure PDF pages. */
   insertedAfterPdfPage: number | null;
+  /**
+   * For pdf pages: the stable pdfium page index this slot renders. Remains
+   * correct after reorder/duplicate/delete. Omitted on blank pages. Optional
+   * for back-compat with older sidecars; derived from position on load when
+   * missing.
+   */
+  pdfSourceIndex?: number;
   /** Page dimensions in PDF points. */
   width: number;
   height: number;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -58,9 +58,17 @@
   }
 
   function onThumbMove(from: number, to: number): void {
-    documentStore.movePage(from, to);
     const snap = viewport.snapshot();
-    if (snap.currentPageIndex === from) viewport.setPage(to, pages.length);
+    const current = snap.currentPageIndex;
+    const clampedTo = Math.max(0, Math.min(to, pages.length - 1));
+    documentStore.movePage(from, to);
+    if (current === from) {
+      viewport.setPage(clampedTo, pages.length);
+    } else if (from < current && current <= clampedTo) {
+      viewport.setPage(Math.max(0, current - 1), pages.length);
+    } else if (clampedTo <= current && current < from) {
+      viewport.setPage(Math.min(pages.length - 1, current + 1), pages.length);
+    }
   }
 
   function onThumbDuplicate(i: number): void {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -57,6 +57,27 @@
     viewport.setPage(i, pages.length);
   }
 
+  function onThumbMove(from: number, to: number): void {
+    documentStore.movePage(from, to);
+    const snap = viewport.snapshot();
+    if (snap.currentPageIndex === from) viewport.setPage(to, pages.length);
+  }
+
+  function onThumbDuplicate(i: number): void {
+    documentStore.duplicatePage(i);
+    viewport.setPage(i + 1, pages.length + 1);
+  }
+
+  function onThumbDelete(i: number): void {
+    if (pages.length <= 1) return;
+    documentStore.deletePage(i);
+    const nextTotal = pages.length - 1;
+    const snap = viewport.snapshot();
+    if (snap.currentPageIndex >= i) {
+      viewport.setPage(Math.max(0, snap.currentPageIndex - 1), nextTotal);
+    }
+  }
+
   const pageCount = $derived(doc?.pages.length ?? meta?.pageCount ?? 0);
   const pageIndex = $derived(Math.min(view.currentPageIndex, Math.max(0, pageCount - 1)));
   const currentPage = $derived(doc?.pages[pageIndex] ?? null);
@@ -432,7 +453,14 @@
   </section>
 
   {#if !isPresenter && pages.length > 0}
-    <ThumbnailStrip {pages} currentIndex={pageIndex} onpick={onThumbPick} />
+    <ThumbnailStrip
+      {pages}
+      currentIndex={pageIndex}
+      onpick={onThumbPick}
+      onmove={onThumbMove}
+      onduplicate={onThumbDuplicate}
+      ondelete={onThumbDelete}
+    />
   {/if}
 
   {#if editor && editorInitial}

--- a/tests/page-ops.test.ts
+++ b/tests/page-ops.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest';
+import { get } from 'svelte/store';
+import { createDocumentStore, pdfPageIndexAt } from '$lib/store/document';
+import type { EldrawDocument, Page, StrokeObject } from '$lib/types';
+
+function stroke(id: string): StrokeObject {
+  return {
+    id,
+    createdAt: 0,
+    type: 'stroke',
+    tool: 'pen',
+    style: { color: '#000', width: 2, dash: 'solid', opacity: 1 },
+    points: [],
+  };
+}
+
+function pdfPage(index: number, withSource = true): Page {
+  const base: Page = {
+    pageIndex: index,
+    type: 'pdf',
+    insertedAfterPdfPage: null,
+    width: 612,
+    height: 792,
+    objects: [],
+  };
+  return withSource ? { ...base, pdfSourceIndex: index } : base;
+}
+
+function blankPage(index: number): Page {
+  return {
+    pageIndex: index,
+    type: 'blank',
+    insertedAfterPdfPage: null,
+    width: 612,
+    height: 792,
+    objects: [],
+  };
+}
+
+function docWithPages(pages: Page[]): EldrawDocument {
+  return {
+    version: 1,
+    pdfHash: 'h',
+    pdfPath: '/tmp/x.pdf',
+    pages,
+    palettes: [],
+    prefs: {
+      sidebarPinned: true,
+      defaultTool: 'pen',
+      toolDefaults: {
+        pen: { color: '#000', width: 2, dash: 'solid', opacity: 1 },
+        highlighter: { color: '#ff0', width: 14, dash: 'solid', opacity: 0.3 },
+        line: { color: '#000', width: 2, dash: 'solid', opacity: 1 },
+      },
+    },
+  };
+}
+
+describe('pdfPageIndexAt', () => {
+  it('honors explicit pdfSourceIndex after reorder', () => {
+    const pages: Page[] = [pdfPage(1), pdfPage(0), pdfPage(2)].map((p, i) => ({
+      ...p,
+      pageIndex: i,
+    }));
+    expect(pdfPageIndexAt(pages, 0)).toBe(1);
+    expect(pdfPageIndexAt(pages, 1)).toBe(0);
+    expect(pdfPageIndexAt(pages, 2)).toBe(2);
+  });
+
+  it('falls back to position counting when pdfSourceIndex is missing', () => {
+    const pages: Page[] = [pdfPage(0, false), blankPage(1), pdfPage(2, false)];
+    expect(pdfPageIndexAt(pages, 0)).toBe(0);
+    expect(pdfPageIndexAt(pages, 1)).toBeNull();
+    expect(pdfPageIndexAt(pages, 2)).toBe(1);
+  });
+});
+
+describe('documentStore page ops', () => {
+  it('load normalizes missing pdfSourceIndex from position', () => {
+    const store = createDocumentStore();
+    store.load(
+      docWithPages([pdfPage(0, false), blankPage(1), pdfPage(2, false), pdfPage(3, false)]),
+    );
+    const doc = get(store)!;
+    expect(doc.pages[0].pdfSourceIndex).toBe(0);
+    expect(doc.pages[1].pdfSourceIndex).toBeUndefined();
+    expect(doc.pages[2].pdfSourceIndex).toBe(1);
+    expect(doc.pages[3].pdfSourceIndex).toBe(2);
+  });
+
+  it('movePage reorders and reindexes', () => {
+    const store = createDocumentStore();
+    store.load(docWithPages([pdfPage(0), pdfPage(1), pdfPage(2)]));
+    store.movePage(0, 2);
+    const doc = get(store)!;
+    expect(doc.pages.map((p) => p.pdfSourceIndex)).toEqual([1, 2, 0]);
+    expect(doc.pages.map((p) => p.pageIndex)).toEqual([0, 1, 2]);
+    expect(pdfPageIndexAt(doc.pages, 2)).toBe(0);
+  });
+
+  it('movePage is a no-op for identity and invalid from', () => {
+    const store = createDocumentStore();
+    store.load(docWithPages([pdfPage(0), pdfPage(1)]));
+    const before = get(store)!.pages.map((p) => p.pdfSourceIndex);
+    store.movePage(0, 0);
+    store.movePage(-1, 1);
+    store.movePage(5, 0);
+    expect(get(store)!.pages.map((p) => p.pdfSourceIndex)).toEqual(before);
+  });
+
+  it('movePage clamps destination to [0, length-1]', () => {
+    const store = createDocumentStore();
+    store.load(docWithPages([pdfPage(0), pdfPage(1), pdfPage(2)]));
+    store.movePage(0, 99);
+    expect(get(store)!.pages.map((p) => p.pdfSourceIndex)).toEqual([1, 2, 0]);
+  });
+
+  it('duplicatePage inserts a copy directly after with fresh object ids', () => {
+    const store = createDocumentStore();
+    store.load(docWithPages([pdfPage(0)]));
+    store.addObject(0, stroke('s1'));
+    store.duplicatePage(0);
+    const doc = get(store)!;
+    expect(doc.pages).toHaveLength(2);
+    expect(doc.pages[1].pdfSourceIndex).toBe(0);
+    expect(doc.pages[1].objects).toHaveLength(1);
+    expect(doc.pages[1].objects[0].id).not.toBe('s1');
+  });
+
+  it('deletePage removes and reindexes', () => {
+    const store = createDocumentStore();
+    store.load(docWithPages([pdfPage(0), pdfPage(1), pdfPage(2)]));
+    store.deletePage(1);
+    const doc = get(store)!;
+    expect(doc.pages).toHaveLength(2);
+    expect(doc.pages.map((p) => p.pdfSourceIndex)).toEqual([0, 2]);
+    expect(doc.pages.map((p) => p.pageIndex)).toEqual([0, 1]);
+  });
+
+  it('deletePage refuses to delete the only remaining page', () => {
+    const store = createDocumentStore();
+    store.load(docWithPages([pdfPage(0)]));
+    store.deletePage(0);
+    expect(get(store)!.pages).toHaveLength(1);
+  });
+
+  it('history travels with moved pages', () => {
+    const store = createDocumentStore();
+    store.load(docWithPages([pdfPage(0), pdfPage(1)]));
+    store.addObject(0, stroke('a'));
+    store.movePage(0, 1);
+    store.undo(1);
+    const doc = get(store)!;
+    expect(doc.pages[1].objects).toHaveLength(0);
+  });
+
+  it('history is dropped for a deleted page and shifts down for higher pages', () => {
+    const store = createDocumentStore();
+    store.load(docWithPages([pdfPage(0), pdfPage(1), pdfPage(2)]));
+    store.addObject(2, stroke('c'));
+    store.deletePage(0);
+    store.undo(1);
+    expect(get(store)!.pages[1].objects).toHaveLength(0);
+  });
+});

--- a/tests/page-ops.test.ts
+++ b/tests/page-ops.test.ts
@@ -162,4 +162,26 @@ describe('documentStore page ops', () => {
     store.undo(1);
     expect(get(store)!.pages[1].objects).toHaveLength(0);
   });
+
+  it('recomputes blank insertedAfterPdfPage after move', () => {
+    const store = createDocumentStore();
+    const blank = blankPage(1);
+    blank.insertedAfterPdfPage = 0;
+    store.load(docWithPages([pdfPage(0), blank, pdfPage(2)]));
+    store.movePage(1, 2);
+    const doc = get(store)!;
+    const movedBlank = doc.pages.find((p) => p.type === 'blank')!;
+    expect(movedBlank.insertedAfterPdfPage).toBe(2);
+  });
+
+  it('recomputes blank insertedAfterPdfPage after delete removes anchor pdf', () => {
+    const store = createDocumentStore();
+    const blank = blankPage(1);
+    blank.insertedAfterPdfPage = 0;
+    store.load(docWithPages([pdfPage(0), blank, pdfPage(2)]));
+    store.deletePage(0);
+    const doc = get(store)!;
+    const remainingBlank = doc.pages.find((p) => p.type === 'blank')!;
+    expect(remainingBlank.insertedAfterPdfPage).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

Phase 3's final worktree: page reorder, duplicate, and delete wired to the thumbnail strip.

## Data model

- `Page.pdfSourceIndex?: number` — optional field tying a pdf slot to a stable pdfium page. Reordering/duplicating pages preserves which page content renders where.
- `pdfPageIndexAt(pages, i)` honors `pdfSourceIndex` when present and falls back to position-counting for older sidecars.
- `documentStore.load()` normalizes missing `pdfSourceIndex` from position so older sidecars load transparently.

## Store ops

- `movePage(from, to)` — splice + reindex + move history stack
- `duplicatePage(index)` — clone with fresh object ids + shift higher history stacks up
- `deletePage(index)` — refuses to remove the only remaining page; drops that stack and shifts higher stacks down

## UI

`ThumbnailStrip` now renders per-thumbnail action buttons (↑ ↓ ⧉ ✕) revealed on hover or focus. `+page.svelte` wires the actions to the store and nudges the viewport's current page so the user stays on the page they moved/duplicated/just-deleted.

## Testing

- `pnpm test` — 197 passed (adds 9 page-ops tests covering normalization, move, clamp, duplicate, delete, refuse-last, and history travel/drop).
- `pnpm lint` — prettier, eslint, svelte-check all clean.