### PR TITLE
feat(document): clear-page button with undo support

### DIFF
--- a/src/lib/store/document.ts
+++ b/src/lib/store/document.ts
@@ -15,6 +15,7 @@ export interface DocumentStore {
   movePage(from: number, to: number): void;
   duplicatePage(index: number): void;
   deletePage(index: number): void;
+  clearPage(pageIndex: number): void;
 
   undo(pageIndex: number): void;
   redo(pageIndex: number): void;
@@ -225,6 +226,14 @@ export function createDocumentStore(): DocumentStore {
         history.onPageDelete(index);
         return { ...doc, pages: reindex(recomputeBlankAnchors(pages)) };
       });
+    },
+
+    clearPage(pageIndex) {
+      const doc = get(state);
+      if (!doc) return;
+      const page = doc.pages[pageIndex];
+      if (!page || page.objects.length === 0) return;
+      pushAndApply(pageIndex, { type: 'clearPage', objects: [...page.objects] });
     },
 
     undo(pageIndex) {

--- a/src/lib/store/history.ts
+++ b/src/lib/store/history.ts
@@ -4,7 +4,9 @@ import type { AnyObject, ObjectId, Page } from '$lib/types';
 export type Command =
   | { type: 'add'; object: AnyObject }
   | { type: 'remove'; object: AnyObject }
-  | { type: 'update'; objectId: ObjectId; before: AnyObject; after: AnyObject };
+  | { type: 'update'; objectId: ObjectId; before: AnyObject; after: AnyObject }
+  | { type: 'clearPage'; objects: AnyObject[] }
+  | { type: 'restorePage'; objects: AnyObject[] };
 
 export const HISTORY_LIMIT = 200;
 
@@ -19,6 +21,10 @@ export function applyCommand(page: Page, cmd: Command): Page {
         ...page,
         objects: page.objects.map((o) => (o.id === cmd.objectId ? cmd.after : o)),
       };
+    case 'clearPage':
+      return { ...page, objects: [] };
+    case 'restorePage':
+      return { ...page, objects: [...cmd.objects] };
   }
 }
 
@@ -35,6 +41,10 @@ export function invertCommand(cmd: Command): Command {
         before: cmd.after,
         after: cmd.before,
       };
+    case 'clearPage':
+      return { type: 'restorePage', objects: cmd.objects };
+    case 'restorePage':
+      return { type: 'clearPage', objects: cmd.objects };
   }
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -338,7 +338,7 @@
   <section class="main">
     {#if !isPresenter}
       <header class="topbar">
-        <button type="button" class="open" onclick={openFromDialog}>Open PDF…</button>
+        <button type="button" class="topbar-btn" onclick={openFromDialog}>Open PDF…</button>
         <div class="pager">
           <button
             type="button"
@@ -371,10 +371,10 @@
         </div>
         <button
           type="button"
-          class="clear-page"
+          class="topbar-btn"
           aria-label="Clear annotations on this page"
           title="Clear annotations on this page"
-          disabled={pageObjects.length === 0 && pageStrokes.length === 0}
+          disabled={pageObjects.length === 0}
           onclick={clearCurrentPage}
         >
           Clear page
@@ -561,7 +561,7 @@
     border-bottom: 1px solid #111;
     font-size: 12px;
   }
-  .open {
+  .topbar-btn {
     background: #2a2a2a;
     border: 1px solid #3a3a3a;
     color: #ddd;
@@ -569,8 +569,12 @@
     padding: 4px 10px;
     cursor: pointer;
   }
-  .open:hover {
+  .topbar-btn:hover:not(:disabled) {
     border-color: #666;
+  }
+  .topbar-btn:disabled {
+    opacity: 0.4;
+    cursor: default;
   }
   .pager,
   .zoom {
@@ -601,22 +605,6 @@
   }
   .zoom {
     margin-left: auto;
-  }
-  .clear-page {
-    background: #2a2a2a;
-    border: 1px solid #3a3a3a;
-    color: #ddd;
-    border-radius: 4px;
-    padding: 4px 10px;
-    cursor: pointer;
-  }
-  .clear-page:hover:not(:disabled) {
-    border-color: #a33;
-    color: #f7b;
-  }
-  .clear-page:disabled {
-    opacity: 0.4;
-    cursor: default;
   }
   .canvas-area {
     position: relative;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -88,6 +88,13 @@
     }
   }
 
+  function clearCurrentPage(): void {
+    if (pageObjects.length === 0) return;
+    const ok = window.confirm('Clear all annotations on this page? This can be undone.');
+    if (!ok) return;
+    documentStore.clearPage(pageIndex);
+  }
+
   const pageCount = $derived(doc?.pages.length ?? meta?.pageCount ?? 0);
   const pageIndex = $derived(Math.min(view.currentPageIndex, Math.max(0, pageCount - 1)));
   const currentPage = $derived(doc?.pages[pageIndex] ?? null);
@@ -362,6 +369,16 @@
           <span class="zoom-indicator">{Math.round(view.scale * 100)}%</span>
           <button type="button" aria-label="Zoom in" onclick={() => viewport.zoomIn()}>+</button>
         </div>
+        <button
+          type="button"
+          class="clear-page"
+          aria-label="Clear annotations on this page"
+          title="Clear annotations on this page"
+          disabled={pageObjects.length === 0 && pageStrokes.length === 0}
+          onclick={clearCurrentPage}
+        >
+          Clear page
+        </button>
       </header>
     {/if}
 
@@ -584,6 +601,22 @@
   }
   .zoom {
     margin-left: auto;
+  }
+  .clear-page {
+    background: #2a2a2a;
+    border: 1px solid #3a3a3a;
+    color: #ddd;
+    border-radius: 4px;
+    padding: 4px 10px;
+    cursor: pointer;
+  }
+  .clear-page:hover:not(:disabled) {
+    border-color: #a33;
+    color: #f7b;
+  }
+  .clear-page:disabled {
+    opacity: 0.4;
+    cursor: default;
   }
   .canvas-area {
     position: relative;

--- a/tests/page-ops.test.ts
+++ b/tests/page-ops.test.ts
@@ -184,4 +184,24 @@ describe('documentStore page ops', () => {
     const remainingBlank = doc.pages.find((p) => p.type === 'blank')!;
     expect(remainingBlank.insertedAfterPdfPage).toBeNull();
   });
+
+  it('clearPage empties the page and undo restores the objects', () => {
+    const store = createDocumentStore();
+    store.load(docWithPages([pdfPage(0), pdfPage(1)]));
+    store.addObject(0, stroke('a'));
+    store.addObject(0, stroke('b'));
+    store.clearPage(0);
+    expect(get(store)!.pages[0].objects).toHaveLength(0);
+    store.undo(0);
+    const ids = get(store)!.pages[0].objects.map((o) => o.id);
+    expect(ids).toEqual(['a', 'b']);
+  });
+
+  it('clearPage is a no-op on an already-empty page', () => {
+    const store = createDocumentStore();
+    store.load(docWithPages([pdfPage(0)]));
+    store.clearPage(0);
+    store.undo(0);
+    expect(get(store)!.pages[0].objects).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary

- Adds a **Clear page** button to the topbar that wipes all annotations on the current page after a confirm.
- Implemented as a new `clearPage` / `restorePage` Command pair in `history.ts`, so it round-trips through undo/redo like every other edit.
- `DocumentStore.clearPage(pageIndex)` snapshots the page's objects and pushes the command; no-op when the page is already empty.

Closes #54.

## Testing

- \`pnpm lint\` clean, \`pnpm test\` 205 passing (includes 2 new tests covering clear + undo round-trip and no-op on empty pages).