### PR TITLE
fix(sidebar): render PDF page thumbnails instead of blank swatches

### DIFF
--- a/src/lib/sidebar/ThumbnailStrip.svelte
+++ b/src/lib/sidebar/ThumbnailStrip.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+  import { onDestroy, untrack } from 'svelte';
   import type { Page } from '$lib/types';
+  import { renderPage } from '$lib/ipc';
   import { thumbnailSize } from './thumbnailSize';
 
   interface Props {
@@ -23,12 +25,58 @@
   }: Props = $props();
 
   const canDelete = $derived(pages.length > 1);
+
+  /** Rendered thumbnail URLs keyed by pdfSourceIndex (the stable PDF page slot). */
+  let previewUrls = $state(new Map<number, string>());
+  const inflight = new Set<number>();
+
+  function thumbnailScale(widthPt: number): number {
+    if (!widthPt || widthPt <= 0) return 1;
+    const target = Math.max(64, Math.min(maxWidth, 220));
+    return target / widthPt;
+  }
+
+  async function ensureThumbnail(page: Page): Promise<void> {
+    if (page.type !== 'pdf') return;
+    const sourceIndex = page.pdfSourceIndex ?? page.pageIndex;
+    if (previewUrls.has(sourceIndex) || inflight.has(sourceIndex)) return;
+    inflight.add(sourceIndex);
+    try {
+      const bytes = await renderPage(sourceIndex, thumbnailScale(page.width));
+      const blob = new Blob([bytes], { type: 'image/png' });
+      const url = URL.createObjectURL(blob);
+      previewUrls = new Map(previewUrls).set(sourceIndex, url);
+    } catch {
+      // Leave the slot blank on failure; main layer surfaces the error.
+    } finally {
+      inflight.delete(sourceIndex);
+    }
+  }
+
+  $effect(() => {
+    const snapshot = pages;
+    untrack(() => {
+      for (const p of snapshot) void ensureThumbnail(p);
+    });
+  });
+
+  onDestroy(() => {
+    for (const url of previewUrls.values()) URL.revokeObjectURL(url);
+    previewUrls.clear();
+  });
+
+  function previewFor(page: Page): string | undefined {
+    if (page.type !== 'pdf') return undefined;
+    const key = page.pdfSourceIndex ?? page.pageIndex;
+    return previewUrls.get(key);
+  }
 </script>
 
 <aside class="strip" aria-label="Page thumbnails">
   <ul>
     {#each pages as page, i (page.pageIndex)}
       {@const size = thumbnailSize(page.width, page.height, maxWidth)}
+      {@const url = previewFor(page)}
       <li class="row" class:active={i === currentIndex}>
         <button
           type="button"
@@ -40,7 +88,9 @@
           <span
             class="preview"
             class:blank={page.type === 'blank'}
-            style="width: {size.width}px; height: {size.height}px;"
+            style="width: {size.width}px; height: {size.height}px; {url
+              ? `background-image: url('${url}');`
+              : ''}"
           ></span>
           <span class="label">{i + 1}</span>
         </button>
@@ -133,11 +183,14 @@
   }
   .preview {
     display: block;
-    background: #fff;
+    background-color: #fff;
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
     box-shadow: 0 1px 4px rgba(0, 0, 0, 0.5);
   }
   .preview.blank {
-    background: #fafafa;
+    background-color: #fafafa;
   }
   .label {
     font-size: 11px;

--- a/src/lib/sidebar/ThumbnailStrip.svelte
+++ b/src/lib/sidebar/ThumbnailStrip.svelte
@@ -12,6 +12,8 @@
     onduplicate?: (index: number) => void;
     ondelete?: (index: number) => void;
     maxWidth?: number;
+    /** Stable identifier for the loaded PDF; thumbnail cache is scoped to it. */
+    docKey?: string | null;
   }
 
   const {
@@ -22,13 +24,18 @@
     onduplicate,
     ondelete,
     maxWidth = 140,
+    docKey = null,
   }: Props = $props();
 
   const canDelete = $derived(pages.length > 1);
+  const MAX_CONCURRENT_RENDERS = 3;
 
-  /** Rendered thumbnail URLs keyed by pdfSourceIndex (the stable PDF page slot). */
   let previewUrls = $state(new Map<number, string>());
   const inflight = new Set<number>();
+  const queue: Page[] = [];
+  let activeRenders = 0;
+  let destroyed = false;
+  let cacheKey: string | null = null;
 
   function thumbnailScale(widthPt: number): number {
     if (!widthPt || widthPt <= 0) return 1;
@@ -36,39 +43,104 @@
     return target / widthPt;
   }
 
