### PR TITLE
feat(sidebar): pinned tool presets recallable via Ctrl+1..9

### DIFF
--- a/src/lib/app/shortcuts.ts
+++ b/src/lib/app/shortcuts.ts
@@ -96,6 +96,11 @@ export const shortcuts: Action<HTMLElement> = () => {
         documentStore.undo(currentPage());
         return;
       }
+      if (!event.shiftKey && !event.altKey && key >= '1' && key <= '9') {
+        event.preventDefault();
+        sidebar.applyPresetSlot(Number(key));
+        return;
+      }
       return;
     }
 

--- a/src/lib/sidebar/Sidebar.svelte
+++ b/src/lib/sidebar/Sidebar.svelte
@@ -4,6 +4,7 @@
   import ColorPalette from './ColorPalette.svelte';
   import WidthPicker from './WidthPicker.svelte';
   import DashStyleToggle from './DashStyleToggle.svelte';
+  import ToolPresets from './ToolPresets.svelte';
 
   interface Props {
     onToolChange?: (tool: ToolKind) => void;
@@ -76,6 +77,22 @@
     sidebar.togglePin();
     onPinChange?.(sidebar.snapshot().pinned);
   }
+
+  function onCapturePreset() {
+    sidebar.capturePreset();
+  }
+
+  function onApplyPreset(id: string) {
+    sidebar.applyPreset(id);
+    const snap = sidebar.snapshot();
+    onToolChange?.(snap.activeTool);
+    const key = styleKeyFor(snap.activeTool);
+    if (key) onStyleChange?.(snap.toolStyles[key]);
+  }
+
+  function onRemovePreset(id: string) {
+    sidebar.removePreset(id);
+  }
 </script>
 
 <aside
@@ -127,6 +144,16 @@
 
   <section class="section" aria-label="Dash">
     <DashStyleToggle value={style.dash} onChange={onDash} />
