### PR TITLE
fix(pdf): return rendered PNG bytes as raw IPC Response

### DIFF
--- a/src-tauri/src/pdf.rs
+++ b/src-tauri/src/pdf.rs
@@ -12,6 +12,7 @@ use std::path::PathBuf;
 use image::ImageFormat;
 use pdfium_render::prelude::{PdfRenderConfig, Pdfium};
 use sha2::{Digest, Sha256};
+use tauri::ipc::Response;
 use tauri::{AppHandle, State};
 
 use crate::error::{AppError, AppResult};
@@ -98,11 +99,11 @@ pub async fn render_page(
     page_index: u32,
     scale: f32,
     state: State<'_, AppState>,
-) -> AppResult<Vec<u8>> {
+) -> AppResult<Response> {
     if !scale.is_finite() || scale <= 0.0 {
         return Err(AppError::Pdf(format!("invalid scale: {scale}")));
     }
-    state.with_open(|open| {
+    let bytes = state.with_open(|open| {
         let pdfium = pdfium(&app)?;
         let doc = load_document(pdfium, &open.bytes)?;
         let page = doc
@@ -136,7 +137,8 @@ pub async fn render_page(
         let mut out = Cursor::new(Vec::<u8>::new());
         image.write_to(&mut out, ImageFormat::Png)?;
         Ok(out.into_inner())
-    })
+    })?;
+    Ok(Response::new(bytes))
 }
 
 #[cfg(test)]

--- a/src/lib/ipc/index.ts
+++ b/src/lib/ipc/index.ts
@@ -5,7 +5,7 @@ export async function openPdf(path: string): Promise<PdfMeta> {
   return invoke('open_pdf', { path });
 }
 
-export async function renderPage(pageIndex: number, scale: number): Promise<Uint8Array> {
+export async function renderPage(pageIndex: number, scale: number): Promise<ArrayBuffer> {
   return invoke('render_page', { pageIndex, scale });
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -184,7 +184,7 @@ export interface EldrawDocument {
  */
 export interface IpcCommands {
   open_pdf: (args: { path: string }) => Promise<PdfMeta>;
-  render_page: (args: { pageIndex: number; scale: number }) => Promise<Uint8Array>;
+  render_page: (args: { pageIndex: number; scale: number }) => Promise<ArrayBuffer>;
   load_sidecar: (args: { pdfPath: string }) => Promise<EldrawDocument | null>;
   save_sidecar: (args: { pdfPath: string; doc: EldrawDocument }) => Promise<void>;
   acquire_lock: (args: { pdfPath: string }) => Promise<boolean>;


### PR DESCRIPTION
## What

Switch `render_page` to return `tauri::ipc::Response` so PNG bytes travel as a raw buffer instead of a JSON array of numbers.

## Why

Discovered while validating `v0.1.0-rc.2`: every PDF page rendered white with frontend error `failed to decode page image`. Root cause: plain `Vec<u8>` returns from Tauri 2 commands serialize through `serde_json` as `number[]`. The TS annotation claimed `Uint8Array` but runtime was `number[]`, so `new Blob([number[]], {type:'image/png'})` coerced each inner array to its `toString()` representation, producing garbage that `<img>` could not decode.

Tauri's `tauri::ipc::Response` is the documented way to send raw bytes over IPC.

## Changes

- `src-tauri/src/pdf.rs`: `render_page` now returns `AppResult<Response>`, wrapping the PNG byte vec via `Response::new`.
- `src/lib/ipc/index.ts` + `src/lib/types.ts`: `renderPage` return type is `Promise<ArrayBuffer>`.
- `PdfLayer.svelte` unchanged — `Blob` accepts `ArrayBuffer` as a `BlobPart` natively.

## Testing

- `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` all pass.
- `pnpm lint` and `pnpm test` (199 tests) all pass.
- Manual AppImage verification will happen on the next rc build.
