### PR TITLE
fix(laser): follow cursor on hover, not only during drag

### DIFF
--- a/src/lib/canvas/LaserLayer.svelte
+++ b/src/lib/canvas/LaserLayer.svelte
@@ -111,6 +111,7 @@
 
   function onPointerMove(e: PointerEvent) {
     if (!active) return;
+    if (activePointerId !== null && activePointerId !== e.pointerId) return;
     pushPoint(e);
     e.preventDefault();
   }
@@ -125,8 +126,7 @@
     activePointerId = null;
   }
 
-  function onPointerLeave() {
-    if (!active) return;
+  function reset() {
     trail = [];
     if (rafId !== null) {
       cancelAnimationFrame(rafId);
@@ -135,13 +135,10 @@
     clear();
   }
 
-  function reset() {
-    trail = [];
-    if (rafId !== null) {
-      cancelAnimationFrame(rafId);
-      rafId = null;
-    }
-    clear();
+  function onPointerLeave(e: PointerEvent) {
+    if (!active) return;
+    if (activePointerId !== null && activePointerId !== e.pointerId) return;
+    reset();
   }
 
   $effect(() => {

--- a/src/lib/canvas/LaserLayer.svelte
+++ b/src/lib/canvas/LaserLayer.svelte
@@ -110,7 +110,7 @@
   }
 
   function onPointerMove(e: PointerEvent) {
-    if (!active || activePointerId !== e.pointerId) return;
+    if (!active) return;
     pushPoint(e);
     e.preventDefault();
   }
@@ -123,6 +123,16 @@
       // not captured; ignore
     }
     activePointerId = null;
+  }
+
+  function onPointerLeave() {
+    if (!active) return;
+    trail = [];
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+    clear();
   }
 
   function reset() {
@@ -164,6 +174,7 @@
   onpointermove={onPointerMove}
   onpointerup={onPointerUp}
   onpointercancel={onPointerUp}
+  onpointerleave={onPointerLeave}
 ></canvas>
 
 <style>


### PR DESCRIPTION
Fixes #37.

## What

`LaserLayer.onPointerMove` gated on `activePointerId !== e.pointerId`, so the laser dot only tracked the cursor while a pointer button was held. Users expect a laser pointer to follow the cursor as soon as the tool is active.

## Fix

- `onPointerMove` now runs whenever `active` is true; no `activePointerId` gate.
- `onPointerDown` / `onPointerUp` still manage pointer capture, so click-drag trails keep working.
- Added `onPointerLeave` that clears the trail and cancels the running raf, so the fading dot doesn't linger at the last position when the cursor exits the canvas.

## Testing

- `pnpm lint` and `pnpm test` pass (the pure `tests/laser.test.ts` helpers are unchanged).
- Manual verification on rc.4: with laser active, moving the mouse without clicking should show the dot; leaving the canvas should clear it; click-drag should still leave a fading trail.