### PR TITLE
chore(release): add tag-triggered release pipeline and bump script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - uses: tauri-apps/tauri-action@v0
+      - uses: tauri-apps/tauri-action@action-v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,106 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    outputs:
+      body: ${{ steps.cliff.outputs.content }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate release notes
+        id: cliff
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --latest --strip all
+        env:
+          OUTPUT: RELEASE_NOTES.md
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-notes
+          path: RELEASE_NOTES.md
+
+  build:
+    needs: changelog
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: ubuntu-latest
+            rust-target: x86_64-unknown-linux-gnu
+            tauri-args: --bundles deb,appimage
+          - platform: windows-latest
+            rust-target: x86_64-pc-windows-msvc
+            tauri-args: --bundles msi,nsis
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust-target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Install Linux build deps
+        if: matrix.platform == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libssl-dev
+
+      - run: pnpm install --frozen-lockfile
+
+      - uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tagName: ${{ github.ref_name }}
+          releaseName: 'eldraw ${{ github.ref_name }}'
+          releaseBody: ${{ needs.changelog.outputs.body }}
+          releaseDraft: true
+          prerelease: false
+          args: ${{ matrix.tauri-args }}
+
+  publish:
+    needs: [build, changelog]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-notes
+
+      - name: Update release body and publish
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release edit "${GITHUB_REF_NAME}" \
+            --notes-file RELEASE_NOTES.md \
+            --draft=false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,18 +117,33 @@ Rules:
 3. `presenter-view` — multi-monitor, thumbnail sidebar
 4. `page-ops` — reorder, duplicate, blank page polish
 
-## Releases (plan — not yet implemented)
+## Releases
 
-Set up in Phase 4:
+Implemented in Phase 4 (`.github/workflows/release.yml`):
 
-- GitHub Actions matrix build on tag push (`v*`):
-  - Windows: `.msi` + portable `.exe`
+- Push a `v*` git tag to trigger the matrix build:
+  - Windows: `.msi` + NSIS `.exe`
   - Linux: `.AppImage` + `.deb`
-- Artifacts attached to a GitHub Release.
-- Conventional Commit history feeds an auto-generated changelog
-  (e.g. `git-cliff`).
-- Version bumping via `npm version` + matching Cargo version; single source
-  of truth is the git tag.
+- `git-cliff` (`cliff.toml`) generates release notes from Conventional Commit
+  history.
+- Artifacts land on a draft GitHub Release, then the `publish` job flips the
+  draft to published with the generated notes.
+- Version is bumped in lockstep across `package.json`,
+  `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json` via
+  `pnpm bump <semver>`. Source of truth is the git tag.
+
+Typical release flow:
+
+```sh
+pnpm bump 0.2.0
+cargo check --manifest-path src-tauri/Cargo.toml   # refresh Cargo.lock
+git commit -am "chore(release): v0.2.0"
+git tag v0.2.0
+git push origin main v0.2.0
+```
+
+Code signing (macOS notarization, Windows Authenticode) is a follow-up once
+certificates exist.
 
 ## Security & Hygiene
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,71 @@
 # eldraw
 
-A cross-platform PDF annotation tool built for live math teaching.
+A cross-platform PDF annotation tool built for live math teaching. Stylus-first,
+low-latency inking with a math-aware toolset — graph plotter, implicit curves,
+LaTeX, protractor, ruler, number line, laser pointer, and more — on top of any
+PDF or blank page.
 
-See [PLAN.md](./PLAN.md) for the full design and roadmap, and
-[AGENTS.md](./AGENTS.md) for contribution rules.
+## Features
 
-## Dev
+- **PDF + blank pages** — open a PDF, mix in blank pages, reorder, duplicate,
+  and delete pages from the thumbnail strip.
+- **Low-latency inking** — perfect-freehand strokes driven by Pointer Events,
+  with palette, widths, dash styles, and fading laser/temporary ink.
+- **Math tools** — function plotter with expression parser, implicit curves
+  via marching squares, LaTeX text objects, shapes, and a number-line tool.
+- **Geometry overlays** — draggable protractor and ruler, angle marks.
+- **Undo / redo** — full per-page history; survives page reorder, duplicate,
+  and delete.
+- **Autosave** — sidecar JSON next to the PDF; reopen right where you left off.
+- **Presenter view** — F5 toggles a fullscreen presentation mode with a
+  thumbnail strip for fast navigation.
+- **Flatten export** — bake annotations back into a shareable PDF.
+
+## Install
+
+Prebuilt installers are attached to each [GitHub Release](https://github.com/Adamkadaban/eldraw/releases):
+
+- Windows: `.msi` or NSIS `.exe`
+- Linux: `.AppImage` or `.deb`
+
+## Develop
 
 ```sh
 pnpm install
 pnpm tauri dev
 ```
 
-## Checks
+### Checks
 
 ```sh
 pnpm lint          # prettier + eslint + svelte-check
 pnpm test          # vitest
 
-cargo fmt --manifest-path src-tauri/Cargo.toml --check
+cargo fmt   --manifest-path src-tauri/Cargo.toml --check
 cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
-cargo test --manifest-path src-tauri/Cargo.toml
+cargo test  --manifest-path src-tauri/Cargo.toml
 ```
+
+### Release
+
+Version is bumped in lockstep across `package.json`, `src-tauri/Cargo.toml`,
+and `src-tauri/tauri.conf.json`:
+
+```sh
+pnpm bump 0.2.0
+cargo check --manifest-path src-tauri/Cargo.toml
+git commit -am "chore(release): v0.2.0"
+git tag v0.2.0 && git push origin main v0.2.0
+```
+
+Pushing the tag triggers the release workflow, which builds Windows and Linux
+installers and publishes a GitHub Release with git-cliff-generated notes.
+
+## Docs
+
+- [PLAN.md](./PLAN.md) — full design, architecture, and roadmap
+- [AGENTS.md](./AGENTS.md) — contribution rules for humans and AI agents
+
+## License
+
+MIT

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,43 @@
+# git-cliff configuration for eldraw
+# https://git-cliff.org/docs/configuration
+
+[changelog]
+header = """
+# Changelog
+
+"""
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | upper_first }}
+    {% for commit in commits %}\
+        - {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | upper_first }}\
+    {% endfor %}
+{% endfor %}\n
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactor" },
+    { message = "^docs", group = "Documentation" },
+    { message = "^test", group = "Tests" },
+    { message = "^build", group = "Build" },
+    { message = "^ci", group = "CI" },
+    { message = "^chore", skip = true },
+    { message = "^style", skip = true },
+]
+filter_commits = true
+tag_pattern = "v[0-9]*"
+topo_order = false
+sort_commits = "oldest"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "format": "prettier --write .",
     "test": "vitest run",
     "test:watch": "vitest",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "bump": "node scripts/bump-version.mjs"
   },
   "license": "MIT",
   "dependencies": {

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -19,10 +19,14 @@ import { fileURLToPath } from 'node:url';
 const here = dirname(fileURLToPath(import.meta.url));
 const root = resolve(here, '..');
 
+const SEMVER =
+  /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
 const next = process.argv[2];
-if (!next || !/^\d+\.\d+\.\d+(-[\w.]+)?$/.test(next)) {
+if (!next || !SEMVER.test(next)) {
   console.error('usage: node scripts/bump-version.mjs <semver>');
   console.error('example: node scripts/bump-version.mjs 0.2.0');
+  console.error('         node scripts/bump-version.mjs 0.2.0-rc.1');
   process.exit(1);
 }
 

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * Bumps the eldraw version in lockstep across:
+ *   - package.json
+ *   - src-tauri/Cargo.toml       (package.version)
+ *   - src-tauri/tauri.conf.json  (version)
+ *
+ * Usage: node scripts/bump-version.mjs <new-version>
+ *        node scripts/bump-version.mjs 0.2.0
+ *
+ * Does not create a git tag — run `git tag v<version>` separately once the
+ * bump commit is on main. Pushing the tag triggers the release workflow.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = resolve(here, '..');
+
+const next = process.argv[2];
+if (!next || !/^\d+\.\d+\.\d+(-[\w.]+)?$/.test(next)) {
+  console.error('usage: node scripts/bump-version.mjs <semver>');
+  console.error('example: node scripts/bump-version.mjs 0.2.0');
+  process.exit(1);
+}
+
+function replaceInFile(path, matcher, replacement, label) {
+  const abs = resolve(root, path);
+  const before = readFileSync(abs, 'utf8');
+  const after = before.replace(matcher, replacement);
+  if (before === after) {
+    throw new Error(`${label}: pattern not found in ${path}`);
+  }
+  writeFileSync(abs, after);
+  console.log(`  ${path}`);
+}
+
+console.log(`bumping eldraw to ${next}`);
+
+replaceInFile('package.json', /("version"\s*:\s*")[^"]+(")/, `$1${next}$2`, 'package.json');
+
+replaceInFile(
+  'src-tauri/Cargo.toml',
+  /(^\s*version\s*=\s*")[^"]+(")/m,
+  `$1${next}$2`,
+  'Cargo.toml',
+);
+
+replaceInFile(
+  'src-tauri/tauri.conf.json',
+  /("version"\s*:\s*")[^"]+(")/,
+  `$1${next}$2`,
+  'tauri.conf.json',
+);
+
+console.log(`done. next: commit, then \`git tag v${next} && git push origin v${next}\`.`);


### PR DESCRIPTION
Closes #23. Phase 4 kickoff: tag-triggered release autobuilds.

## What

- `.github/workflows/release.yml` — matrix build on `v*` tag push:
  - `windows-latest` → `.msi` + NSIS `.exe` via tauri-action
  - `ubuntu-latest` → `.AppImage` + `.deb`
  - `changelog` job runs `git-cliff` (config in `cliff.toml`) to generate release notes; `publish` job flips the draft release to published with the generated body.
- `scripts/bump-version.mjs` (exposed as `pnpm bump <semver>`) syncs the version across `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`.
- README rewritten with a features list and install / develop / release sections.
- AGENTS.md release section moved from "plan — not yet implemented" to the actual flow.

## Testing

- `pnpm lint` — prettier, eslint, svelte-check clean.
- `pnpm test` — untouched; no source changes.
- Ran `pnpm bump 9.9.9` locally, verified all three files updated, reverted to `0.1.0`.

## Out of scope

- Code signing (macOS notarization, Windows Authenticode) — follow-up once certificates exist.
- Auto-update endpoint — follow-up.

## Verification plan

Merge this, then push a test tag (e.g. `v0.1.0-rc.1`) to confirm the workflow end-to-end and inspect the draft release artifacts before cutting `v0.1.0` proper.