### PR TITLE
fix(pdf): bundle pdfium as app resource and surface load errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,14 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Fetch pdfium
+        shell: bash
+        run: |
+          case "${{ runner.os }}" in
+            Linux)   ./scripts/fetch-pdfium.sh linux ;;
+            Windows) ./scripts/fetch-pdfium.sh windows ;;
+          esac
+
       - uses: tauri-apps/tauri-action@action-v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,8 +99,8 @@ jobs:
         shell: bash
         run: |
           case "${{ runner.os }}" in
-            Linux)   ./scripts/fetch-pdfium.sh linux ;;
-            Windows) ./scripts/fetch-pdfium.sh windows ;;
+            Linux)   bash scripts/fetch-pdfium.sh linux ;;
+            Windows) bash scripts/fetch-pdfium.sh windows ;;
           esac
 
       - uses: tauri-apps/tauri-action@action-v0.6.2

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,8 @@ vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 
 # pdfium binaries (downloaded at build time)
-src-tauri/pdfium/
+src-tauri/pdfium/*
+!src-tauri/pdfium/README.md
 
 # Autosave / crash recovery
 *.eldraw.lock

--- a/README.md
+++ b/README.md
@@ -32,8 +32,15 @@ Prebuilt installers are attached to each [GitHub Release](https://github.com/Ada
 
 ```sh
 pnpm install
+./scripts/fetch-pdfium.sh   # downloads libpdfium into src-tauri/pdfium/
 pnpm tauri dev
 ```
+
+The fetch script is only required the first time (and when the pinned pdfium
+version changes). It verifies the SHA-256 of the downloaded archive against
+a value committed in the script. `pnpm tauri dev` works without it only if a
+matching libpdfium is already installed on your system; `pnpm tauri build`
+always requires the bundled copy under `src-tauri/pdfium/`.
 
 ### Checks
 

--- a/scripts/fetch-pdfium.sh
+++ b/scripts/fetch-pdfium.sh
@@ -57,7 +57,15 @@ trap 'rm -rf "$tmp"' EXIT
 echo "Fetching $url"
 curl --proto '=https' --tlsv1.2 -fL --retry 3 -o "$tmp/$asset" "$url"
 
-actual="$(shasum -a 256 "$tmp/$asset" | awk '{print $1}')"
+actual=""
+if command -v sha256sum >/dev/null 2>&1; then
+  actual="$(sha256sum "$tmp/$asset" | awk '{print $1}')"
+elif command -v shasum >/dev/null 2>&1; then
+  actual="$(shasum -a 256 "$tmp/$asset" | awk '{print $1}')"
+else
+  echo "Neither sha256sum nor shasum is available for checksum verification" >&2
+  exit 1
+fi
 if [ "$actual" != "$expected" ]; then
   echo "pdfium checksum mismatch for $asset" >&2
   echo "  expected: $expected" >&2

--- a/scripts/fetch-pdfium.sh
+++ b/scripts/fetch-pdfium.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Downloads the pdfium native library into src-tauri/pdfium/ so that
+# `cargo tauri build` can bundle it as an app resource. The release CI
+# workflow runs this same logic inline.
+#
+# Usage:
+#   scripts/fetch-pdfium.sh            # auto-detect host OS
+#   scripts/fetch-pdfium.sh linux
+#   scripts/fetch-pdfium.sh windows
+#
+# Pinned to a specific bblanchon/pdfium-binaries release with SHA-256 digests
+# verified against GitHub's release asset metadata.
+
+set -euo pipefail
+
+PDFIUM_TAG="chromium/7789"
+SHA256_LINUX_X64="c30e092dc491b74bb666e6d35cd8d126102dad90fa87a722e16b312a2cd66c52"
+SHA256_WIN_X64="5d93c5b5677bc38c5b13f5f2314fd4e0cd6c79b311797a2545644a10ce94180d"
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+dest="$repo_root/src-tauri/pdfium"
+mkdir -p "$dest"
+
+host="${1:-}"
+if [ -z "$host" ]; then
+  case "$(uname -s)" in
+    Linux*) host="linux" ;;
+    MINGW*|MSYS*|CYGWIN*) host="windows" ;;
+    *) echo "Unsupported host OS: $(uname -s)" >&2; exit 1 ;;
+  esac
+fi
+
+case "$host" in
+  linux)
+    asset="pdfium-linux-x64.tgz"
+    expected="$SHA256_LINUX_X64"
+    libfile="lib/libpdfium.so"
+    outfile="libpdfium.so"
+    ;;
+  windows)
+    asset="pdfium-win-x64.tgz"
+    expected="$SHA256_WIN_X64"
+    libfile="bin/pdfium.dll"
+    outfile="pdfium.dll"
+    ;;
+  *)
+    echo "Unsupported target: $host (expected 'linux' or 'windows')" >&2
+    exit 1
+    ;;
+esac
+
+url="https://github.com/bblanchon/pdfium-binaries/releases/download/$PDFIUM_TAG/$asset"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+echo "Fetching $url"
+curl --proto '=https' --tlsv1.2 -fL --retry 3 -o "$tmp/$asset" "$url"
+
+actual="$(shasum -a 256 "$tmp/$asset" | awk '{print $1}')"
+if [ "$actual" != "$expected" ]; then
+  echo "pdfium checksum mismatch for $asset" >&2
+  echo "  expected: $expected" >&2
+  echo "  actual:   $actual" >&2
+  exit 1
+fi
+
+tar -xzf "$tmp/$asset" -C "$tmp"
+cp "$tmp/$libfile" "$dest/$outfile"
+echo "Installed $dest/$outfile ($PDFIUM_TAG)"

--- a/src-tauri/pdfium/README.md
+++ b/src-tauri/pdfium/README.md
@@ -1,0 +1,3 @@
+# Populated at build time by scripts/fetch-pdfium.sh or the release CI workflow.
+
+# See README for details.

--- a/src-tauri/src/pdf.rs
+++ b/src-tauri/src/pdf.rs
@@ -1,9 +1,10 @@
 //! PDF ingest & raster pipeline.
 //!
 //! Rendering uses pdfium-render. The native pdfium library is resolved at
-//! runtime by [`crate::state::pdfium`]: system loader first, then a binary
-//! placed next to the executable. Distributions should ship the matching
-//! `libpdfium.so` / `pdfium.dll` / `libpdfium.dylib` in the app bundle.
+//! runtime by [`crate::state::pdfium`]: bundled resource dir first, then a
+//! binary next to the executable, then the system loader. Installers ship
+//! the matching `libpdfium.so` / `pdfium.dll` / `libpdfium.dylib` inside the
+//! app's resource directory under `pdfium/`.
 
 use std::io::Cursor;
 use std::path::PathBuf;
@@ -11,7 +12,7 @@ use std::path::PathBuf;
 use image::ImageFormat;
 use pdfium_render::prelude::{PdfRenderConfig, Pdfium};
 use sha2::{Digest, Sha256};
-use tauri::State;
+use tauri::{AppHandle, State};
 
 use crate::error::{AppError, AppResult};
 use crate::model::{PageDims, PdfMeta};
@@ -54,12 +55,16 @@ fn load_document<'a>(
 }
 
 #[tauri::command]
-pub async fn open_pdf(path: String, state: State<'_, AppState>) -> AppResult<PdfMeta> {
+pub async fn open_pdf(
+    app: AppHandle,
+    path: String,
+    state: State<'_, AppState>,
+) -> AppResult<PdfMeta> {
     let pdf_path = PathBuf::from(&path);
     let bytes = std::fs::read(&pdf_path)?;
     let hash = hash_bytes(&bytes);
 
-    let pdfium = pdfium()?;
+    let pdfium = pdfium(&app)?;
     let doc = load_document(pdfium, &bytes)?;
 
     let mut pages = Vec::with_capacity(usize::try_from(doc.pages().len()).unwrap_or(0));
@@ -89,6 +94,7 @@ const MAX_PIXEL_AREA: u64 = 64 * 1024 * 1024;
 
 #[tauri::command]
 pub async fn render_page(
+    app: AppHandle,
     page_index: u32,
     scale: f32,
     state: State<'_, AppState>,
@@ -97,7 +103,7 @@ pub async fn render_page(
         return Err(AppError::Pdf(format!("invalid scale: {scale}")));
     }
     state.with_open(|open| {
-        let pdfium = pdfium()?;
+        let pdfium = pdfium(&app)?;
         let doc = load_document(pdfium, &open.bytes)?;
         let page = doc
             .pages()

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,6 +1,8 @@
 use pdfium_render::prelude::Pdfium;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
+
+use tauri::{AppHandle, Manager};
 
 use crate::error::{AppError, AppResult};
 
@@ -45,25 +47,60 @@ impl AppState {
 }
 
 /// Returns a process-wide Pdfium handle. The native binary is resolved by
-/// first trying `Pdfium::bind_to_system_library()`, then falling back to a
-/// binary co-located with the running executable. If neither is available,
-/// the error is surfaced to the caller.
-pub fn pdfium() -> AppResult<&'static Pdfium> {
+/// trying, in order:
+///   1. `<resource_dir>/pdfium/` — bundled library shipped with the installer.
+///   2. The directory containing the current executable — useful for portable
+///      layouts and local `cargo run` with a sibling binary.
+///   3. The system loader — last-resort for developers who have pdfium
+///      installed system-wide.
+///
+/// Initialization happens once per process; subsequent calls reuse the handle
+/// regardless of which `app` is passed.
+pub fn pdfium(app: &AppHandle) -> AppResult<&'static Pdfium> {
     static PDFIUM: OnceLock<Result<Pdfium, String>> = OnceLock::new();
     let slot = PDFIUM.get_or_init(|| {
-        let bindings = Pdfium::bind_to_system_library()
-            .or_else(|_| {
-                let exe_dir = std::env::current_exe()
-                    .ok()
-                    .and_then(|p| p.parent().map(PathBuf::from))
-                    .unwrap_or_else(|| PathBuf::from("."));
-                Pdfium::bind_to_library(Pdfium::pdfium_platform_library_name_at_path(&exe_dir))
-            })
-            .map_err(|e| format!("failed to load pdfium binary: {e}"))?;
-        Ok(Pdfium::new(bindings))
+        let mut attempts: Vec<String> = Vec::new();
+
+        if let Ok(resource_dir) = app.path().resource_dir() {
+            let bundled = resource_dir.join("pdfium");
+            if let Some(pdfium) = try_bind(&bundled, &mut attempts) {
+                return Ok(pdfium);
+            }
+        }
+
+        if let Some(exe_dir) = std::env::current_exe()
+            .ok()
+            .and_then(|p| p.parent().map(PathBuf::from))
+        {
+            if let Some(pdfium) = try_bind(&exe_dir, &mut attempts) {
+                return Ok(pdfium);
+            }
+        }
+
+        match Pdfium::bind_to_system_library() {
+            Ok(bindings) => Ok(Pdfium::new(bindings)),
+            Err(e) => {
+                attempts.push(format!("system: {e}"));
+                Err(format!(
+                    "failed to load pdfium binary; tried: {}",
+                    attempts.join("; ")
+                ))
+            }
+        }
     });
     match slot {
         Ok(p) => Ok(p),
         Err(msg) => Err(AppError::Pdf(msg.clone())),
+    }
+}
+
+fn try_bind(dir: &Path, attempts: &mut Vec<String>) -> Option<Pdfium> {
+    let path = Pdfium::pdfium_platform_library_name_at_path(dir);
+    match Pdfium::bind_to_library(&path) {
+        Ok(bindings) => Some(Pdfium::new(bindings)),
+        Err(e) => {
+            attempts.push(format!("{}: {e}", path.display()));
+            None
+        }
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,6 +24,9 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "resources": {
+      "pdfium/*": "pdfium/"
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src/lib/store/pdf.ts
+++ b/src/lib/store/pdf.ts
@@ -25,6 +25,10 @@ export function setError(error: string): void {
   internal.update((s) => ({ ...s, error, loading: false }));
 }
 
+export function clearError(): void {
+  internal.update((s) => ({ ...s, error: null }));
+}
+
 export function reset(): void {
   internal.set(initial);
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -14,7 +14,7 @@
   import { ThumbnailStrip } from '$lib/sidebar';
   import { openAndLoadPdf } from '$lib/ipc/pdf';
   import { loadSidecar } from '$lib/ipc';
-  import { pdf } from '$lib/store/pdf';
+  import { pdf, clearError } from '$lib/store/pdf';
   import { sidebar } from '$lib/store/sidebar';
   import { currentDocument, documentStore, pdfPageIndexAt } from '$lib/store/document';
   import { startAutosave } from '$lib/store/autosave';
@@ -483,6 +483,15 @@
       oncancel={onEditorCancel}
     />
   {/if}
+
+  {#if pdfState.error}
+    <div class="error-banner" role="alert">
+      <span class="error-msg">{pdfState.error}</span>
+      <button type="button" class="error-dismiss" aria-label="Dismiss error" onclick={clearError}
+        >×</button
+      >
+    </div>
+  {/if}
 </main>
 
 <style>
@@ -647,5 +656,40 @@
     border: 1px solid #3a3a3a;
     padding: 1px 6px;
     border-radius: 3px;
+  }
+  .error-banner {
+    position: fixed;
+    bottom: 16px;
+    left: 50%;
+    transform: translateX(-50%);
+    max-width: min(720px, calc(100vw - 32px));
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 14px;
+    background: #4a1b1b;
+    border: 1px solid #7a2a2a;
+    border-radius: 6px;
+    color: #fdd;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+    font-size: 13px;
+    z-index: 100;
+  }
+  .error-msg {
+    flex: 1 1 auto;
+    word-break: break-word;
+  }
+  .error-dismiss {
+    flex: 0 0 auto;
+    background: transparent;
+    border: none;
+    color: #fdd;
+    font-size: 18px;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0 4px;
+  }
+  .error-dismiss:hover {
+    color: #fff;
   }
 </style>


### PR DESCRIPTION
## Summary

Fixes the silent failure on every release installer: `open_pdf` always
errored because no `libpdfium` was bundled, and the frontend swallowed the
error so users saw nothing happen after picking a PDF.

## Changes

- **`state::pdfium`** now probes, in order:
  1. `<resource_dir>/pdfium/` — bundled with the installer
  2. Exe-sibling dir — portable layouts
  3. System loader — dev fallback

  All attempted paths are collected into the error message when every probe
  fails, so the next silent failure won't be silent.
- **`tauri.conf.json`** declares `pdfium/*` → `pdfium/` under
  `bundle.resources`, so `.msi` / `.deb` / `.AppImage` / `.nsis` all ship
  libpdfium next to the binary.
- **Frontend error banner** renders `pdfState.error` as a dismissible alert.
  New `clearError` action in the pdf store.
- **`scripts/fetch-pdfium.sh`** pinned to `bblanchon/pdfium-binaries`
  `chromium/7789`. SHA-256 digests pulled from the GitHub release asset
  metadata and verified on download. Handles `linux` and `windows` targets.
- **Release workflow** invokes the script per-OS before `tauri-action` so
  the bundler finds `src-tauri/pdfium/libpdfium.so` or `pdfium.dll`.
- **README** documents the first-time `./scripts/fetch-pdfium.sh` step.
- **gitignore** keeps `src-tauri/pdfium/*` out of the tree except for the
  tracked `README.md`.

## Testing

Local (Linux):
- `pnpm lint` ✅ (prettier, eslint, svelte-check)
- `pnpm test` ✅ (199 tests)
- `cargo fmt --check` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo test` ✅ (10 tests)
- `./scripts/fetch-pdfium.sh linux` downloads, verifies SHA-256, and
  installs `libpdfium.so` into `src-tauri/pdfium/`.

End-to-end verification will happen against tag `v0.1.0-rc.2` once this
and #26 are both on `main`.