### PR TITLE
fix(sidebar): dash style buttons no longer overflow sidebar

### DIFF
--- a/src/lib/sidebar/DashStyleToggle.svelte
+++ b/src/lib/sidebar/DashStyleToggle.svelte
@@ -42,7 +42,7 @@
         aria-pressed={style === value}
         onclick={() => select(style)}
       >
-        <svg viewBox="0 0 60 12" width="60" height="12" aria-hidden="true">
+        <svg viewBox="0 0 60 12" preserveAspectRatio="none" class="dash-svg" aria-hidden="true">
           <line
             x1="2"
             y1="6"
@@ -97,6 +97,14 @@
     cursor: pointer;
     display: grid;
     place-items: center;
+    min-width: 0;
+    overflow: hidden;
+  }
+  .dash-svg {
+    display: block;
+    width: 100%;
+    height: 12px;
+    max-width: 60px;
   }
   .option:hover {
     border-color: #555;


### PR DESCRIPTION
## Summary

- Dash option SVGs had `width="60"` which exceeded the available column width (~57px) inside the 220px sidebar, pushing the row past the aside.
- Switched to `width: 100%` with `preserveAspectRatio="none"` and a 60px `max-width` so they scale down to fit any sidebar width.

Closes #52

## Testing
- `pnpm lint`: clean
- `pnpm test`: 203/203