-  async function ensureThumbnail(page: Page): Promise<void> {
-    if (page.type !== 'pdf') return;
-    const sourceIndex = page.pdfSourceIndex ?? page.pageIndex;
-    if (previewUrls.has(sourceIndex) || inflight.has(sourceIndex)) return;
-    inflight.add(sourceIndex);
+  function sourceKey(page: Page): number {
+    return page.pdfSourceIndex ?? page.pageIndex;
+  }
+
+  function revokeAll() {
+    for (const url of previewUrls.values()) URL.revokeObjectURL(url);
+    previewUrls = new Map();
+    inflight.clear();
+    queue.length = 0;
+    activeRenders = 0;
+  }
+
+  function pumpQueue() {
+    while (!destroyed && activeRenders < MAX_CONCURRENT_RENDERS && queue.length > 0) {
+      const page = queue.shift()!;
+      void renderOne(page);
+    }
+  }
+
+  async function renderOne(page: Page): Promise<void> {
+    const key = sourceKey(page);
+    activeRenders += 1;
     try {
-      const bytes = await renderPage(sourceIndex, thumbnailScale(page.width));
+      const bytes = await renderPage(key, thumbnailScale(page.width));
+      if (destroyed) return;
       const blob = new Blob([bytes], { type: 'image/png' });
       const url = URL.createObjectURL(blob);
-      previewUrls = new Map(previewUrls).set(sourceIndex, url);
+      if (destroyed) {
+        URL.revokeObjectURL(url);
+        return;
+      }
+      const next = new Map(previewUrls);
+      const prior = next.get(key);
+      if (prior) URL.revokeObjectURL(prior);
+      next.set(key, url);
+      previewUrls = next;
     } catch {
       // Leave the slot blank on failure; main layer surfaces the error.
     } finally {
-      inflight.delete(sourceIndex);
+      inflight.delete(key);
+      activeRenders -= 1;
+      pumpQueue();
     }
   }
+
+  function enqueue(page: Page) {
+    if (page.type !== 'pdf') return;
+    const key = sourceKey(page);
+    if (previewUrls.has(key) || inflight.has(key)) return;
+    inflight.add(key);
+    queue.push(page);
+  }
+
+  function pruneStaleKeys(snapshot: Page[]) {
+    const live = new Set<number>();
+    for (const p of snapshot) if (p.type === 'pdf') live.add(sourceKey(p));
+    let changed = false;
+    const next = new Map(previewUrls);
+    for (const [key, url] of next) {
+      if (!live.has(key)) {
+        URL.revokeObjectURL(url);
+        next.delete(key);
+        changed = true;
+      }
+    }
+    if (changed) previewUrls = next;
+  }
+
+  $effect(() => {
+    const key = docKey;
+    untrack(() => {
+      if (key !== cacheKey) {
+        revokeAll();
+        cacheKey = key;
+      }
+    });
+  });
 
   $effect(() => {
     const snapshot = pages;
     untrack(() => {
-      for (const p of snapshot) void ensureThumbnail(p);
+      pruneStaleKeys(snapshot);
+      for (const p of snapshot) enqueue(p);
+      pumpQueue();
     });
   });
 
   onDestroy(() => {
+    destroyed = true;
     for (const url of previewUrls.values()) URL.revokeObjectURL(url);
     previewUrls.clear();
+    inflight.clear();
+    queue.length = 0;
   });
 
   function previewFor(page: Page): string | undefined {
     if (page.type !== 'pdf') return undefined;
-    const key = page.pdfSourceIndex ?? page.pageIndex;
-    return previewUrls.get(key);
+    return previewUrls.get(sourceKey(page));
   }
 </script>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -464,6 +464,7 @@
     <ThumbnailStrip
       {pages}
       currentIndex={pageIndex}
+      docKey={doc?.pdfHash ?? null}
       onpick={onThumbPick}
       onmove={onThumbMove}
       onduplicate={onThumbDuplicate}


### PR DESCRIPTION
Fixes #34.

## What

`ThumbnailStrip` has always rendered a solid-white `<span class="preview">` placeholder — it never called `renderPage`, so thumbnails were never drawn. This PR wires thumbnails to the same IPC the main `PdfLayer` uses.

## Fix

- `ensureThumbnail(page)` calls `renderPage(sourceIndex, scale)` at a target pixel width clamped to `[64, 220]` px.
- Rendered PNG bytes are wrapped in a `Blob` and stored as an object URL, keyed by `pdfSourceIndex` so reorder / duplicate / delete reuse existing renders.
- Blank pages stay blank; failures leave the slot empty and fall through to the main layer's error reporting.
- Object URLs are revoked on destroy to avoid leaks.

## Testing

- `pnpm lint` and `pnpm test` pass.
- Manual verification on rc.4 AppImage: open a multi-page PDF, thumbnails should render each page scaled down.

## Performance note

Each thumbnail is its own `render_page` call at a smaller scale. This is fine for now but adds load at open time. Once #36 (page bitmap cache) lands, thumbnails will benefit automatically by sharing the cache with the main render path.