### PR TITLE
feat(document): sample background color for blank pages

### DIFF
--- a/src/lib/app/shortcuts.ts
+++ b/src/lib/app/shortcuts.ts
@@ -5,6 +5,7 @@ import { documentStore, currentDocument } from '$lib/store/document';
 import { viewport } from '$lib/store/viewport';
 import { presenter } from '$lib/store/presenter';
 import { zen } from '$lib/store/zen';
+import { sampleCanvasBackground } from '$lib/canvas/bgSample';
 import { isEditableTarget } from './shortcutParser';
 
 /**
@@ -57,13 +58,23 @@ export const shortcuts: Action<HTMLElement> = () => {
     }
   }
 
+  function sampleCurrentPageBackground(): string | undefined {
+    if (typeof document === 'undefined') return undefined;
+    const canvas = document.querySelector<HTMLCanvasElement>(
+      '.pdf-slot canvas[aria-label="Rendered PDF page"]',
+    );
+    if (!canvas) return undefined;
+    return sampleCanvasBackground(canvas) ?? undefined;
+  }
+
   function insertBlankAfterCurrent(): void {
     const doc = get(currentDocument);
     if (!doc) return;
     const idx = currentPage();
     const page = doc.pages[idx];
     if (!page) return;
-    documentStore.insertBlankPageAfter(idx, page.width, page.height);
+    const background = page.type === 'pdf' ? sampleCurrentPageBackground() : page.background;
+    documentStore.insertBlankPageAfter(idx, page.width, page.height, background);
   }
 
   function handleKeyDown(event: KeyboardEvent): void {

--- a/src/lib/canvas/bgSample.ts
+++ b/src/lib/canvas/bgSample.ts
@@ -1,0 +1,109 @@
+/**
+ * Background color sampling for blank pages.
+ *
+ * Given a rendered PDF bitmap, we pick a handful of points away from the
+ * center (corners + edge midpoints + center) and find the dominant color
+ * bucket. If no bucket is clearly dominant (photographic / high-variance
+ * pages), we return `null` and callers fall back to white.
+ *
+ * Pure logic is exported separately so it can be unit-tested without a DOM.
+ */
+
+const DOMINANT_FRACTION = 0.5;
+const QUANTIZE_STEP = 16;
+
+export interface SamplePoint {
+  x: number;
+  y: number;
+}
+
+export function pickSamplePoints(width: number, height: number): SamplePoint[] {
+  if (width <= 0 || height <= 0) return [];
+  const inset = Math.max(1, Math.floor(Math.min(width, height) * 0.02));
+  const clampX = (n: number) => Math.max(0, Math.min(width - 1, n));
+  const clampY = (n: number) => Math.max(0, Math.min(height - 1, n));
+  const xs = [clampX(inset), clampX(Math.floor(width / 2)), clampX(width - 1 - inset)];
+  const ys = [clampY(inset), clampY(Math.floor(height / 2)), clampY(height - 1 - inset)];
+  const pts: SamplePoint[] = [];
+  for (const y of ys) {
+    for (const x of xs) pts.push({ x, y });
+  }
+  return pts;
+}
+
+function toHex(r: number, g: number, b: number): string {
+  const component = (n: number) =>
+    Math.max(0, Math.min(255, Math.round(n)))
+      .toString(16)
+      .padStart(2, '0');
+  return `#${component(r)}${component(g)}${component(b)}`;
+}
+
+/**
+ * Sample the dominant color from a rendered bitmap's RGBA pixel buffer.
+ * Returns a `#rrggbb` string, or `null` when the image is too noisy for a
+ * single color to dominate (photographic content, heavy gradients).
+ */
+export function sampleBackgroundFromPixels(
+  pixels: Uint8ClampedArray,
+  width: number,
+  height: number,
+): string | null {
+  if (width <= 0 || height <= 0) return null;
+  if (pixels.length < width * height * 4) return null;
+
+  const samples = pickSamplePoints(width, height);
+  const buckets = new Map<number, { count: number; r: number; g: number; b: number }>();
+  let total = 0;
+
+  for (const { x, y } of samples) {
+    const i = (y * width + x) * 4;
+    const r = pixels[i];
+    const g = pixels[i + 1];
+    const b = pixels[i + 2];
+    const a = pixels[i + 3];
+    if (a < 128) continue;
+    const qr = Math.round(r / QUANTIZE_STEP);
+    const qg = Math.round(g / QUANTIZE_STEP);
+    const qb = Math.round(b / QUANTIZE_STEP);
+    const key = (qr << 16) | (qg << 8) | qb;
+    const existing = buckets.get(key);
+    if (existing) {
+      existing.count += 1;
+      existing.r += r;
+      existing.g += g;
+      existing.b += b;
+    } else {
+      buckets.set(key, { count: 1, r, g, b });
+    }
+    total += 1;
+  }
+
+  if (total === 0) return null;
+
+  let best: { count: number; r: number; g: number; b: number } | null = null;
+  for (const bucket of buckets.values()) {
+    if (!best || bucket.count > best.count) best = bucket;
+  }
+  if (!best) return null;
+  if (best.count / total < DOMINANT_FRACTION) return null;
+
+  return toHex(best.r / best.count, best.g / best.count, best.b / best.count);
+}
+
+/**
+ * Sample the dominant color from a 2D canvas. Returns `null` when the
+ * canvas is unreadable (e.g., tainted by a cross-origin image) or the
+ * content is too varied to pick a clear background.
+ */
+export function sampleCanvasBackground(canvas: HTMLCanvasElement): string | null {
+  if (canvas.width === 0 || canvas.height === 0) return null;
+  const ctx = canvas.getContext('2d', { willReadFrequently: true });
+  if (!ctx) return null;
+  try {
+    const data = ctx.getImageData(0, 0, canvas.width, canvas.height);
+    return sampleBackgroundFromPixels(data.data, data.width, data.height);
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/canvas/bgSample.ts
+++ b/src/lib/canvas/bgSample.ts
@@ -9,6 +9,8 @@
  * Pure logic is exported separately so it can be unit-tested without a DOM.
  */
 
+import { isSafeHexColor } from '$lib/color';
+
 const DOMINANT_FRACTION = 0.5;
 const QUANTIZE_STEP = 16;
 
@@ -95,15 +97,78 @@ export function sampleBackgroundFromPixels(
  * Sample the dominant color from a 2D canvas. Returns `null` when the
  * canvas is unreadable (e.g., tainted by a cross-origin image) or the
  * content is too varied to pick a clear background.
+ *
+ * Reads only the ~9 sample points rather than the whole canvas to keep
+ * large bitmaps cheap.
  */
 export function sampleCanvasBackground(canvas: HTMLCanvasElement): string | null {
-  if (canvas.width === 0 || canvas.height === 0) return null;
+  const { width, height } = canvas;
+  if (width === 0 || height === 0) return null;
   const ctx = canvas.getContext('2d', { willReadFrequently: true });
   if (!ctx) return null;
+  const points = pickSamplePoints(width, height);
+  if (points.length === 0) return null;
+
+  const pixels = new Uint8ClampedArray(points.length * 4);
   try {
-    const data = ctx.getImageData(0, 0, canvas.width, canvas.height);
-    return sampleBackgroundFromPixels(data.data, data.width, data.height);
+    for (let i = 0; i < points.length; i += 1) {
+      const { x, y } = points[i];
+      const sample = ctx.getImageData(x, y, 1, 1).data;
+      pixels[i * 4] = sample[0];
+      pixels[i * 4 + 1] = sample[1];
+      pixels[i * 4 + 2] = sample[2];
+      pixels[i * 4 + 3] = sample[3];
+    }
   } catch {
     return null;
   }
+
+  const color = sampleBackgroundFromContiguousPixels(pixels, points.length);
+  return isSafeHexColor(color) ? color : null;
+}
+
+/**
+ * Dominant-color pick over a small packed RGBA buffer of exactly
+ * `sampleCount` pixels (one per sample point). Kept private; the exported
+ * {@link sampleBackgroundFromPixels} continues to accept a full 2D buffer
+ * for unit tests that operate on synthesized images.
+ */
+function sampleBackgroundFromContiguousPixels(
+  pixels: Uint8ClampedArray,
+  sampleCount: number,
+): string | null {
+  const buckets = new Map<number, { count: number; r: number; g: number; b: number }>();
+  let total = 0;
+
+  for (let i = 0; i < sampleCount; i += 1) {
+    const off = i * 4;
+    const r = pixels[off];
+    const g = pixels[off + 1];
+    const b = pixels[off + 2];
+    const a = pixels[off + 3];
+    if (a < 128) continue;
+    const qr = Math.round(r / QUANTIZE_STEP);
+    const qg = Math.round(g / QUANTIZE_STEP);
+    const qb = Math.round(b / QUANTIZE_STEP);
+    const key = (qr << 16) | (qg << 8) | qb;
+    const existing = buckets.get(key);
+    if (existing) {
+      existing.count += 1;
+      existing.r += r;
+      existing.g += g;
+      existing.b += b;
+    } else {
+      buckets.set(key, { count: 1, r, g, b });
+    }
+    total += 1;
+  }
+
+  if (total === 0) return null;
+  let best: { count: number; r: number; g: number; b: number } | null = null;
+  for (const bucket of buckets.values()) {
+    if (!best || bucket.count > best.count) best = bucket;
+  }
+  if (!best) return null;
+  if (best.count / total < DOMINANT_FRACTION) return null;
+  return toHex(best.r / best.count, best.g / best.count, best.b / best.count);
 }

--- a/src/lib/color.ts
+++ b/src/lib/color.ts
@@ -1,0 +1,14 @@
+/**
+ * Strict hex color validation. Accepts only `#rrggbb` with exactly six
+ * hexadecimal digits. Used as a trust boundary for values that are later
+ * interpolated into CSS (sidecars are untrusted input).
+ */
+const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/;
+
+export function isSafeHexColor(value: unknown): value is string {
+  return typeof value === 'string' && HEX_COLOR_RE.test(value);
+}
+
+export function sanitizeHexColor(value: unknown): string | undefined {
+  return isSafeHexColor(value) ? value : undefined;
+}

--- a/src/lib/sidebar/ThumbnailStrip.svelte
+++ b/src/lib/sidebar/ThumbnailStrip.svelte
@@ -160,9 +160,10 @@
           <span
             class="preview"
             class:blank={page.type === 'blank'}
-            style="width: {size.width}px; height: {size.height}px; {url
-              ? `background-image: url('${url}');`
-              : ''}"
+            style="width: {size.width}px; height: {size.height}px;{page.type === 'blank' &&
+            page.background
+              ? ` background-color: ${page.background};`
+              : ''}{url ? ` background-image: url('${url}');` : ''}"
           ></span>
           <span class="label">{i + 1}</span>
         </button>

--- a/src/lib/sidebar/ThumbnailStrip.svelte
+++ b/src/lib/sidebar/ThumbnailStrip.svelte
@@ -160,10 +160,12 @@
           <span
             class="preview"
             class:blank={page.type === 'blank'}
-            style="width: {size.width}px; height: {size.height}px;{page.type === 'blank' &&
-            page.background
-              ? ` background-color: ${page.background};`
-              : ''}{url ? ` background-image: url('${url}');` : ''}"
+            style="width: {size.width}px; height: {size.height}px;{url
+              ? ` background-image: url('${url}');`
+              : ''}"
+            style:background-color={page.type === 'blank'
+              ? (page.background ?? undefined)
+              : undefined}
           ></span>
           <span class="label">{i + 1}</span>
         </button>

