### PR TITLE
fix(ui): suppress webview default context menu in release builds

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import 'katex/dist/katex.min.css';
 
   interface Props {
@@ -6,6 +7,13 @@
   }
 
   let { children }: Props = $props();
+
+  onMount(() => {
+    if (import.meta.env.DEV) return;
+    const suppress = (e: MouseEvent) => e.preventDefault();
+    window.addEventListener('contextmenu', suppress);
+    return () => window.removeEventListener('contextmenu', suppress);
+  });
 </script>
 
 {@render children?.()}


### PR DESCRIPTION
Fixes #35.

## What

Right-clicking anywhere in the app showed the webview's default navigation menu (Back / Forward / Stop / Reload), all greyed out except Reload. That menu has no reason to exist in a desktop annotator.

## Fix

Added a global `contextmenu` listener on `window` in `+layout.svelte` that `preventDefault`s in production builds. In dev the menu is preserved so right-click inspection still works.

Existing per-element handlers (e.g. the custom-swatch delete in `ColorPalette.svelte`) fire at the target phase before the window listener, so they are unaffected.

## Testing

- `pnpm lint` and `pnpm test` pass.
- Manual verification on rc.4 AppImage: right-click should do nothing visible.