### PR TITLE
fix(canvas): render dashed/dotted strokes as centerline only

### DIFF
--- a/src/lib/canvas/strokeRenderer.ts
+++ b/src/lib/canvas/strokeRenderer.ts
@@ -52,27 +52,30 @@ export function drawStroke(
   const widthPx = stroke.style.width * ptToPx;
   const input = inputToPx(stroke.points, ptToPx);
 
-  const outline = getStroke(input, {
-    size: widthPx * 2,
-    thinning: 0.6,
-    smoothing: 0.5,
-    streamline: 0.5,
-    simulatePressure: opts.simulatePressure ?? false,
-    last: true,
-  });
+  const outline =
+    stroke.style.dash === 'solid'
+      ? getStroke(input, {
+          size: widthPx * 2,
+          thinning: 0.6,
+          smoothing: 0.5,
+          streamline: 0.5,
+          simulatePressure: opts.simulatePressure ?? false,
+          last: true,
+        })
+      : [];
 
   ctx.save();
   ctx.globalAlpha = stroke.style.opacity;
-  ctx.fillStyle = stroke.style.color;
 
-  if (outline.length > 0) {
-    const path = new Path2D(toSvgPath(outline));
-    ctx.fill(path);
-  }
-
-  if (stroke.style.dash !== 'solid' && input.length > 1) {
+  if (stroke.style.dash === 'solid') {
+    ctx.fillStyle = stroke.style.color;
+    if (outline.length > 0) {
+      const path = new Path2D(toSvgPath(outline));
+      ctx.fill(path);
+    }
+  } else if (input.length > 1) {
     ctx.strokeStyle = stroke.style.color;
-    ctx.lineWidth = Math.max(1, widthPx * 0.6);
+    ctx.lineWidth = Math.max(1, widthPx);
     ctx.lineCap = 'round';
     ctx.lineJoin = 'round';
     ctx.setLineDash(dashPattern(stroke.style.dash, widthPx));

--- a/src/lib/canvas/strokeRenderer.ts
+++ b/src/lib/canvas/strokeRenderer.ts
@@ -75,7 +75,7 @@ export function drawStroke(
     }
   } else if (input.length > 1) {
     ctx.strokeStyle = stroke.style.color;
-    ctx.lineWidth = Math.max(1, widthPx);
+    ctx.lineWidth = Math.max(0.5, widthPx);
     ctx.lineCap = 'round';
     ctx.lineJoin = 'round';
     ctx.setLineDash(dashPattern(stroke.style.dash, widthPx));
@@ -86,6 +86,11 @@ export function drawStroke(
     }
     ctx.stroke();
     ctx.setLineDash([]);
+  } else if (input.length === 1) {
+    ctx.fillStyle = stroke.style.color;
+    ctx.beginPath();
+    ctx.arc(input[0][0], input[0][1], Math.max(0.5, widthPx / 2), 0, Math.PI * 2);
+    ctx.fill();
   }
 
   ctx.restore();


### PR DESCRIPTION
## Summary

When drawing with a dashed or dotted stroke, the renderer was painting **both** the perfect-freehand filled outline and a dashed centerline on top. At normal speed the two overlapped; at higher pointer speed the streamline-smoothed outline drifted from the raw polyline and you'd see a solid "ghost" offset from the dashed line.

Fix: for dashed/dotted, skip the perfect-freehand fill entirely and just stroke the dashed centerline. Solid strokes are unchanged.

## Testing

- \`pnpm lint\` clean, \`pnpm test\` 203/203.
- Manual: draw slowly and quickly with pen + dashed / pen + dotted; only the dashed/dotted line appears.