### PR TITLE
chore(release): v0.1.0-rc.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eldraw",
-  "version": "0.1.0-rc.6",
+  "version": "0.1.0-rc.7",
   "description": "PDF annotation tool for live math teaching",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1013,7 +1013,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "eldraw"
-version = "0.1.0-rc.6"
+version = "0.1.0-rc.7"
 dependencies = [
  "image",
  "pdfium-render",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eldraw"
-version = "0.1.0-rc.6"
+version = "0.1.0-rc.7"
 description = "PDF annotation tool for live math teaching"
 authors = ["Adam"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "eldraw",
-  "version": "0.1.0-rc.6",
+  "version": "0.1.0-rc.7",
   "identifier": "com.adamkadaban.eldraw",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary

Bumps version to `v0.1.0-rc.7` across `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, and `Cargo.lock`.

## Changes since rc.6

- feat(protractor): toggle between semi and full circle (#68, closes #17)
- perf(graph): adaptive sampling for explicit y=f(x) curves (#70, closes #13)
- feat(document): sample background color for blank pages (#69)
- feat(ruler): snap strokes to ruler edge (#71, closes #16)
- feat(sidebar): draggable floating sidebar with edge snapping (#72)

## Release flow

After merge, tag `v0.1.0-rc.7` on `main` to trigger the release workflow
(AppImage, deb, NSIS, MSI artifacts via git-cliff-generated notes).