### PR TITLE
fix(canvas): stop wrapper divs from eating pointer events

### DIFF
--- a/src/lib/canvas/CanvasStack.svelte
+++ b/src/lib/canvas/CanvasStack.svelte
@@ -124,15 +124,19 @@
   }
   .layer-live {
     z-index: 4;
+    pointer-events: none;
   }
   .layer-shape-live {
     z-index: 5;
+    pointer-events: none;
   }
   .layer-temp-ink {
     z-index: 6;
+    pointer-events: none;
   }
   .layer-laser {
     z-index: 7;
+    pointer-events: none;
   }
   .layer-overlay {
     z-index: 8;


### PR DESCRIPTION
Fixes #33.

## What

`CanvasStack.svelte` wraps each draw surface in a `<div class="layer layer-X">` with an explicit `z-index` but no `pointer-events` rule. CSS defaults that to `auto`, so the wrapper divs at z:5/6/7 (`layer-shape-live`, `layer-temp-ink`, `layer-laser`) intercepted every click at the full canvas area and silently discarded it. Pointers never reached `LiveLayer` (z:4) even when the pen tool was the active tool.

## Why it broke everything

The child canvases already self-gate (`.temp-ink-layer` and `.laser-layer` are `pointer-events: none` when inactive; `.shape-live` toggles `inactive` based on tool kind). But a child being `none` does not let events fall through if the parent is `auto` — the event still hits the parent, and the parent has no handler.

So the wrapper divs consistently ate the clicks before they reached `LiveLayer` or the `HighlightLayer` beneath.

## Fix

Set `pointer-events: none` on all four interactive wrapper divs. Child canvases continue to opt in with their own `pointer-events: auto` when their tool is active.

## Testing

- `pnpm lint` and `pnpm test` (199 tests) pass.
- Manual verification needs rc.4 build; expected: pen, highlighter, eraser, graph, line, rect, ellipse, numberline all produce output.

No new unit test because this is a CSS / stacking fix with no pure-logic surface; the repo has no component tests harness yet. I'll open a separate issue to introduce one if it becomes useful.