### PR TITLE
fix(canvas): make ShapeLiveLayer reactive and lighten text editor

### DIFF
--- a/src/lib/canvas/ShapeLiveLayer.svelte
+++ b/src/lib/canvas/ShapeLiveLayer.svelte
@@ -31,8 +31,8 @@
   let activePointerId: number | null = null;
   let start = { x: 0, y: 0 };
   let end = { x: 0, y: 0 };
-  let currentTool: ToolKind = 'pen';
-  let style: StrokeStyle = { color: '#000', width: 2, dash: 'solid', opacity: 1 };
+  let currentTool: ToolKind = $state('pen');
+  let style: StrokeStyle = $state({ color: '#000', width: 2, dash: 'solid', opacity: 1 });
 
   const unsubTool = toolStore.subscribe((s) => {
     currentTool = s.tool;

--- a/src/lib/canvas/TextEditor.svelte
+++ b/src/lib/canvas/TextEditor.svelte
@@ -140,8 +140,8 @@
   .content {
     width: 100%;
     box-sizing: border-box;
-    background: #1b1b1b;
-    color: #eee;
+    background: #fff;
+    color: #111;
     border: 1px solid #3a3a3a;
     border-radius: 4px;
     padding: 6px;


### PR DESCRIPTION
## Summary

- Fix line/rect/ellipse/numberline being inert after rc.5: \`currentTool\` and \`style\` in \`ShapeLiveLayer.svelte\` were plain \`let\` bindings mutated from store subscriptions. Svelte 5 \`\$derived\` only tracks \`\$state\`, so \`isActive\` never re-derived from its initial \`'pen'\` value and the canvas stayed pinned with \`pointer-events: none\` via \`.inactive\`. Same pattern was already fixed in \`LiveLayer.svelte\` but missed here.
- Lighten \`TextEditor\` textarea background from \`#1b1b1b\` to \`#fff\` so user-picked colors (default black) are readable while typing, matching the KaTeX preview pane.

Closes #48

## Testing

- \`pnpm lint\`: clean
- \`pnpm test\`: 203/203 passing