### PR TITLE
chore(release): v0.1.0-rc.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eldraw",
-  "version": "0.1.0-rc.3",
+  "version": "0.1.0-rc.4",
   "description": "PDF annotation tool for live math teaching",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1013,7 +1013,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "eldraw"
-version = "0.1.0-rc.3"
+version = "0.1.0-rc.4"
 dependencies = [
  "image",
  "pdfium-render",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eldraw"
-version = "0.1.0-rc.3"
+version = "0.1.0-rc.4"
 description = "PDF annotation tool for live math teaching"
 authors = ["Adam"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "eldraw",
-  "version": "0.1.0-rc.3",
+  "version": "0.1.0-rc.4",
   "identifier": "com.adamkadaban.eldraw",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary

Fourth release candidate. Addresses every bug reported against rc.3.

## Fixes since rc.3

- **#33 / #40** — wrapper `<div>`s in `CanvasStack` no longer swallow pointer events; pen, highlighter, eraser, shapes, text, graph, and numberline tools all draw again.
- **#34 / #43** — sidebar thumbnails now render via `renderPage`, with a per-document cache (keyed on `pdfHash`), bounded concurrency, stale-key pruning, and teardown safety.
- **#35 / #41** — global `contextmenu` listener suppresses the webview's browser context menu in production builds.
- **#37 / #42** — laser pointer follows the cursor on hover; multi-pointer safety guards on move and leave.

## Deferred

- #36 (perf / page cache), #38 (detached sidebar window), #39 (ruler/line tool).

## Testing

- `pnpm lint && pnpm test` and `cargo check` clean on each contributing branch.
- Manual verification needed from the artifacts produced by the `v0.1.0-rc.4` tag.