### PR TITLE
chore(release): v0.1.0-rc.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eldraw",
-  "version": "0.1.0-rc.4",
+  "version": "0.1.0-rc.5",
   "description": "PDF annotation tool for live math teaching",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1013,7 +1013,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "eldraw"
-version = "0.1.0-rc.4"
+version = "0.1.0-rc.5"
 dependencies = [
  "image",
  "pdfium-render",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eldraw"
-version = "0.1.0-rc.4"
+version = "0.1.0-rc.5"
 description = "PDF annotation tool for live math teaching"
 authors = ["Adam"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "eldraw",
-  "version": "0.1.0-rc.4",
+  "version": "0.1.0-rc.5",
   "identifier": "com.adamkadaban.eldraw",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary

Fifth release candidate. Fixes the rc.4 regression where no drawing tool produced output, adds tool cursors, and ships a debug logger.

## Fixes since rc.4

- **#45 / #46** — `LiveLayer` and `ShapeLiveLayer` now explicitly set `pointer-events: auto`, restoring pen/highlighter/eraser/graph/shape/numberline input.
- Cursor now reflects the active tool (SVG pen/highlighter/eraser, crosshair for shapes, text caret, grab for pan).
- New `src/lib/log.ts` debug logger. Enable with `localStorage.ELDRAW_DEBUG=1` or `?eldrawDebug=1`, or toggle at runtime with `window.eldrawDebug(true|false)` in devtools. Instruments pointer-down/commit on live layers, tool changes, `renderPage` / `openPdf` timings, and thumbnail picks.

## Testing

- `pnpm lint && pnpm test` clean (203 passing, +4 for cursors).
- Awaiting manual verification on the rc.5 artifacts.