### PR TITLE
feat(app): zen mode for distraction-free inking

### DIFF
--- a/src/lib/app/shortcuts.ts
+++ b/src/lib/app/shortcuts.ts
@@ -4,6 +4,7 @@ import { sidebar, styleKeyFor } from '$lib/store/sidebar';
 import { documentStore, currentDocument } from '$lib/store/document';
 import { viewport } from '$lib/store/viewport';
 import { presenter } from '$lib/store/presenter';
+import { zen } from '$lib/store/zen';
 import { isEditableTarget } from './shortcutParser';
 
 /**
@@ -79,6 +80,24 @@ export const shortcuts: Action<HTMLElement> = () => {
     if (key === 'Escape' && presenter.isActive()) {
       event.preventDefault();
       presenter.exit();
+      return;
+    }
+
+    if (key === 'Escape' && zen.isActive()) {
+      event.preventDefault();
+      zen.exit();
+      return;
+    }
+
+    if (
+      event.shiftKey &&
+      !event.ctrlKey &&
+      !event.metaKey &&
+      !event.altKey &&
+      (key === 'Z' || key === 'z')
+    ) {
+      event.preventDefault();
+      zen.toggle();
       return;
     }
 

--- a/src/lib/store/zen.ts
+++ b/src/lib/store/zen.ts
@@ -16,15 +16,15 @@ function createZen() {
     },
 
     enter(): void {
-      update((s) => (s.active ? s : { active: true }));
+      update((s) => (s.active ? s : { ...s, active: true }));
     },
 
     exit(): void {
-      update((s) => (s.active ? { active: false } : s));
+      update((s) => (s.active ? { ...s, active: false } : s));
     },
 
     toggle(): void {
-      update((s) => ({ active: !s.active }));
+      update((s) => ({ ...s, active: !s.active }));
     },
 
     reset(): void {

--- a/src/lib/store/zen.ts
+++ b/src/lib/store/zen.ts
@@ -1,0 +1,38 @@
+import { get, writable, type Readable } from 'svelte/store';
+
+export interface ZenState {
+  active: boolean;
+}
+
+function createZen() {
+  const store = writable<ZenState>({ active: false });
+  const { subscribe, update, set } = store;
+
+  return {
+    subscribe,
+
+    isActive(): boolean {
+      return get(store).active;
+    },
+
+    enter(): void {
+      update((s) => (s.active ? s : { active: true }));
+    },
+
+    exit(): void {
+      update((s) => (s.active ? { active: false } : s));
+    },
+
+    toggle(): void {
+      update((s) => ({ active: !s.active }));
+    },
+
+    reset(): void {
+      set({ active: false });
+    },
+  };
+}
+
+export const zen = createZen();
+
+export const zenStore: Readable<ZenState> = { subscribe: zen.subscribe };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -20,6 +20,7 @@
   import { startAutosave } from '$lib/store/autosave';
   import { viewport, viewportStore, MIN_SCALE, MAX_SCALE } from '$lib/store/viewport';
   import { presenterStore } from '$lib/store/presenter';
+  import { zenStore } from '$lib/store/zen';
   import { startToolBridge } from '$lib/app/toolBridge';
   import { shortcuts } from '$lib/app/shortcuts';
   import { openPdfDialog } from '$lib/app/openPdfDialog';
@@ -52,6 +53,9 @@
   const sidebarState = $derived($sidebar);
   const presenterState = $derived($presenterStore);
   const isPresenter = $derived(presenterState.active);
+  const zenState = $derived($zenStore);
+  const isZen = $derived(zenState.active);
+  const chromeHidden = $derived(isPresenter || isZen);
   const pages = $derived(doc?.pages ?? []);
 
   function onThumbPick(i: number): void {
@@ -330,17 +334,18 @@
   class="app"
   class:pinned={sidebarState.pinned}
   class:presenter={isPresenter}
-  class:has-thumbs={!isPresenter && pages.length > 0}
+  class:zen={isZen}
+  class:has-thumbs={!chromeHidden && pages.length > 0}
   use:shortcuts
   tabindex="-1"
   role="application"
 >
-  {#if !isPresenter}
+  {#if !chromeHidden}
     <Sidebar />
   {/if}
 
   <section class="main">
-    {#if !isPresenter}
+    {#if !chromeHidden}
       <header class="topbar">
         <button type="button" class="topbar-btn" onclick={openFromDialog}>Open PDF…</button>
         <div class="pager">
@@ -483,7 +488,7 @@
     </div>
   </section>
 
-  {#if !isPresenter && pages.length > 0}
+  {#if !chromeHidden && pages.length > 0}
     <ThumbnailStrip
       {pages}
       currentIndex={pageIndex}
@@ -493,6 +498,10 @@
       onduplicate={onThumbDuplicate}
       ondelete={onThumbDelete}
     />
+  {/if}
+
+  {#if isZen}
+    <div class="zen-hint" role="status">Zen mode — Shift+Z or Esc to exit</div>
   {/if}
 
   {#if editor && editorInitial}
@@ -548,6 +557,37 @@
   }
   .app.presenter .canvas-area {
     background: #000;
+  }
+  .app.zen {
+    grid-template-columns: 1fr;
+  }
+  .zen-hint {
+    position: fixed;
+    top: 16px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(20, 20, 20, 0.85);
+    color: #ddd;
+    padding: 6px 14px;
+    border-radius: 6px;
+    font-size: 12px;
+    pointer-events: none;
+    animation: zen-hint-fade 2.4s ease-out forwards;
+    z-index: 1000;
+  }
+  @keyframes zen-hint-fade {
+    0% {
+      opacity: 0;
+    }
+    15% {
+      opacity: 1;
+    }
+    70% {
+      opacity: 1;
+    }
+    100% {
+      opacity: 0;
+    }
   }
   .main {
     display: flex;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -56,6 +56,19 @@
   const zenState = $derived($zenStore);
   const isZen = $derived(zenState.active);
   const chromeHidden = $derived(isPresenter || isZen);
+
+  let zenHintVisible = $state(false);
+  $effect(() => {
+    if (!isZen) {
+      zenHintVisible = false;
+      return;
+    }
+    zenHintVisible = true;
+    const timer = window.setTimeout(() => {
+      zenHintVisible = false;
+    }, 2400);
+    return () => window.clearTimeout(timer);
+  });
   const pages = $derived(doc?.pages ?? []);
 
   function onThumbPick(i: number): void {
@@ -500,7 +513,7 @@
     />
   {/if}
 
-  {#if isZen}
+  {#if isZen && zenHintVisible}
     <div class="zen-hint" role="status">Zen mode — Shift+Z or Esc to exit</div>
   {/if}
 

--- a/tests/zen-store.test.ts
+++ b/tests/zen-store.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+import { zen } from '../src/lib/store/zen';
+
+describe('zen store', () => {
+  beforeEach(() => zen.reset());
+
+  it('starts inactive', () => {
+    expect(get(zen).active).toBe(false);
+    expect(zen.isActive()).toBe(false);
+  });
+
+  it('enter activates and is idempotent', () => {
+    zen.enter();
+    expect(zen.isActive()).toBe(true);
+    zen.enter();
+    expect(zen.isActive()).toBe(true);
+  });
+
+  it('exit deactivates and is idempotent', () => {
+    zen.enter();
+    zen.exit();
+    expect(zen.isActive()).toBe(false);
+    zen.exit();
+    expect(zen.isActive()).toBe(false);
+  });
+
+  it('toggle flips state', () => {
+    zen.toggle();
+    expect(zen.isActive()).toBe(true);
+    zen.toggle();
+    expect(zen.isActive()).toBe(false);
+  });
+
+  it('reset returns to inactive', () => {
+    zen.enter();
+    zen.reset();
+    expect(zen.isActive()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a **zen mode** that hides the sidebar, topbar, and thumbnail strip, leaving only the canvas.
- Toggled with `Shift+Z`; `Esc` also exits.
- Brief hint overlay on entry: _"Zen mode — Shift+Z or Esc to exit"_.

## Why

Requested for fully-focused live inking (e.g. when teaching from a blank page) without dropping into presenter mode.

## Implementation

- New \`src/lib/store/zen.ts\` mirrors the \`presenter.ts\` toggle store pattern (enter / exit / toggle / reset / isActive).
- \`shortcuts.ts\`: Shift+Z toggle (explicitly rejects ctrl/meta/alt to avoid colliding with Ctrl+Shift+Z redo); Esc exits when active.
- \`+page.svelte\`: new \`chromeHidden = isPresenter || isZen\` derived guard; adds \`.app.zen\` class + hint overlay.

## Testing

- \`pnpm lint\` ✅
- \`pnpm test\` ✅ (5 new tests in \`tests/zen-store.test.ts\`, 214 total passing)

Closes #65