+  </section>
+
+  <section class="section" aria-label="Presets">
+    <ToolPresets
+      presets={state.presets}
+      activeTool={state.activeTool}
+      onApply={onApplyPreset}
+      onCapture={onCapturePreset}
+      onRemove={onRemovePreset}
+    />
   </section>
 
   {#if state.activeTool === 'laser'}

--- a/src/lib/sidebar/ToolPresets.svelte
+++ b/src/lib/sidebar/ToolPresets.svelte
@@ -42,7 +42,7 @@
   </div>
   {#if presets.length === 0}
     <p class="empty">
-      Configure a tool, then press <kbd>+</kbd> to save it. Recall with <kbd>Ctrl</kbd>+<kbd
+      Configure a tool, then click <kbd>+</kbd> to save it. Recall with <kbd>Ctrl</kbd>+<kbd
         >1-9</kbd
       >.
     </p>
@@ -188,7 +188,8 @@
     display: none;
     padding: 0;
   }
-  .slot:hover .remove {
+  .slot:hover .remove,
+  .slot:focus-within .remove {
     display: block;
   }
   .remove:hover {

--- a/src/lib/sidebar/ToolPresets.svelte
+++ b/src/lib/sidebar/ToolPresets.svelte
@@ -1,0 +1,199 @@
+<script lang="ts">
+  import type { ToolKind, ToolPreset } from '$lib/types';
+  import { MAX_PRESETS, canPresetTool } from '$lib/store/sidebar';
+
+  interface Props {
+    presets: ToolPreset[];
+    activeTool: ToolKind;
+    onApply?: (id: string) => void;
+    onCapture?: () => void;
+    onRemove?: (id: string) => void;
+  }
+
+  let { presets, activeTool, onApply, onCapture, onRemove }: Props = $props();
+
+  const ICON: Record<string, string> = {
+    pen: '✏️',
+    highlighter: '🖍️',
+    line: '／',
+    rect: '▭',
+    ellipse: '◯',
+    numberline: '↔',
+  };
+
+  const canCapture = $derived(presets.length < MAX_PRESETS && canPresetTool(activeTool));
+
+  function dashTitle(dash: string): string {
+    return dash === 'solid' ? '' : ` ${dash}`;
+  }
+</script>
+
+<div class="presets">
+  <div class="header">
+    <h3 class="section-title">Presets</h3>
+    <button
+      type="button"
+      class="capture"
+      aria-label="Save current tool as preset"
+      title={canCapture ? 'Save current tool as preset' : 'Presets full or tool not presettable'}
+      disabled={!canCapture}
+      onclick={onCapture}>+</button
+    >
+  </div>
+  {#if presets.length === 0}
+    <p class="empty">
+      Configure a tool, then press <kbd>+</kbd> to save it. Recall with <kbd>Ctrl</kbd>+<kbd
+        >1-9</kbd
+      >.
+    </p>
+  {:else}
+    <div class="grid" role="list">
+      {#each presets as preset, i (preset.id)}
+        <div class="slot" role="listitem">
+          <button
+            type="button"
+            class="chip"
+            title={`${preset.tool} ${preset.style.width}px${dashTitle(preset.style.dash)} — Ctrl+${i + 1}`}
+            onclick={() => onApply?.(preset.id)}
+          >
+            <span class="dot" style="background: {preset.style.color};"></span>
+            <span class="icon" aria-hidden="true">{ICON[preset.tool] ?? '?'}</span>
+            <span class="w">{preset.style.width}</span>
+            <span class="slot-num" aria-hidden="true">{i + 1}</span>
+          </button>
+          <button
+            type="button"
+            class="remove"
+            aria-label={`Remove preset ${i + 1}`}
+            title="Remove preset"
+            onclick={() => onRemove?.(preset.id)}>×</button
+          >
+        </div>
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .presets {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  .section-title {
+    font-size: 11px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: #bbb;
+    margin: 0;
+    font-weight: 500;
+  }
+  .capture {
+    background: #1b1b1b;
+    border: 1px solid #333;
+    color: #ddd;
+    border-radius: 4px;
+    width: 22px;
+    height: 22px;
+    line-height: 1;
+    cursor: pointer;
+    font-size: 14px;
+  }
+  .capture:hover:not(:disabled) {
+    border-color: #7ab7ff;
+    color: #fff;
+  }
+  .capture:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+  .empty {
+    font-size: 10px;
+    color: #888;
+    margin: 0;
+    line-height: 1.4;
+  }
+  .empty kbd {
+    background: #1b1b1b;
+    border: 1px solid #333;
+    border-radius: 3px;
+    padding: 0 3px;
+    font-size: 9px;
+    font-family: ui-monospace, monospace;
+  }
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 4px;
+  }
+  .slot {
+    position: relative;
+  }
+  .chip {
+    width: 100%;
+    background: #1b1b1b;
+    border: 1px solid #333;
+    color: #ddd;
+    border-radius: 4px;
+    padding: 6px 4px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 11px;
+    min-width: 0;
+    overflow: hidden;
+  }
+  .chip:hover {
+    border-color: #7ab7ff;
+  }
+  .dot {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    border: 1px solid #555;
+    flex: 0 0 auto;
+  }
+  .icon {
+    font-size: 12px;
+  }
+  .w {
+    font-variant-numeric: tabular-nums;
+    color: #aaa;
+  }
+  .slot-num {
+    margin-left: auto;
+    font-size: 9px;
+    color: #666;
+  }
+  .remove {
+    position: absolute;
+    top: -4px;
+    right: -4px;
+    width: 14px;
+    height: 14px;
+    line-height: 1;
+    background: #2a2a2a;
+    border: 1px solid #555;
+    color: #ccc;
+    border-radius: 50%;
+    cursor: pointer;
+    font-size: 10px;
+    display: none;
+    padding: 0;
+  }
+  .slot:hover .remove {
+    display: block;
+  }
+  .remove:hover {
+    border-color: #e53935;
+    color: #fff;
+    background: #e53935;
+  }
+</style>

--- a/src/lib/sidebar/index.ts
+++ b/src/lib/sidebar/index.ts
@@ -3,4 +3,5 @@ export { default as ColorPalette } from './ColorPalette.svelte';
 export { default as WidthPicker } from './WidthPicker.svelte';
 export { default as DashStyleToggle } from './DashStyleToggle.svelte';
 export { default as ThumbnailStrip } from './ThumbnailStrip.svelte';
+export { default as ToolPresets } from './ToolPresets.svelte';
 export { thumbnailSize, type ThumbSize } from './thumbnailSize';

--- a/src/lib/store/sidebar.ts
+++ b/src/lib/store/sidebar.ts
@@ -259,18 +259,54 @@ export const sidebar = createSidebarStore();
 
 const PRESETS_STORAGE_KEY = 'eldraw.presets.v1';
 
+const VALID_TOOLS: ReadonlySet<ToolKind> = new Set<ToolKind>([
+  'pen',
+  'highlighter',
+  'eraser',
+  'line',
+  'rect',
+  'ellipse',
+  'numberline',
+  'graph',
+  'text',
+  'select',
+  'pan',
+  'laser',
+  'temp-ink',
+  'protractor',
+  'ruler',
+]);
+
+const VALID_DASH: ReadonlySet<DashStyle> = new Set<DashStyle>(['solid', 'dashed', 'dotted']);
+
+function clamp(n: number, lo: number, hi: number): number {
+  if (!Number.isFinite(n)) return lo;
+  return Math.max(lo, Math.min(hi, n));
+}
+
 function isValidPreset(value: unknown): value is ToolPreset {
   if (!value || typeof value !== 'object') return false;
   const p = value as Record<string, unknown>;
-  if (typeof p.id !== 'string' || typeof p.tool !== 'string') return false;
+  if (typeof p.id !== 'string') return false;
+  if (typeof p.tool !== 'string' || !VALID_TOOLS.has(p.tool as ToolKind)) return false;
   const style = p.style as Record<string, unknown> | undefined;
   if (!style || typeof style !== 'object') return false;
-  return (
-    typeof style.color === 'string' &&
-    typeof style.width === 'number' &&
-    typeof style.dash === 'string' &&
-    typeof style.opacity === 'number'
-  );
+  if (typeof style.color !== 'string') return false;
+  if (typeof style.dash !== 'string' || !VALID_DASH.has(style.dash as DashStyle)) return false;
+  if (typeof style.width !== 'number' || !Number.isFinite(style.width)) return false;
+  if (typeof style.opacity !== 'number' || !Number.isFinite(style.opacity)) return false;
+  return true;
+}
+
+function sanitizePreset(p: ToolPreset): ToolPreset {
+  return {
+    ...p,
+    style: {
+      ...p.style,
+      width: clamp(p.style.width, 0.25, 64),
+      opacity: clamp(p.style.opacity, 0, 1),
+    },
+  };
 }
 
 function loadPersistedPresets(): ToolPreset[] | null {
@@ -280,25 +316,40 @@ function loadPersistedPresets(): ToolPreset[] | null {
     if (!raw) return null;
     const parsed: unknown = JSON.parse(raw);
     if (!Array.isArray(parsed)) return null;
-    return parsed.filter(isValidPreset).slice(0, MAX_PRESETS);
+    return parsed.filter(isValidPreset).map(sanitizePreset).slice(0, MAX_PRESETS);
   } catch {
     return null;
   }
 }
 
-export function hydrateSidebarFromStorage(): void {
+let hydrated = false;
+let hydrationUnsubscribe: (() => void) | null = null;
+
+export function hydrateSidebarFromStorage(): () => void {
+  if (hydrated) return hydrationUnsubscribe ?? (() => undefined);
+  hydrated = true;
+
   const presets = loadPersistedPresets();
   if (presets && presets.length > 0) sidebar.setPresets(presets);
 
-  if (typeof localStorage !== 'undefined') {
-    sidebar.subscribe((s) => {
-      try {
-        localStorage.setItem(PRESETS_STORAGE_KEY, JSON.stringify(s.presets));
-      } catch {
-        // storage full or unavailable; ignore
-      }
-    });
+  if (typeof localStorage === 'undefined') {
+    hydrationUnsubscribe = () => undefined;
+    return hydrationUnsubscribe;
   }
+
+  const unsubscribe = sidebar.subscribe((s) => {
+    try {
+      localStorage.setItem(PRESETS_STORAGE_KEY, JSON.stringify(s.presets));
+    } catch {
+      // storage full or unavailable; ignore
+    }
+  });
+  hydrationUnsubscribe = () => {
+    unsubscribe();
+    hydrated = false;
+    hydrationUnsubscribe = null;
+  };
+  return hydrationUnsubscribe;
 }
 
 export const currentStyle: Readable<StrokeStyle> = derived(sidebar, (s) => {

--- a/src/lib/store/sidebar.ts
+++ b/src/lib/store/sidebar.ts
@@ -1,8 +1,10 @@
 import { derived, get, writable, type Readable } from 'svelte/store';
-import type { ColorPalette, DashStyle, StrokeStyle, ToolKind } from '$lib/types';
+import type { ColorPalette, DashStyle, StrokeStyle, ToolKind, ToolPreset } from '$lib/types';
 import { clampFadeMs, DEFAULT_TEMP_INK_FADE_MS } from '$lib/tools/tempInk';
 
 export type StyledTool = 'pen' | 'highlighter' | 'line';
+
+export const MAX_PRESETS = 9;
 
 export interface LaserStyle {
   color: string;
@@ -43,6 +45,7 @@ export interface SidebarState {
   activeColor: string;
   laser: LaserStyle;
   tempInkFadeMs: number;
+  presets: ToolPreset[];
 }
 
 function initialState(): SidebarState {
@@ -61,7 +64,12 @@ function initialState(): SidebarState {
     activeColor: '#000000',
     laser: { ...DEFAULT_LASER_STYLE },
     tempInkFadeMs: DEFAULT_TEMP_INK_FADE_MS,
+    presets: [],
   };
+}
+
+export function canPresetTool(tool: ToolKind): boolean {
+  return styleKeyFor(tool) !== null;
 }
 
 export function styleKeyFor(tool: ToolKind): StyledTool | null {
@@ -90,6 +98,17 @@ function mapPalette(
 function createSidebarStore() {
   const store = writable<SidebarState>(initialState());
   const { subscribe, update, set } = store;
+
+  function applyPresetValue(preset: ToolPreset) {
+    const key = styleKeyFor(preset.tool);
+    if (!key) return;
+    update((st) => ({
+      ...st,
+      activeTool: preset.tool,
+      activeColor: preset.style.color,
+      toolStyles: { ...st.toolStyles, [key]: { ...preset.style } },
+    }));
+  }
 
   return {
     subscribe,
@@ -195,6 +214,41 @@ function createSidebarStore() {
       update((s) => ({ ...s, tempInkFadeMs: clampFadeMs(ms) }));
     },
 
+    capturePreset(): ToolPreset | null {
+      const s = get(store);
+      const key = styleKeyFor(s.activeTool);
+      if (!key) return null;
+      if (s.presets.length >= MAX_PRESETS) return null;
+      const preset: ToolPreset = {
+        id: crypto.randomUUID(),
+        tool: s.activeTool,
+        style: { ...s.toolStyles[key], color: s.activeColor },
+      };
+      update((st) => ({ ...st, presets: [...st.presets, preset] }));
+      return preset;
+    },
+
+    removePreset(id: string) {
+      update((s) => ({ ...s, presets: s.presets.filter((p) => p.id !== id) }));
+    },
+
+    applyPreset(id: string) {
+      const s = get(store);
+      const preset = s.presets.find((p) => p.id === id);
+      if (!preset) return;
+      applyPresetValue(preset);
+    },
+
+    applyPresetSlot(slot: number) {
+      const s = get(store);
+      const preset = s.presets[slot - 1];
+      if (preset) applyPresetValue(preset);
+    },
+
+    setPresets(presets: ToolPreset[]) {
+      update((s) => ({ ...s, presets: presets.slice(0, MAX_PRESETS) }));
+    },
+
     snapshot(): SidebarState {
       return get(store);
     },
@@ -202,6 +256,50 @@ function createSidebarStore() {
 }
 
 export const sidebar = createSidebarStore();
+
+const PRESETS_STORAGE_KEY = 'eldraw.presets.v1';
+
+function isValidPreset(value: unknown): value is ToolPreset {
+  if (!value || typeof value !== 'object') return false;
+  const p = value as Record<string, unknown>;
+  if (typeof p.id !== 'string' || typeof p.tool !== 'string') return false;
+  const style = p.style as Record<string, unknown> | undefined;
+  if (!style || typeof style !== 'object') return false;
+  return (
+    typeof style.color === 'string' &&
+    typeof style.width === 'number' &&
+    typeof style.dash === 'string' &&
+    typeof style.opacity === 'number'
+  );
+}
+
+function loadPersistedPresets(): ToolPreset[] | null {
+  if (typeof localStorage === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(PRESETS_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return null;
+    return parsed.filter(isValidPreset).slice(0, MAX_PRESETS);
+  } catch {
+    return null;
+  }
+}
+
+export function hydrateSidebarFromStorage(): void {
+  const presets = loadPersistedPresets();
+  if (presets && presets.length > 0) sidebar.setPresets(presets);
+
+  if (typeof localStorage !== 'undefined') {
+    sidebar.subscribe((s) => {
+      try {
+        localStorage.setItem(PRESETS_STORAGE_KEY, JSON.stringify(s.presets));
+      } catch {
+        // storage full or unavailable; ignore
+      }
+    });
+  }
+}
 
 export const currentStyle: Readable<StrokeStyle> = derived(sidebar, (s) => {
   const key = styleKeyFor(s.activeTool);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -51,6 +51,12 @@ export interface StrokeStyle {
   opacity: number;
 }
 
+export interface ToolPreset {
+  id: string;
+  tool: ToolKind;
+  style: StrokeStyle;
+}
+
 interface ObjectBase {
   id: ObjectId;
   createdAt: number;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,7 +15,7 @@
   import { openAndLoadPdf } from '$lib/ipc/pdf';
   import { loadSidecar } from '$lib/ipc';
   import { pdf, clearError } from '$lib/store/pdf';
-  import { sidebar } from '$lib/store/sidebar';
+  import { sidebar, hydrateSidebarFromStorage } from '$lib/store/sidebar';
   import { currentDocument, documentStore, pdfPageIndexAt } from '$lib/store/document';
   import { startAutosave } from '$lib/store/autosave';
   import { viewport, viewportStore, MIN_SCALE, MAX_SCALE } from '$lib/store/viewport';
@@ -304,6 +304,7 @@
   }
 
   onMount(() => {
+    hydrateSidebarFromStorage();
     stopBridge = startToolBridge();
   });
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -303,14 +303,17 @@
     else if (event.deltaY > 0) viewport.zoomOut();
   }
 
+  let stopHydration: (() => void) | null = null;
+
   onMount(() => {
-    hydrateSidebarFromStorage();
+    stopHydration = hydrateSidebarFromStorage();
     stopBridge = startToolBridge();
   });
 
   onDestroy(() => {
     stopBridge?.();
     stopAutosave?.();
+    stopHydration?.();
   });
 </script>
 

--- a/tests/sidebar-store.test.ts
+++ b/tests/sidebar-store.test.ts
@@ -75,4 +75,54 @@ describe('sidebar store', () => {
     sidebar.togglePin();
     expect(sidebar.snapshot().pinned).toBe(false);
   });
+
+  it('capturePreset stores the current tool + style and caps at 9', () => {
+    sidebar.setTool('pen');
+    sidebar.setActiveColor('#ff00aa');
+    sidebar.setWidth(5);
+    const p = sidebar.capturePreset();
+    expect(p).not.toBeNull();
+    expect(p?.tool).toBe('pen');
+    expect(p?.style.color).toBe('#ff00aa');
+    expect(p?.style.width).toBe(5);
+    expect(sidebar.snapshot().presets).toHaveLength(1);
+
+    for (let i = 0; i < 20; i += 1) sidebar.capturePreset();
+    expect(sidebar.snapshot().presets).toHaveLength(9);
+  });
+
+  it('capturePreset refuses tools without a style key', () => {
+    sidebar.setTool('laser');
+    expect(sidebar.capturePreset()).toBeNull();
+    expect(sidebar.snapshot().presets).toHaveLength(0);
+  });
+
+  it('applyPreset restores tool + style; applyPresetSlot is 1-indexed', () => {
+    sidebar.setTool('pen');
+    sidebar.setActiveColor('#112233');
+    sidebar.setWidth(3);
+    sidebar.capturePreset();
+    sidebar.setTool('highlighter');
+    sidebar.setActiveColor('#fdd835');
+    sidebar.setWidth(20);
+    sidebar.capturePreset();
+
+    sidebar.setTool('pen');
+    sidebar.setActiveColor('#000000');
+    sidebar.setWidth(1);
+
+    sidebar.applyPresetSlot(2);
+    const s = sidebar.snapshot();
+    expect(s.activeTool).toBe('highlighter');
+    expect(s.activeColor).toBe('#fdd835');
+    expect(s.toolStyles.highlighter.width).toBe(20);
+  });
+
+  it('removePreset drops by id', () => {
+    sidebar.setTool('pen');
+    const p = sidebar.capturePreset();
+    expect(sidebar.snapshot().presets).toHaveLength(1);
+    if (p) sidebar.removePreset(p.id);
+    expect(sidebar.snapshot().presets).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary

- Up to 9 tool+style presets saved from the current active tool (color, width, dash, opacity, tool kind).
- Recall with `Ctrl+1`..`Ctrl+9` or by clicking the chip in the new sidebar section.
- Each chip shows color dot + tool icon + width + slot number. Hover reveals × to remove.
- Presets persist across sessions in localStorage (`eldraw.presets.v1`). Hydration happens on `+page.svelte` mount.
- Only styleable tools (pen/highlighter/line/rect/ellipse/numberline) can be presetted; eraser/laser/temp-ink skipped.

Closes #53

## Testing
- `pnpm lint`: clean
- `pnpm test`: 207/207 (added 4 new tests)
- Manual: capture preset, switch tool+color, Ctrl+1 restores config