### PR TITLE
fix(canvas): restore pointer events on live layers + tool cursor + debug logger

### DIFF
--- a/src/lib/canvas/LiveLayer.svelte
+++ b/src/lib/canvas/LiveLayer.svelte
@@ -4,6 +4,8 @@
   import { toolStore } from '$lib/store/tool';
   import { strokeFromInput } from '$lib/tools/pen';
   import { drawLiveStroke } from './strokeRenderer';
+  import { cursorForTool } from './cursors';
+  import { log } from '$lib/log';
 
   interface Props {
     width: number;
@@ -24,7 +26,7 @@
   let activePointerId: number | null = null;
   let startTime = 0;
   let points: Point[] = [];
-  let currentTool: ToolKind = 'pen';
+  let currentTool: ToolKind = $state('pen');
   let currentStyle: StrokeStyle = {
     color: '#000',
     width: 2,
@@ -35,6 +37,7 @@
   const unsubscribeTool = toolStore.subscribe((s) => {
     currentTool = s.tool;
     currentStyle = s.style;
+    log('tool', `live-layer sees tool=${s.tool}`, s.style);
   });
   onDestroy(unsubscribeTool);
 
@@ -108,6 +111,7 @@
   }
 
   function onPointerDown(e: PointerEvent) {
+    log('live', `pointerdown tool=${currentTool} type=${e.pointerType} id=${e.pointerId}`);
     if (e.pointerType === 'touch') return;
     if (
       currentTool !== 'pen' &&
@@ -172,6 +176,7 @@
 
     if (commit && (currentTool === 'pen' || currentTool === 'highlighter') && points.length > 0) {
       const stroke = strokeFromInput(points, currentStyle, currentTool);
+      log('live', `commit ${currentTool} stroke points=${points.length}`);
       oncommit?.(stroke);
     }
     if (commit && currentTool === 'graph' && graphStart && graphEnd) {
@@ -211,7 +216,7 @@
   {width}
   {height}
   class="live-layer"
-  style="width: {width}px; height: {height}px;"
+  style="width: {width}px; height: {height}px; cursor: {cursorForTool(currentTool)};"
   onpointerdown={onPointerDown}
   onpointermove={onPointerMove}
   onpointerup={onPointerUp}
@@ -222,7 +227,7 @@
   .live-layer {
     position: absolute;
     inset: 0;
+    pointer-events: auto;
     touch-action: none;
-    cursor: crosshair;
   }
 </style>

--- a/src/lib/canvas/ShapeLiveLayer.svelte
+++ b/src/lib/canvas/ShapeLiveLayer.svelte
@@ -11,6 +11,7 @@
   import { currentStyle } from '$lib/store/sidebar';
   import { normalizeBounds } from '$lib/tools/shapes';
   import { drawLine, drawNumberLine, drawShape } from './objectRenderer';
+  import { log } from '$lib/log';
 
   interface Props {
     width: number;
@@ -127,6 +128,7 @@
   }
 
   function onPointerDown(e: PointerEvent) {
+    log('shape', `pointerdown tool=${currentTool} active=${isActive} id=${e.pointerId}`);
     if (!isActive) return;
     if (e.pointerType === 'touch') return;
     canvas.setPointerCapture(e.pointerId);
@@ -152,7 +154,10 @@
       // not captured
     }
     activePointerId = null;
-    if (doCommit) commit();
+    if (doCommit) {
+      log('shape', `commit ${currentTool}`);
+      commit();
+    }
     clear();
   }
 
@@ -182,6 +187,7 @@
   .shape-live {
     position: absolute;
     inset: 0;
+    pointer-events: auto;
     touch-action: none;
     cursor: crosshair;
   }

--- a/src/lib/canvas/cursors.ts
+++ b/src/lib/canvas/cursors.ts
@@ -1,0 +1,42 @@
+import type { ToolKind } from '$lib/types';
+
+/**
+ * CSS cursor value for each drawing tool. Uses inline SVG data URIs for
+ * pen/highlighter so the hotspot visibly reflects the active tool.
+ */
+const PEN_SVG =
+  "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20'><path d='M2 18 L6 14 L14 6 L18 2 L18 2 L14 6 L6 14 Z' fill='%23222' stroke='white' stroke-width='1'/><circle cx='2' cy='18' r='1.2' fill='white'/></svg>\") 2 18, crosshair";
+
+const HIGHLIGHTER_SVG =
+  "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='22' height='22' viewBox='0 0 22 22'><path d='M3 19 L7 15 L15 7 L19 11 L11 19 Z' fill='%23fdd835' stroke='%23555' stroke-width='1'/></svg>\") 3 19, crosshair";
+
+const ERASER_SVG =
+  "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'><rect x='4' y='8' width='14' height='8' rx='2' fill='%23f4a' stroke='%23222' stroke-width='1.4' transform='rotate(-30 11 12)'/></svg>\") 12 12, cell";
+
+export function cursorForTool(tool: ToolKind): string {
+  switch (tool) {
+    case 'pen':
+      return PEN_SVG;
+    case 'highlighter':
+      return HIGHLIGHTER_SVG;
+    case 'eraser':
+      return ERASER_SVG;
+    case 'line':
+    case 'rect':
+    case 'ellipse':
+    case 'numberline':
+    case 'graph':
+    case 'ruler':
+    case 'protractor':
+      return 'crosshair';
+    case 'text':
+      return 'text';
+    case 'select':
+      return 'default';
+    case 'pan':
+      return 'grab';
+    case 'laser':
+    case 'temp-ink':
+      return 'crosshair';
+  }
+}

--- a/src/lib/ipc/index.ts
+++ b/src/lib/ipc/index.ts
@@ -1,12 +1,32 @@
 import { invoke } from '@tauri-apps/api/core';
 import type { EldrawDocument, PdfMeta } from '$lib/types';
+import { log, warn } from '$lib/log';
 
 export async function openPdf(path: string): Promise<PdfMeta> {
-  return invoke('open_pdf', { path });
+  const t = performance.now();
+  try {
+    const meta = await invoke<PdfMeta>('open_pdf', { path });
+    log('ipc', `open_pdf ok pages=${meta.pages.length} in ${(performance.now() - t).toFixed(1)}ms`);
+    return meta;
+  } catch (err) {
+    warn('ipc', `open_pdf failed after ${(performance.now() - t).toFixed(1)}ms`, err);
+    throw err;
+  }
 }
 
 export async function renderPage(pageIndex: number, scale: number): Promise<ArrayBuffer> {
-  return invoke('render_page', { pageIndex, scale });
+  const t = performance.now();
+  try {
+    const bytes = await invoke<ArrayBuffer>('render_page', { pageIndex, scale });
+    log(
+      'ipc',
+      `render_page idx=${pageIndex} scale=${scale.toFixed(3)} bytes=${bytes.byteLength} in ${(performance.now() - t).toFixed(1)}ms`,
+    );
+    return bytes;
+  } catch (err) {
+    warn('ipc', `render_page idx=${pageIndex} failed`, err);
+    throw err;
+  }
 }
 
 export async function loadSidecar(pdfPath: string): Promise<EldrawDocument | null> {

--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -1,9 +1,7 @@
 /**
- * Toggleable debug logger. Enable with `localStorage.ELDRAW_DEBUG=1` or
- * `?eldrawDebug=1` in the URL. Off by default so production is quiet.
- *
- * Output goes to the webview console; in a Tauri build the user can open
- * devtools (Ctrl+Shift+I) or pipe logs through `tauri-plugin-log` later.
+ * Toggleable debug logger. Enable with `localStorage.ELDRAW_DEBUG=1`,
+ * `?eldrawDebug=1`, or `window.eldrawDebug(true)` at runtime. Off by default
+ * so production is quiet; `warn()` is also gated.
  */
 
 type Scope = 'tool' | 'live' | 'shape' | 'temp-ink' | 'laser' | 'render' | 'page' | 'doc' | 'ipc';
@@ -22,18 +20,20 @@ function detect(): boolean {
 }
 
 export function initDebugLogger(): void {
+  if (typeof window === 'undefined') return;
   enabled = detect();
-  if (enabled && typeof window !== 'undefined') {
-    // Expose a runtime toggle so the user can flip it in devtools.
-    (window as unknown as { eldrawDebug: (on: boolean) => void }).eldrawDebug = (on: boolean) => {
-      enabled = on;
-      try {
-        window.localStorage.setItem('ELDRAW_DEBUG', on ? '1' : '0');
-      } catch {
-        // ignore
-      }
-      console.info(`[eldraw] debug logging ${on ? 'ON' : 'OFF'}`);
-    };
+
+  (window as unknown as { eldrawDebug: (on: boolean) => void }).eldrawDebug = (on: boolean) => {
+    enabled = on;
+    try {
+      window.localStorage.setItem('ELDRAW_DEBUG', on ? '1' : '0');
+    } catch {
+      // ignore
+    }
+    console.info(`[eldraw] debug logging ${on ? 'ON' : 'OFF'}`);
+  };
+
+  if (enabled) {
     console.info('[eldraw] debug logging ON (set window.eldrawDebug(false) to stop)');
   }
 }
@@ -48,6 +48,7 @@ export function log(scope: Scope, message: string, data?: unknown): void {
 }
 
 export function warn(scope: Scope, message: string, data?: unknown): void {
+  if (!enabled) return;
   if (data === undefined) {
     console.warn(`[eldraw:${scope}] ${message}`);
   } else {

--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -1,0 +1,60 @@
+/**
+ * Toggleable debug logger. Enable with `localStorage.ELDRAW_DEBUG=1` or
+ * `?eldrawDebug=1` in the URL. Off by default so production is quiet.
+ *
+ * Output goes to the webview console; in a Tauri build the user can open
+ * devtools (Ctrl+Shift+I) or pipe logs through `tauri-plugin-log` later.
+ */
+
+type Scope = 'tool' | 'live' | 'shape' | 'temp-ink' | 'laser' | 'render' | 'page' | 'doc' | 'ipc';
+
+let enabled = false;
+
+function detect(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    if (window.localStorage?.getItem('ELDRAW_DEBUG') === '1') return true;
+  } catch {
+    // localStorage may be disabled.
+  }
+  const qs = new URLSearchParams(window.location.search);
+  return qs.get('eldrawDebug') === '1';
+}
+
+export function initDebugLogger(): void {
+  enabled = detect();
+  if (enabled && typeof window !== 'undefined') {
+    // Expose a runtime toggle so the user can flip it in devtools.
+    (window as unknown as { eldrawDebug: (on: boolean) => void }).eldrawDebug = (on: boolean) => {
+      enabled = on;
+      try {
+        window.localStorage.setItem('ELDRAW_DEBUG', on ? '1' : '0');
+      } catch {
+        // ignore
+      }
+      console.info(`[eldraw] debug logging ${on ? 'ON' : 'OFF'}`);
+    };
+    console.info('[eldraw] debug logging ON (set window.eldrawDebug(false) to stop)');
+  }
+}
+
+export function log(scope: Scope, message: string, data?: unknown): void {
+  if (!enabled) return;
+  if (data === undefined) {
+    console.log(`[eldraw:${scope}] ${message}`);
+  } else {
+    console.log(`[eldraw:${scope}] ${message}`, data);
+  }
+}
+
+export function warn(scope: Scope, message: string, data?: unknown): void {
+  if (data === undefined) {
+    console.warn(`[eldraw:${scope}] ${message}`);
+  } else {
+    console.warn(`[eldraw:${scope}] ${message}`, data);
+  }
+}
+
+export function isDebugEnabled(): boolean {
+  return enabled;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import 'katex/dist/katex.min.css';
+  import { initDebugLogger } from '$lib/log';
 
   interface Props {
     children?: import('svelte').Snippet;
@@ -9,6 +10,7 @@
   let { children }: Props = $props();
 
   onMount(() => {
+    initDebugLogger();
     if (import.meta.env.DEV) return;
     const suppress = (e: MouseEvent) => e.preventDefault();
     window.addEventListener('contextmenu', suppress);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -27,6 +27,7 @@
   import { activeGraph, clearActiveGraph, setActiveGraph } from '$lib/store/activeGraph';
   import { createGraphObject } from '$lib/graph/graphObject';
   import GraphEditor from '$lib/graph/GraphEditor.svelte';
+  import { log } from '$lib/log';
   import type {
     AnyObject,
     EldrawDocument,
@@ -54,6 +55,7 @@
   const pages = $derived(doc?.pages ?? []);
 
   function onThumbPick(i: number): void {
+    log('page', `thumb pick ${i}`);
     viewport.setPage(i, pages.length);
   }
 

--- a/tests/cursors.test.ts
+++ b/tests/cursors.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { cursorForTool } from '../src/lib/canvas/cursors';
+import type { ToolKind } from '../src/lib/types';
+
+describe('cursorForTool', () => {
+  it('uses inline SVG cursors for ink tools with explicit hotspots', () => {
+    const pen = cursorForTool('pen');
+    expect(pen).toMatch(/^url\("data:image\/svg\+xml/);
+    expect(pen).toMatch(/2 18/);
+    expect(pen).toMatch(/, crosshair$/);
+
+    const highlighter = cursorForTool('highlighter');
+    expect(highlighter).toMatch(/fdd835/);
+    expect(highlighter).toMatch(/3 19/);
+
+    const eraser = cursorForTool('eraser');
+    expect(eraser).toMatch(/12 12/);
+    expect(eraser).toMatch(/, cell$/);
+  });
+
+  it('maps shape-like tools to crosshair', () => {
+    const shapeTools: ToolKind[] = [
+      'line',
+      'rect',
+      'ellipse',
+      'numberline',
+      'graph',
+      'ruler',
+      'protractor',
+      'laser',
+      'temp-ink',
+    ];
+    for (const t of shapeTools) {
+      expect(cursorForTool(t)).toBe('crosshair');
+    }
+  });
+
+  it('maps navigation/selection tools to native cursors', () => {
+    expect(cursorForTool('text')).toBe('text');
+    expect(cursorForTool('select')).toBe('default');
+    expect(cursorForTool('pan')).toBe('grab');
+  });
+
+  it('returns a non-empty string for every tool kind', () => {
+    const all: ToolKind[] = [
+      'pen',
+      'highlighter',
+      'eraser',
+      'line',
+      'rect',
+      'ellipse',
+      'numberline',
+      'graph',
+      'text',
+      'select',
+      'pan',
+      'laser',
+      'temp-ink',
+      'protractor',
+      'ruler',
+    ];
+    for (const t of all) {
+      const cursor = cursorForTool(t);
+      expect(cursor.length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #45. rc.4 regressed drawing because my earlier wrapper fix (#40) set every `.layer-*` div to `pointer-events: none`. `LaserLayer` and `TempInkLayer` explicitly redeclare `pointer-events: auto` on their `.active` canvas, but `LiveLayer` and `ShapeLiveLayer` never did — per the CSS UI spec, the *initial* value `auto` on a descendant does **not** override a `none` ancestor; it has to be redeclared.

## Changes

- `LiveLayer.svelte`: explicit `pointer-events: auto` on `.live-layer`; `currentTool` is now `\$state` so the cursor re-derives on tool change.
- `ShapeLiveLayer.svelte`: explicit `pointer-events: auto` on `.shape-live` (the `.inactive { none }` override still shuts it off when a non-shape tool is selected).
- `src/lib/canvas/cursors.ts`: new `cursorForTool()` returns inline-SVG cursors for pen/highlighter/eraser, `crosshair` for shapes/graph, `text` for text, `grab` for pan, etc. Applied via inline `style` on `.live-layer`.
- `src/lib/log.ts`: toggleable debug logger. Enabled by `localStorage.ELDRAW_DEBUG=1` or `?eldrawDebug=1`; exposes `window.eldrawDebug(true/false)` at runtime. Instrumented `LiveLayer`, `ShapeLiveLayer`, `renderPage`, `openPdf`, and thumbnail picks.
- `+layout.svelte`: calls `initDebugLogger()` on mount.

## Testing

- `pnpm lint && pnpm test` clean (199 passing).
- Manual: set `localStorage.ELDRAW_DEBUG=1`, reload, open devtools — pointer-down, commit, and render timings show up with `[eldraw:…]` prefix.