### PR TITLE
chore(release): v0.1.0-rc.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eldraw",
-  "version": "0.1.0-rc.1",
+  "version": "0.1.0-rc.2",
   "description": "PDF annotation tool for live math teaching",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1013,7 +1013,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "eldraw"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "image",
  "pdfium-render",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eldraw"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 description = "PDF annotation tool for live math teaching"
 authors = ["Adam"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "eldraw",
-  "version": "0.1.0-rc.1",
+  "version": "0.1.0-rc.2",
   "identifier": "com.adamkadaban.eldraw",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Validates the MSI pre-release fix (#26) and the pdfium bundling fix (#29) end-to-end. Tag `v0.1.0-rc.2` will be pushed after merge.