### PR TITLE
fix(release): skip MSI on pre-release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,17 +51,21 @@ jobs:
         id: bundles
         shell: bash
         run: |
-          is_prerelease=${{ contains(github.ref_name, '-') }}
-          case "${{ matrix.platform }}" in
-            ubuntu-latest)
+          is_prerelease="${{ contains(github.ref_name, '-') }}"
+          case "${{ runner.os }}" in
+            Linux)
               list="deb,appimage"
               ;;
-            windows-latest)
+            Windows)
               if [ "$is_prerelease" = "true" ]; then
                 list="nsis"
               else
                 list="msi,nsis"
               fi
+              ;;
+            *)
+              echo "Unsupported runner.os for bundle resolution: ${{ runner.os }}" >&2
+              exit 1
               ;;
           esac
           echo "list=$list" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,15 +39,32 @@ jobs:
         include:
           - platform: ubuntu-latest
             rust-target: x86_64-unknown-linux-gnu
-            tauri-args: --bundles deb,appimage
           - platform: windows-latest
             rust-target: x86_64-pc-windows-msvc
-            tauri-args: --bundles msi,nsis
 
     runs-on: ${{ matrix.platform }}
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Resolve bundle list
+        id: bundles
+        shell: bash
+        run: |
+          is_prerelease=${{ contains(github.ref_name, '-') }}
+          case "${{ matrix.platform }}" in
+            ubuntu-latest)
+              list="deb,appimage"
+              ;;
+            windows-latest)
+              if [ "$is_prerelease" = "true" ]; then
+                list="nsis"
+              else
+                list="msi,nsis"
+              fi
+              ;;
+          esac
+          echo "list=$list" >> "$GITHUB_OUTPUT"
 
       - uses: pnpm/action-setup@v4
         with:
@@ -83,7 +100,7 @@ jobs:
           releaseBody: ${{ needs.changelog.outputs.body }}
           releaseDraft: true
           prerelease: ${{ contains(github.ref_name, '-') }}
-          args: ${{ matrix.tauri-args }}
+          args: --bundles ${{ steps.bundles.outputs.list }}
 
   publish:
     needs: [build, changelog]


### PR DESCRIPTION
Smoke-test of `v0.1.0-rc.1` found the Windows build compiled all 400+ release crates (15m13s) then failed in the MSI bundler:

```
failed to bundle project `optional pre-release identifier in app version
must be numeric-only and cannot be greater than 65535 for msi target`
```

## Cause

Windows MSI uses a 4-part numeric version (16 bits per field), so `0.1.0-rc.1` can't be expressed. NSIS has no such constraint.

## Fix

Bundle list moves from a static matrix value into a per-job step. For tags containing a hyphen (the semver pre-release marker), Windows ships NSIS only. Stable tags still ship both MSI and NSIS. Linux is unchanged (always `deb,appimage`).

## Side effect

Because the Windows job failed, `Swatinem/rust-cache` didn't save, so next release would have been a cold Windows build again. With this fix a successful run will populate the cache, cutting subsequent same-lockfile Windows builds from ~15m to an expected ~5m.

## Verification plan

Merge → delete the failed `v0.1.0-rc.1` tag/release → push `v0.1.0-rc.2` and confirm both OSes succeed.