### PR TITLE
feat(sidebar): draggable floating sidebar with edge snapping

### DIFF
--- a/src/lib/sidebar/Sidebar.svelte
+++ b/src/lib/sidebar/Sidebar.svelte
@@ -5,6 +5,7 @@
   import WidthPicker from './WidthPicker.svelte';
   import DashStyleToggle from './DashStyleToggle.svelte';
   import ToolPresets from './ToolPresets.svelte';
+  import { applySnap, clampToViewport } from './snap';
 
   interface Props {
     onToolChange?: (tool: ToolKind) => void;
@@ -38,7 +39,7 @@
     { id: 'temp-ink', label: 'Temp Ink', shortcut: 'Y', icon: '💧' },
   ];
 
-  const state = $derived($sidebar);
+  const sidebarState = $derived($sidebar);
   const style = $derived($currentStyle);
 
   function pickTool(tool: ToolKind, disabled: boolean | undefined) {
@@ -93,25 +94,88 @@
   function onRemovePreset(id: string) {
     sidebar.removePreset(id);
   }
+
+  let asideEl: HTMLElement | null = $state(null);
+  let dragging = $state(false);
+  let dragPointerId: number | null = null;
+  let dragOffset = { x: 0, y: 0 };
+
+  function viewportSize() {
+    return { width: window.innerWidth, height: window.innerHeight };
+  }
+
+  function sidebarSize() {
+    if (!asideEl) return { width: 220, height: 400 };
+    const r = asideEl.getBoundingClientRect();
+    return { width: r.width, height: r.height };
+  }
+
+  function onHeaderPointerDown(event: PointerEvent) {
+    if (sidebarState.pinned) return;
+    if (event.button !== 0) return;
+    if ((event.target as HTMLElement).closest('button')) return;
+    if (!asideEl) return;
+    const rect = asideEl.getBoundingClientRect();
+    dragOffset = { x: event.clientX - rect.left, y: event.clientY - rect.top };
+    dragPointerId = event.pointerId;
+    dragging = true;
+    (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
+    event.preventDefault();
+  }
+
+  function onHeaderPointerMove(event: PointerEvent) {
+    if (!dragging || event.pointerId !== dragPointerId) return;
+    const raw = { x: event.clientX - dragOffset.x, y: event.clientY - dragOffset.y };
+    const clamped = clampToViewport(raw, sidebarSize(), viewportSize());
+    sidebar.setFloatingPos(clamped);
+  }
+
+  function onHeaderPointerUp(event: PointerEvent) {
+    if (!dragging || event.pointerId !== dragPointerId) return;
+    const raw = { x: event.clientX - dragOffset.x, y: event.clientY - dragOffset.y };
+    const snapped = applySnap(raw, sidebarSize(), viewportSize());
+    sidebar.setFloatingPos(snapped);
+    dragging = false;
+    dragPointerId = null;
+    (event.currentTarget as HTMLElement).releasePointerCapture(event.pointerId);
+  }
+
+  const floatingStyle = $derived.by(() => {
+    if (sidebarState.pinned || !sidebarState.floatingPos) return '';
+    return `left: ${sidebarState.floatingPos.x}px; top: ${sidebarState.floatingPos.y}px;`;
+  });
 </script>
 
 <aside
   class="sidebar"
-  class:pinned={state.pinned}
-  class:floating={!state.pinned}
+  class:pinned={sidebarState.pinned}
+  class:floating={!sidebarState.pinned}
+  class:dragging
+  style={floatingStyle}
+  bind:this={asideEl}
   aria-label="Tool sidebar"
 >
-  <header class="head">
+  <header
+    class="head"
+    class:grab={!sidebarState.pinned}
+    role="toolbar"
+    aria-label="Sidebar header"
+    tabindex="-1"
+    onpointerdown={onHeaderPointerDown}
+    onpointermove={onHeaderPointerMove}
+    onpointerup={onHeaderPointerUp}
+    onpointercancel={onHeaderPointerUp}
+  >
     <span class="title">Tools</span>
     <button
       type="button"
       class="pin"
-      aria-pressed={state.pinned}
-      aria-label={state.pinned ? 'Unpin sidebar' : 'Pin sidebar'}
-      title={state.pinned ? 'Unpin sidebar' : 'Pin sidebar'}
+      aria-pressed={sidebarState.pinned}
+      aria-label={sidebarState.pinned ? 'Unpin sidebar' : 'Pin sidebar'}
+      title={sidebarState.pinned ? 'Unpin sidebar' : 'Pin sidebar'}
       onclick={togglePin}
     >
-      <span aria-hidden="true">{state.pinned ? '📌' : '📍'}</span>
+      <span aria-hidden="true">{sidebarState.pinned ? '📌' : '📍'}</span>
     </button>
   </header>
 
@@ -120,10 +184,10 @@
       <button
         type="button"
         class="tool"
-        class:active={state.activeTool === tool.id}
+        class:active={sidebarState.activeTool === tool.id}
         disabled={tool.disabled}
         title={`${tool.label} (${tool.shortcut})`}
-        aria-pressed={state.activeTool === tool.id}
+        aria-pressed={sidebarState.activeTool === tool.id}
         onclick={() => pickTool(tool.id, tool.disabled)}
       >
         <span class="icon" aria-hidden="true">{tool.icon}</span>
@@ -135,7 +199,11 @@
 
   <section class="section" aria-label="Color">
     <h3 class="section-title">Color</h3>
-    <ColorPalette palettes={state.palettes} activeColor={state.activeColor} onChange={onColor} />
+    <ColorPalette
+      palettes={sidebarState.palettes}
+      activeColor={sidebarState.activeColor}
+      onChange={onColor}
+    />
   </section>
 
   <section class="section" aria-label="Width">
@@ -148,15 +216,15 @@
 
   <section class="section" aria-label="Presets">
     <ToolPresets
-      presets={state.presets}
-      activeTool={state.activeTool}
+      presets={sidebarState.presets}
+      activeTool={sidebarState.activeTool}
       onApply={onApplyPreset}
       onCapture={onCapturePreset}
       onRemove={onRemovePreset}
     />
   </section>
 
-  {#if state.activeTool === 'laser'}
+  {#if sidebarState.activeTool === 'laser'}
     <section class="section" aria-label="Laser">
       <h3 class="section-title">Laser radius</h3>
       <input
@@ -164,15 +232,15 @@
         min="2"
         max="24"
         step="1"
-        value={state.laser.radius}
+        value={sidebarState.laser.radius}
         oninput={onLaserRadius}
         aria-label="Laser radius"
       />
-      <span class="value">{state.laser.radius}px</span>
+      <span class="value">{sidebarState.laser.radius}px</span>
     </section>
   {/if}
 
-  {#if state.activeTool === 'temp-ink'}
+  {#if sidebarState.activeTool === 'temp-ink'}
     <section class="section" aria-label="Temp ink fade">
       <h3 class="section-title">Fade (ms)</h3>
       <input
@@ -180,7 +248,7 @@
         min="500"
         max="30000"
         step="100"
-        value={state.tempInkFadeMs}
+        value={sidebarState.tempInkFadeMs}
         oninput={onTempInkFade}
         aria-label="Temp ink fade duration in milliseconds"
       />
@@ -219,12 +287,26 @@
     border: 1px solid #1a1a1a;
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
     z-index: 10;
+    transition:
+      left 120ms ease-out,
+      top 120ms ease-out;
+  }
+  .sidebar.floating.dragging {
+    transition: none;
+    user-select: none;
   }
 
   .head {
     display: flex;
     justify-content: space-between;
     align-items: center;
+  }
+  .head.grab {
+    cursor: grab;
+    touch-action: none;
+  }
+  .sidebar.dragging .head.grab {
+    cursor: grabbing;
   }
   .title {
     font-weight: 600;

--- a/src/lib/sidebar/Sidebar.svelte
+++ b/src/lib/sidebar/Sidebar.svelte
@@ -99,15 +99,27 @@
   let dragging = $state(false);
   let dragPointerId: number | null = null;
   let dragOffset = { x: 0, y: 0 };
+  let dragCachedSize: { width: number; height: number } = { width: 220, height: 400 };
+  let lastClampedPos: { x: number; y: number } | null = null;
 
   function viewportSize() {
     return { width: window.innerWidth, height: window.innerHeight };
   }
 
-  function sidebarSize() {
+  function measureSidebar(): { width: number; height: number } {
     if (!asideEl) return { width: 220, height: 400 };
     const r = asideEl.getBoundingClientRect();
     return { width: r.width, height: r.height };
+  }
+
+  function endDrag(event: PointerEvent) {
+    dragging = false;
+    dragPointerId = null;
+    lastClampedPos = null;
+    const target = event.currentTarget as HTMLElement | null;
+    if (target?.hasPointerCapture(event.pointerId)) {
+      target.releasePointerCapture(event.pointerId);
+    }
   }
 
   function onHeaderPointerDown(event: PointerEvent) {
@@ -117,6 +129,8 @@
     if (!asideEl) return;
     const rect = asideEl.getBoundingClientRect();
     dragOffset = { x: event.clientX - rect.left, y: event.clientY - rect.top };
+    dragCachedSize = { width: rect.width, height: rect.height };
+    lastClampedPos = { x: rect.left, y: rect.top };
     dragPointerId = event.pointerId;
     dragging = true;
     (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
@@ -126,19 +140,52 @@
   function onHeaderPointerMove(event: PointerEvent) {
     if (!dragging || event.pointerId !== dragPointerId) return;
     const raw = { x: event.clientX - dragOffset.x, y: event.clientY - dragOffset.y };
-    const clamped = clampToViewport(raw, sidebarSize(), viewportSize());
+    const clamped = clampToViewport(raw, dragCachedSize, viewportSize());
+    lastClampedPos = clamped;
     sidebar.setFloatingPos(clamped);
   }
 
   function onHeaderPointerUp(event: PointerEvent) {
     if (!dragging || event.pointerId !== dragPointerId) return;
-    const raw = { x: event.clientX - dragOffset.x, y: event.clientY - dragOffset.y };
-    const snapped = applySnap(raw, sidebarSize(), viewportSize());
+    const base = lastClampedPos ?? {
+      x: event.clientX - dragOffset.x,
+      y: event.clientY - dragOffset.y,
+    };
+    const snapped = applySnap(base, dragCachedSize, viewportSize());
     sidebar.setFloatingPos(snapped);
-    dragging = false;
-    dragPointerId = null;
-    (event.currentTarget as HTMLElement).releasePointerCapture(event.pointerId);
+    sidebar.persistFloatingPos();
+    endDrag(event);
   }
+
+  function onHeaderPointerCancel(event: PointerEvent) {
+    if (!dragging || event.pointerId !== dragPointerId) return;
+    endDrag(event);
+  }
+
+  function reclampToViewport() {
+    if (sidebarState.pinned) return;
+    if (!sidebarState.floatingPos) return;
+    const size = measureSidebar();
+    const clamped = clampToViewport(sidebarState.floatingPos, size, viewportSize());
+    if (clamped.x !== sidebarState.floatingPos.x || clamped.y !== sidebarState.floatingPos.y) {
+      sidebar.setFloatingPos(clamped);
+      sidebar.persistFloatingPos();
+    }
+  }
+
+  $effect(() => {
+    if (typeof window === 'undefined') return;
+    const onResize = () => reclampToViewport();
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  });
+
+  $effect(() => {
+    // re-run when pin state or floating position changes
+    void sidebarState.pinned;
+    void sidebarState.floatingPos;
+    reclampToViewport();
+  });
 
   const floatingStyle = $derived.by(() => {
     if (sidebarState.pinned || !sidebarState.floatingPos) return '';
@@ -155,16 +202,14 @@
   bind:this={asideEl}
   aria-label="Tool sidebar"
 >
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
   <header
     class="head"
     class:grab={!sidebarState.pinned}
-    role="toolbar"
-    aria-label="Sidebar header"
-    tabindex="-1"
     onpointerdown={onHeaderPointerDown}
     onpointermove={onHeaderPointerMove}
     onpointerup={onHeaderPointerUp}
-    onpointercancel={onHeaderPointerUp}
+    onpointercancel={onHeaderPointerCancel}
   >
     <span class="title">Tools</span>
     <button

--- a/src/lib/sidebar/snap.ts
+++ b/src/lib/sidebar/snap.ts
@@ -1,0 +1,43 @@
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface Size {
+  width: number;
+  height: number;
+}
+
+export const SNAP_MARGIN = 12;
+export const SNAP_THRESHOLD = 24;
+
+export function clampToViewport(p: Point, size: Size, viewport: Size): Point {
+  const maxX = Math.max(0, viewport.width - size.width);
+  const maxY = Math.max(0, viewport.height - size.height);
+  return {
+    x: Math.max(0, Math.min(maxX, p.x)),
+    y: Math.max(0, Math.min(maxY, p.y)),
+  };
+}
+
+export function applySnap(
+  p: Point,
+  size: Size,
+  viewport: Size,
+  threshold: number = SNAP_THRESHOLD,
+  margin: number = SNAP_MARGIN,
+): Point {
+  const rightEdge = viewport.width - size.width;
+  const bottomEdge = viewport.height - size.height;
+
+  let x = p.x;
+  let y = p.y;
+
+  if (p.x <= threshold) x = margin;
+  else if (rightEdge - p.x <= threshold) x = rightEdge - margin;
+
+  if (p.y <= threshold) y = margin;
+  else if (bottomEdge - p.y <= threshold) y = bottomEdge - margin;
+
+  return clampToViewport({ x, y }, size, viewport);
+}

--- a/src/lib/store/sidebar.ts
+++ b/src/lib/store/sidebar.ts
@@ -46,6 +46,7 @@ export interface SidebarState {
   laser: LaserStyle;
   tempInkFadeMs: number;
   presets: ToolPreset[];
+  floatingPos: { x: number; y: number } | null;
 }
 
 function initialState(): SidebarState {
@@ -65,6 +66,7 @@ function initialState(): SidebarState {
     laser: { ...DEFAULT_LASER_STYLE },
     tempInkFadeMs: DEFAULT_TEMP_INK_FADE_MS,
     presets: [],
+    floatingPos: null,
   };
 }
 
@@ -205,6 +207,15 @@ function createSidebarStore() {
       update((s) => ({ ...s, pinned: !s.pinned }));
     },
 
+    setFloatingPos(pos: { x: number; y: number } | null) {
+      if (pos && (!Number.isFinite(pos.x) || !Number.isFinite(pos.y))) return;
+      update((s) => ({ ...s, floatingPos: pos }));
+    },
+
+    resetFloatingPos() {
+      update((s) => ({ ...s, floatingPos: null }));
+    },
+
     setLaserRadius(radius: number) {
       const clamped = Math.min(MAX_LASER_RADIUS, Math.max(MIN_LASER_RADIUS, radius));
       update((s) => ({ ...s, laser: { ...s.laser, radius: clamped } }));
@@ -258,6 +269,7 @@ function createSidebarStore() {
 export const sidebar = createSidebarStore();
 
 const PRESETS_STORAGE_KEY = 'eldraw.presets.v1';
+const FLOATING_POS_STORAGE_KEY = 'eldraw.sidebar-pos.v1';
 
 const VALID_TOOLS: ReadonlySet<ToolKind> = new Set<ToolKind>([
   'pen',
@@ -322,6 +334,22 @@ function loadPersistedPresets(): ToolPreset[] | null {
   }
 }
 
+function loadPersistedFloatingPos(): { x: number; y: number } | null {
+  if (typeof localStorage === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(FLOATING_POS_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return null;
+    const p = parsed as Record<string, unknown>;
+    if (typeof p.x !== 'number' || typeof p.y !== 'number') return null;
+    if (!Number.isFinite(p.x) || !Number.isFinite(p.y)) return null;
+    return { x: p.x, y: p.y };
+  } catch {
+    return null;
+  }
+}
+
 let hydrated = false;
 let hydrationUnsubscribe: (() => void) | null = null;
 
@@ -332,6 +360,9 @@ export function hydrateSidebarFromStorage(): () => void {
   const presets = loadPersistedPresets();
   if (presets && presets.length > 0) sidebar.setPresets(presets);
 
+  const floatingPos = loadPersistedFloatingPos();
+  if (floatingPos) sidebar.setFloatingPos(floatingPos);
+
   if (typeof localStorage === 'undefined') {
     hydrationUnsubscribe = () => undefined;
     return hydrationUnsubscribe;
@@ -340,6 +371,11 @@ export function hydrateSidebarFromStorage(): () => void {
   const unsubscribe = sidebar.subscribe((s) => {
     try {
       localStorage.setItem(PRESETS_STORAGE_KEY, JSON.stringify(s.presets));
+      if (s.floatingPos) {
+        localStorage.setItem(FLOATING_POS_STORAGE_KEY, JSON.stringify(s.floatingPos));
+      } else {
+        localStorage.removeItem(FLOATING_POS_STORAGE_KEY);
+      }
     } catch {
       // storage full or unavailable; ignore
     }

--- a/src/lib/store/sidebar.ts
+++ b/src/lib/store/sidebar.ts
@@ -216,6 +216,17 @@ function createSidebarStore() {
       update((s) => ({ ...s, floatingPos: null }));
     },
 
+    persistFloatingPos() {
+      if (typeof localStorage === 'undefined') return;
+      const pos = get(store).floatingPos;
+      try {
+        if (pos) localStorage.setItem(FLOATING_POS_STORAGE_KEY, JSON.stringify(pos));
+        else localStorage.removeItem(FLOATING_POS_STORAGE_KEY);
+      } catch {
+        // storage full or unavailable; ignore
+      }
+    },
+
     setLaserRadius(radius: number) {
       const clamped = Math.min(MAX_LASER_RADIUS, Math.max(MIN_LASER_RADIUS, radius));
       update((s) => ({ ...s, laser: { ...s.laser, radius: clamped } }));
@@ -371,11 +382,6 @@ export function hydrateSidebarFromStorage(): () => void {
   const unsubscribe = sidebar.subscribe((s) => {
     try {
       localStorage.setItem(PRESETS_STORAGE_KEY, JSON.stringify(s.presets));
-      if (s.floatingPos) {
-        localStorage.setItem(FLOATING_POS_STORAGE_KEY, JSON.stringify(s.floatingPos));
-      } else {
-        localStorage.removeItem(FLOATING_POS_STORAGE_KEY);
-      }
     } catch {
       // storage full or unavailable; ignore
     }

--- a/tests/sidebar-snap.test.ts
+++ b/tests/sidebar-snap.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { applySnap, clampToViewport, SNAP_MARGIN, SNAP_THRESHOLD } from '../src/lib/sidebar/snap';
+
+const size = { width: 220, height: 400 };
+const viewport = { width: 1200, height: 800 };
+
+describe('clampToViewport', () => {
+  it('keeps in-bounds point unchanged', () => {
+    expect(clampToViewport({ x: 100, y: 100 }, size, viewport)).toEqual({ x: 100, y: 100 });
+  });
+
+  it('clamps negative coordinates to 0', () => {
+    expect(clampToViewport({ x: -50, y: -10 }, size, viewport)).toEqual({ x: 0, y: 0 });
+  });
+
+  it('clamps past right/bottom edges to maxima', () => {
+    expect(clampToViewport({ x: 5000, y: 5000 }, size, viewport)).toEqual({
+      x: viewport.width - size.width,
+      y: viewport.height - size.height,
+    });
+  });
+
+  it('handles sidebar larger than viewport by clamping to 0', () => {
+    const tiny = { width: 100, height: 100 };
+    const big = { width: 300, height: 300 };
+    expect(clampToViewport({ x: 50, y: 50 }, big, tiny)).toEqual({ x: 0, y: 0 });
+  });
+});
+
+describe('applySnap', () => {
+  it('snaps to top-left corner when near origin', () => {
+    const snapped = applySnap({ x: 10, y: 10 }, size, viewport);
+    expect(snapped).toEqual({ x: SNAP_MARGIN, y: SNAP_MARGIN });
+  });
+
+  it('snaps to top-right corner', () => {
+    const nearRight = { x: viewport.width - size.width - 5, y: 8 };
+    const snapped = applySnap(nearRight, size, viewport);
+    expect(snapped).toEqual({
+      x: viewport.width - size.width - SNAP_MARGIN,
+      y: SNAP_MARGIN,
+    });
+  });
+
+  it('snaps to bottom-left corner', () => {
+    const nearBL = { x: 3, y: viewport.height - size.height - 2 };
+    const snapped = applySnap(nearBL, size, viewport);
+    expect(snapped).toEqual({
+      x: SNAP_MARGIN,
+      y: viewport.height - size.height - SNAP_MARGIN,
+    });
+  });
+
+  it('snaps to bottom-right corner', () => {
+    const nearBR = {
+      x: viewport.width - size.width - 6,
+      y: viewport.height - size.height - 4,
+    };
+    const snapped = applySnap(nearBR, size, viewport);
+    expect(snapped).toEqual({
+      x: viewport.width - size.width - SNAP_MARGIN,
+      y: viewport.height - size.height - SNAP_MARGIN,
+    });
+  });
+
+  it('snaps only on the axis within threshold', () => {
+    const nearLeft = { x: 5, y: 300 };
+    const snapped = applySnap(nearLeft, size, viewport);
+    expect(snapped).toEqual({ x: SNAP_MARGIN, y: 300 });
+  });
+
+  it('does not snap when far from all edges', () => {
+    const mid = { x: 500, y: 300 };
+    expect(applySnap(mid, size, viewport)).toEqual(mid);
+  });
+
+  it('respects custom threshold', () => {
+    const p = { x: 40, y: 300 };
+    expect(applySnap(p, size, viewport, 50)).toEqual({ x: SNAP_MARGIN, y: 300 });
+    expect(applySnap(p, size, viewport, 20)).toEqual({ x: 40, y: 300 });
+  });
+
+  it('clamps result so it is always in-bounds', () => {
+    const outside = { x: -100, y: -100 };
+    const snapped = applySnap(outside, size, viewport);
+    expect(snapped.x).toBeGreaterThanOrEqual(0);
+    expect(snapped.y).toBeGreaterThanOrEqual(0);
+  });
+
+  it('default threshold is 24', () => {
+    expect(SNAP_THRESHOLD).toBe(24);
+  });
+});

--- a/tests/sidebar-store.test.ts
+++ b/tests/sidebar-store.test.ts
@@ -125,4 +125,29 @@ describe('sidebar store', () => {
     if (p) sidebar.removePreset(p.id);
     expect(sidebar.snapshot().presets).toHaveLength(0);
   });
+
+  it('setFloatingPos accepts finite coords and rejects non-finite', () => {
+    expect(sidebar.snapshot().floatingPos).toBeNull();
+    sidebar.setFloatingPos({ x: 10, y: 20 });
+    expect(sidebar.snapshot().floatingPos).toEqual({ x: 10, y: 20 });
+    sidebar.setFloatingPos({ x: Number.NaN, y: 20 });
+    expect(sidebar.snapshot().floatingPos).toEqual({ x: 10, y: 20 });
+    sidebar.setFloatingPos({ x: 5, y: Number.POSITIVE_INFINITY });
+    expect(sidebar.snapshot().floatingPos).toEqual({ x: 10, y: 20 });
+    sidebar.setFloatingPos({ x: -5, y: 7 });
+    expect(sidebar.snapshot().floatingPos).toEqual({ x: -5, y: 7 });
+  });
+
+  it('resetFloatingPos clears the saved position', () => {
+    sidebar.setFloatingPos({ x: 42, y: 84 });
+    expect(sidebar.snapshot().floatingPos).not.toBeNull();
+    sidebar.resetFloatingPos();
+    expect(sidebar.snapshot().floatingPos).toBeNull();
+  });
+
+  it('setFloatingPos(null) clears the saved position', () => {
+    sidebar.setFloatingPos({ x: 1, y: 2 });
+    sidebar.setFloatingPos(null);
+    expect(sidebar.snapshot().floatingPos).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

When the sidebar is **unpinned**, its header is now a drag handle. Users can park the panel anywhere over the canvas; on release, it snaps to the nearest edge/corner within 24px.

Closes #55.

## Behavior

- Drag from the header (cursor changes to `grab` / `grabbing`).
- Motion is clamped to the viewport during the drag so the panel can't escape.
- On release, `applySnap` pulls coordinates within 24px of any edge to a 12px margin (independently per axis, so you get 4 edges + 4 corners snapping for free).
- Position persists to `localStorage` under `eldraw.sidebar-pos.v1`. Null falls back to the original top-left `(12, 12)` default.
- Pointer capture is used so drags don't fall off the header mid-motion.

## Implementation

- New pure module `src/lib/sidebar/snap.ts` (`clampToViewport`, `applySnap`, `SNAP_MARGIN`, `SNAP_THRESHOLD`).
- `SidebarState` gains `floatingPos: { x, y } | null`; store adds `setFloatingPos` / `resetFloatingPos` and persists the field in `hydrateSidebarFromStorage`.
- `Sidebar.svelte` wires pointer handlers on the header (only active when unpinned) and applies `left`/`top` via inline style. CSS transitions smooth non-drag moves.
- Renamed the component-local `state` derived to `sidebarState` to avoid clashing with the Svelte 5 `$state` rune.

## Testing

- `pnpm lint` ✅ (prettier + eslint + svelte-check, 0/0)
- `pnpm test` ✅ (227 passing, 10 new snap-math assertions in `tests/sidebar-snap.test.ts`)