--- a/src/lib/store/document.ts
+++ b/src/lib/store/document.ts
@@ -11,7 +11,12 @@ export interface DocumentStore {
   removeObject(pageIndex: number, id: ObjectId): void;
   updateObject(pageIndex: number, id: ObjectId, patch: Partial<AnyObject>): void;
 
-  insertBlankPageAfter(afterArrayIndex: number, width: number, height: number): void;
+  insertBlankPageAfter(
+    afterArrayIndex: number,
+    width: number,
+    height: number,
+    background?: string,
+  ): void;
   movePage(from: number, to: number): void;
   duplicatePage(index: number): void;
   deletePage(index: number): void;
@@ -169,7 +174,7 @@ export function createDocumentStore(): DocumentStore {
       pushAndApply(pageIndex, { type: 'update', objectId: id, before, after });
     },
 
-    insertBlankPageAfter(afterArrayIndex, width, height) {
+    insertBlankPageAfter(afterArrayIndex, width, height, background) {
       state.update((doc) => {
         if (!doc) return doc;
         const insertIdx = afterArrayIndex + 1;
@@ -180,6 +185,7 @@ export function createDocumentStore(): DocumentStore {
           insertedAfterPdfPage,
           width,
           height,
+          ...(background ? { background } : {}),
           objects: [],
         };
         const pages = [...doc.pages];

--- a/src/lib/store/document.ts
+++ b/src/lib/store/document.ts
@@ -1,5 +1,6 @@
 import { derived, get, writable, type Readable } from 'svelte/store';
 import type { AnyObject, EldrawDocument, ObjectId, Page } from '$lib/types';
+import { isSafeHexColor } from '$lib/color';
 import { applyCommand, createHistory, type Command, type History } from './history';
 
 export interface DocumentStore {
@@ -72,7 +73,8 @@ function lastPdfIndexAtOrBefore(pages: readonly Page[], arrayIndex: number): num
 function normalizeLoaded(doc: EldrawDocument): EldrawDocument {
   let nextDerived = 0;
   const pages = doc.pages.map((p, i) => {
-    const base = p.pageIndex === i ? p : { ...p, pageIndex: i };
+    const withBg = sanitizePageBackground(p);
+    const base = withBg.pageIndex === i ? withBg : { ...withBg, pageIndex: i };
     if (base.type === 'pdf' && typeof base.pdfSourceIndex !== 'number') {
       const withSource = { ...base, pdfSourceIndex: nextDerived };
       nextDerived += 1;
@@ -84,6 +86,19 @@ function normalizeLoaded(doc: EldrawDocument): EldrawDocument {
     return base;
   });
   return { ...doc, pages };
+}
+
+/**
+ * Sidecars are untrusted input. Drop any `background` value that doesn't
+ * match the strict `#rrggbb` invariant so it can't leak into CSS at render
+ * time.
+ */
+function sanitizePageBackground(page: Page): Page {
+  if (page.background === undefined) return page;
+  if (isSafeHexColor(page.background)) return page;
+  const { background: _drop, ...rest } = page;
+  void _drop;
+  return rest as Page;
 }
 
 function reindex(pages: Page[]): Page[] {
@@ -179,13 +194,14 @@ export function createDocumentStore(): DocumentStore {
         if (!doc) return doc;
         const insertIdx = afterArrayIndex + 1;
         const insertedAfterPdfPage = lastPdfIndexAtOrBefore(doc.pages, afterArrayIndex);
+        const safeBg = isSafeHexColor(background) ? background : undefined;
         const blank: Page = {
           pageIndex: insertIdx,
           type: 'blank',
           insertedAfterPdfPage,
           width,
           height,
-          ...(background ? { background } : {}),
+          ...(safeBg ? { background: safeBg } : {}),
           objects: [],
         };
         const pages = [...doc.pages];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -154,6 +154,12 @@ export interface Page {
   /** Page dimensions in PDF points. */
   width: number;
   height: number;
+  /**
+   * Fill color for blank pages, sampled from the preceding PDF page when
+   * available. Optional for back-compat and for pdf pages (which ignore it).
+   * Any CSS color string; sampler emits `#rrggbb`.
+   */
+  background?: string;
   objects: AnyObject[];
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -157,7 +157,11 @@ export interface Page {
   /**
    * Fill color for blank pages, sampled from the preceding PDF page when
    * available. Optional for back-compat and for pdf pages (which ignore it).
-   * Any CSS color string; sampler emits `#rrggbb`.
+   *
+   * Invariant: strictly `#rrggbb` (6-digit hex). Any other value is rejected
+   * at the load/insert boundary (see `isSafeHexColor`). This is a trust
+   * boundary — sidecars are untrusted input and this field is interpolated
+   * into CSS at render time.
    */
   background?: string;
   objects: AnyObject[];

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -416,7 +416,11 @@
               <PdfLayer pageIndex={pdfPageIndex} scale={view.scale} />
             </div>
           {:else if currentPage?.type === 'blank'}
-            <div class="blank-slot" style="width: {size.width}px; height: {size.height}px;"></div>
+            <div
+              class="blank-slot"
+              style="width: {size.width}px; height: {size.height}px; background: {currentPage.background ??
+                '#fff'};"
+            ></div>
           {/if}
           <div class="stack-slot">
             <CanvasStack
@@ -704,6 +708,7 @@
   }
   .blank-slot {
     background: #fff;
+    box-sizing: border-box;
   }
   .empty {
     position: absolute;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -418,8 +418,8 @@
           {:else if currentPage?.type === 'blank'}
             <div
               class="blank-slot"
-              style="width: {size.width}px; height: {size.height}px; background: {currentPage.background ??
-                '#fff'};"
+              style="width: {size.width}px; height: {size.height}px;"
+              style:background-color={currentPage.background ?? '#fff'}
             ></div>
           {/if}
           <div class="stack-slot">

--- a/tests/bg-sample.test.ts
+++ b/tests/bg-sample.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { pickSamplePoints, sampleBackgroundFromPixels } from '$lib/canvas/bgSample';
+import {
+  pickSamplePoints,
+  sampleBackgroundFromPixels,
+  sampleCanvasBackground,
+} from '$lib/canvas/bgSample';
+import { isSafeHexColor } from '$lib/color';
 
 function solidImage(
   width: number,
@@ -83,5 +88,72 @@ describe('sampleBackgroundFromPixels', () => {
   it('ignores fully transparent pixels', () => {
     const pixels = new Uint8ClampedArray(20 * 20 * 4);
     expect(sampleBackgroundFromPixels(pixels, 20, 20)).toBeNull();
+  });
+});
+
+describe('isSafeHexColor', () => {
+  it('accepts strict 6-digit hex', () => {
+    expect(isSafeHexColor('#ffffff')).toBe(true);
+    expect(isSafeHexColor('#000000')).toBe(true);
+    expect(isSafeHexColor('#AaBbCc')).toBe(true);
+  });
+
+  it('rejects short hex, non-hex, and injection payloads', () => {
+    expect(isSafeHexColor('#fff')).toBe(false);
+    expect(isSafeHexColor('red')).toBe(false);
+    expect(isSafeHexColor('rgb(0,0,0)')).toBe(false);
+    expect(isSafeHexColor('#ggggggg')).toBe(false);
+    expect(isSafeHexColor('#ffffff ')).toBe(false);
+    expect(isSafeHexColor('red; background-image: url(x)')).toBe(false);
+    expect(isSafeHexColor('#ffffff; background-image: url(x)')).toBe(false);
+    expect(isSafeHexColor(undefined)).toBe(false);
+    expect(isSafeHexColor(null)).toBe(false);
+    expect(isSafeHexColor(123)).toBe(false);
+  });
+});
+
+describe('sampleCanvasBackground', () => {
+  function fakeCanvas(width: number, height: number, rgba: [number, number, number, number]) {
+    return {
+      width,
+      height,
+      getContext: () => ({
+        getImageData: (_x: number, _y: number, w: number, h: number) => ({
+          data: new Uint8ClampedArray([...rgba]),
+          width: w,
+          height: h,
+        }),
+      }),
+    } as unknown as HTMLCanvasElement;
+  }
+
+  it('samples at most 9 pixels (one per sample point)', () => {
+    let calls = 0;
+    const canvas = {
+      width: 1000,
+      height: 1000,
+      getContext: () => ({
+        getImageData: (_x: number, _y: number, w: number, h: number) => {
+          calls += 1;
+          expect(w).toBe(1);
+          expect(h).toBe(1);
+          return { data: new Uint8ClampedArray([240, 240, 240, 255]), width: 1, height: 1 };
+        },
+      }),
+    } as unknown as HTMLCanvasElement;
+    const color = sampleCanvasBackground(canvas);
+    expect(calls).toBe(9);
+    expect(color).toBe('#f0f0f0');
+  });
+
+  it('returns a valid #rrggbb string', () => {
+    const canvas = fakeCanvas(50, 50, [255, 255, 255, 255]);
+    const color = sampleCanvasBackground(canvas);
+    expect(color).toBe('#ffffff');
+    expect(isSafeHexColor(color!)).toBe(true);
+  });
+
+  it('returns null for zero-size canvases', () => {
+    expect(sampleCanvasBackground(fakeCanvas(0, 100, [0, 0, 0, 255]))).toBeNull();
   });
 });

--- a/tests/bg-sample.test.ts
+++ b/tests/bg-sample.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { pickSamplePoints, sampleBackgroundFromPixels } from '$lib/canvas/bgSample';
+
+function solidImage(
+  width: number,
+  height: number,
+  r: number,
+  g: number,
+  b: number,
+): Uint8ClampedArray {
+  const pixels = new Uint8ClampedArray(width * height * 4);
+  for (let i = 0; i < width * height; i += 1) {
+    pixels[i * 4] = r;
+    pixels[i * 4 + 1] = g;
+    pixels[i * 4 + 2] = b;
+    pixels[i * 4 + 3] = 255;
+  }
+  return pixels;
+}
+
+describe('pickSamplePoints', () => {
+  it('returns nine points inside the image bounds', () => {
+    const pts = pickSamplePoints(100, 80);
+    expect(pts).toHaveLength(9);
+    for (const { x, y } of pts) {
+      expect(x).toBeGreaterThanOrEqual(0);
+      expect(x).toBeLessThan(100);
+      expect(y).toBeGreaterThanOrEqual(0);
+      expect(y).toBeLessThan(80);
+    }
+  });
+
+  it('returns an empty set for zero-size images', () => {
+    expect(pickSamplePoints(0, 10)).toEqual([]);
+    expect(pickSamplePoints(10, 0)).toEqual([]);
+  });
+});
+
+describe('sampleBackgroundFromPixels', () => {
+  it('returns exact color for a solid fill', () => {
+    const pixels = solidImage(50, 50, 255, 255, 255);
+    expect(sampleBackgroundFromPixels(pixels, 50, 50)).toBe('#ffffff');
+  });
+
+  it('detects off-white cream backgrounds', () => {
+    const pixels = solidImage(50, 50, 250, 245, 230);
+    expect(sampleBackgroundFromPixels(pixels, 50, 50)).toBe('#faf5e6');
+  });
+
+  it('detects dark-mode backgrounds', () => {
+    const pixels = solidImage(64, 64, 16, 18, 20);
+    expect(sampleBackgroundFromPixels(pixels, 64, 64)).toBe('#101214');
+  });
+
+  it('returns dominant color when minority pixels differ', () => {
+    const pixels = solidImage(60, 60, 240, 240, 240);
+    // Paint one corner black: only one of nine sample points lands there.
+    const i = 0;
+    pixels[i] = 0;
+    pixels[i + 1] = 0;
+    pixels[i + 2] = 0;
+    const result = sampleBackgroundFromPixels(pixels, 60, 60);
+    expect(result).toBe('#f0f0f0');
+  });
+
+  it('returns null when no single color dominates', () => {
+    const pixels = new Uint8ClampedArray(60 * 60 * 4);
+    for (let i = 0; i < 60 * 60; i += 1) {
+      const c = ((i * 53) % 256) | 0;
+      pixels[i * 4] = c;
+      pixels[i * 4 + 1] = (c * 3) % 256;
+      pixels[i * 4 + 2] = (c * 7) % 256;
+      pixels[i * 4 + 3] = 255;
+    }
+    expect(sampleBackgroundFromPixels(pixels, 60, 60)).toBeNull();
+  });
+
+  it('returns null when the buffer is too small', () => {
+    const pixels = new Uint8ClampedArray(4);
+    expect(sampleBackgroundFromPixels(pixels, 10, 10)).toBeNull();
+  });
+
+  it('ignores fully transparent pixels', () => {
+    const pixels = new Uint8ClampedArray(20 * 20 * 4);
+    expect(sampleBackgroundFromPixels(pixels, 20, 20)).toBeNull();
+  });
+});

--- a/tests/document-store.test.ts
+++ b/tests/document-store.test.ts
@@ -141,4 +141,53 @@ describe('documentStore', () => {
     store.addObject(0, stroke('a'));
     expect(get(derivedStore).map((o) => o.id)).toEqual(['a']);
   });
+
+  it('load strips non-hex background values from sidecar blank pages', () => {
+    const store = createDocumentStore();
+    const malicious: Page = {
+      pageIndex: 0,
+      type: 'blank',
+      insertedAfterPdfPage: null,
+      width: 500,
+      height: 700,
+      background: 'red; background-image: url(x)',
+      objects: [],
+    };
+    store.load(docWithPages([malicious]));
+    const doc = get(store)!;
+    expect(doc.pages[0].background).toBeUndefined();
+  });
+
+  it('load preserves valid #rrggbb backgrounds', () => {
+    const store = createDocumentStore();
+    const page: Page = {
+      pageIndex: 0,
+      type: 'blank',
+      insertedAfterPdfPage: null,
+      width: 500,
+      height: 700,
+      background: '#abcdef',
+      objects: [],
+    };
+    store.load(docWithPages([page]));
+    const doc = get(store)!;
+    expect(doc.pages[0].background).toBe('#abcdef');
+  });
+
+  it('insertBlankPageAfter ignores non-hex background params', () => {
+    const store = createDocumentStore();
+    store.load(docWithPages([pdfPage(0)]));
+    store.insertBlankPageAfter(0, 500, 700, 'red; background-image: url(x)');
+    const doc = get(store)!;
+    expect(doc.pages[1].type).toBe('blank');
+    expect(doc.pages[1].background).toBeUndefined();
+  });
+
+  it('insertBlankPageAfter accepts valid #rrggbb background params', () => {
+    const store = createDocumentStore();
+    store.load(docWithPages([pdfPage(0)]));
+    store.insertBlankPageAfter(0, 500, 700, '#123456');
+    const doc = get(store)!;
+    expect(doc.pages[1].background).toBe('#123456');
+  });
 });


### PR DESCRIPTION
Closes #58

## What
When a blank page is inserted (via `B` / `insertBlankPageAfter`), sample
the dominant background color from the currently rendered PDF canvas
and use it as the blank page's fill instead of hardcoded white.

## How
- New `Page.background?: string` (optional for back-compat).
- New pure module `src/lib/canvas/bgSample.ts`:
  - `pickSamplePoints(w, h)` — 9 points: corners (inset 2%), edge
    midpoints, center.
  - `sampleBackgroundFromPixels(pixels, w, h)` — quantizes to 16-step
    buckets, picks the mode, requires ≥50% dominance. Returns `null`
    on photographic / high-variance pages so callers fall back to white.
  - `sampleCanvasBackground(canvas)` — DOM wrapper around the pure
    sampler; resilient to tainted canvases.
- `insertBlankPageAfter` gains an optional `background` parameter.
- The `B` shortcut locates the live PDF canvas via
  `.pdf-slot canvas[aria-label="Rendered PDF page"]`, samples it, and
  passes the color through. Blank-after-blank inherits the previous
  blank's color.
- Main canvas `.blank-slot` and the sidebar thumbnail preview honor
  `page.background` when present.

## Testing
- `pnpm lint` — clean (prettier + eslint + svelte-check, 0 errors).
- `pnpm test` — 223/223 passing, including 9 new cases in
  `tests/bg-sample.test.ts` covering white / cream / dark / noisy /
  transparent / undersized inputs.

## Trade-offs & Notes
- The sampler is deliberately conservative: only returns a color when
  ≥50% of sampled pixels fall in the same quantized bucket. This
  matches the issue's "fall back to white if variance is high"
  requirement.
- Sampling reads from the already-rendered canvas in the DOM rather
  than introducing a new IPC/Rust path. Issue #8 (server-side pdfium
  sampling for _document-level_ defaults) is still open and
  complementary — this PR addresses #58's per-insertion behavior.
- Existing sidecars without `background` render as white, identical
  to today.