### PR TITLE
feat(line): shift constrains line tool to 15° increments (#39)

### DIFF
--- a/src/lib/canvas/ShapeLiveLayer.svelte
+++ b/src/lib/canvas/ShapeLiveLayer.svelte
@@ -10,6 +10,7 @@
   import { toolStore } from '$lib/store/tool';
   import { currentStyle } from '$lib/store/sidebar';
   import { normalizeBounds } from '$lib/tools/shapes';
+  import { snapAngle15 } from '$lib/tools/lineSnap';
   import { drawLine, drawNumberLine, drawShape } from './objectRenderer';
   import { log } from '$lib/log';
 
@@ -31,6 +32,7 @@
   let activePointerId: number | null = null;
   let start = { x: 0, y: 0 };
   let end = { x: 0, y: 0 };
+  let shiftHeld = false;
   let currentTool: ToolKind = $state('pen');
   let style: StrokeStyle = $state({ color: '#000', width: 2, dash: 'solid', opacity: 1 });
 
@@ -65,13 +67,14 @@
   function previewObject(): LineObject | ShapeObject | NumberLineObject | null {
     if (!isDragKind(currentTool)) return null;
     if (currentTool === 'line') {
+      const to = shiftHeld ? snapAngle15(start, end) : { ...end };
       return {
         id: 'preview',
         createdAt: 0,
         type: 'line',
         style,
         from: { ...start },
-        to: { ...end },
+        to,
         arrow: { start: false, end: false },
       };
     }
@@ -135,6 +138,7 @@
     activePointerId = e.pointerId;
     start = toPagePoint(e);
     end = { ...start };
+    shiftHeld = e.shiftKey;
     redraw();
     e.preventDefault();
   }
@@ -142,12 +146,14 @@
   function onPointerMove(e: PointerEvent) {
     if (activePointerId !== e.pointerId) return;
     end = toPagePoint(e);
+    shiftHeld = e.shiftKey;
     redraw();
     e.preventDefault();
   }
 
   function finish(e: PointerEvent, doCommit: boolean) {
     if (activePointerId !== e.pointerId) return;
+    shiftHeld = e.shiftKey;
     try {
       canvas.releasePointerCapture(e.pointerId);
     } catch {

--- a/src/lib/tools/lineSnap.ts
+++ b/src/lib/tools/lineSnap.ts
@@ -1,0 +1,20 @@
+import type { Point2 } from './shapes';
+
+const SNAP_STEP = Math.PI / 12;
+
+/**
+ * Snap `end` so the vector from `start` to `end` has an angle that is a
+ * multiple of 15° (π/12 rad), preserving length. Zero-length drags are
+ * returned unchanged.
+ */
+export function snapAngle15(start: Point2, end: Point2): Point2 {
+  const dx = end.x - start.x;
+  const dy = end.y - start.y;
+  const length = Math.hypot(dx, dy);
+  if (length === 0) return { x: end.x, y: end.y };
+  const snapped = Math.round(Math.atan2(dy, dx) / SNAP_STEP) * SNAP_STEP;
+  return {
+    x: start.x + length * Math.cos(snapped),
+    y: start.y + length * Math.sin(snapped),
+  };
+}

--- a/tests/line-snap.test.ts
+++ b/tests/line-snap.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { snapAngle15 } from '$lib/tools/lineSnap';
+
+const start = { x: 10, y: 20 };
+
+function angleOf(a: { x: number; y: number }, b: { x: number; y: number }): number {
+  return Math.atan2(b.y - a.y, b.x - a.x);
+}
+
+function lengthOf(a: { x: number; y: number }, b: { x: number; y: number }): number {
+  return Math.hypot(b.x - a.x, b.y - a.y);
+}
+
+describe('snapAngle15', () => {
+  it('leaves 0° unchanged', () => {
+    const end = { x: 110, y: 20 };
+    const snapped = snapAngle15(start, end);
+    expect(snapped.x).toBeCloseTo(110, 6);
+    expect(snapped.y).toBeCloseTo(20, 6);
+  });
+
+  it('snaps near-horizontal drag to 0°', () => {
+    const end = { x: 110, y: 22 };
+    const snapped = snapAngle15(start, end);
+    expect(angleOf(start, snapped)).toBeCloseTo(0, 6);
+    expect(lengthOf(start, snapped)).toBeCloseTo(lengthOf(start, end), 6);
+  });
+
+  it('snaps a drag near 15° to exactly 15°', () => {
+    const radius = 100;
+    const target = (15 * Math.PI) / 180;
+    const noisy = {
+      x: start.x + radius * Math.cos(target + 0.02),
+      y: start.y + radius * Math.sin(target + 0.02),
+    };
+    const snapped = snapAngle15(start, noisy);
+    expect(angleOf(start, snapped)).toBeCloseTo(target, 6);
+  });
+
+  it('snaps a drag near 30° to exactly 30°', () => {
+    const radius = 50;
+    const target = (30 * Math.PI) / 180;
+    const noisy = {
+      x: start.x + radius * Math.cos(target - 0.05),
+      y: start.y + radius * Math.sin(target - 0.05),
+    };
+    const snapped = snapAngle15(start, noisy);
+    expect(angleOf(start, snapped)).toBeCloseTo(target, 6);
+    expect(lengthOf(start, snapped)).toBeCloseTo(radius, 6);
+  });
+
+  it('snaps a drag near 45° to exactly 45°', () => {
+    const end = { x: start.x + 70, y: start.y + 73 };
+    const snapped = snapAngle15(start, end);
+    expect(angleOf(start, snapped)).toBeCloseTo(Math.PI / 4, 6);
+  });
+
+  it('snaps a drag near 90° to exactly 90°', () => {
+    const end = { x: start.x + 3, y: start.y + 80 };
+    const snapped = snapAngle15(start, end);
+    expect(angleOf(start, snapped)).toBeCloseTo(Math.PI / 2, 6);
+    expect(snapped.x).toBeCloseTo(start.x, 6);
+  });
+
+  it('snaps a drag near 180° to exactly 180°', () => {
+    const end = { x: start.x - 100, y: start.y + 1 };
+    const snapped = snapAngle15(start, end);
+    expect(Math.abs(angleOf(start, snapped))).toBeCloseTo(Math.PI, 6);
+  });
+
+  it('snaps negative angles (upward drag) to multiples of 15°', () => {
+    const radius = 40;
+    const target = (-75 * Math.PI) / 180;
+    const noisy = {
+      x: start.x + radius * Math.cos(target + 0.03),
+      y: start.y + radius * Math.sin(target + 0.03),
+    };
+    const snapped = snapAngle15(start, noisy);
+    expect(angleOf(start, snapped)).toBeCloseTo(target, 6);
+  });
+
+  it('always lands on a multiple of 15° for arbitrary input', () => {
+    const step = Math.PI / 12;
+    for (let deg = -180; deg <= 180; deg += 7) {
+      const rad = (deg * Math.PI) / 180;
+      const noisy = {
+        x: start.x + 25 * Math.cos(rad),
+        y: start.y + 25 * Math.sin(rad),
+      };
+      const snapped = snapAngle15(start, noisy);
+      const snappedAngle = angleOf(start, snapped);
+      const remainder = snappedAngle / step;
+      expect(remainder).toBeCloseTo(Math.round(remainder), 6);
+    }
+  });
+
+  it('preserves length after snapping', () => {
+    const end = { x: start.x + 37, y: start.y + 11 };
+    const snapped = snapAngle15(start, end);
+    expect(lengthOf(start, snapped)).toBeCloseTo(lengthOf(start, end), 6);
+  });
+
+  it('returns the end point unchanged when start equals end', () => {
+    const end = { x: start.x, y: start.y };
+    const snapped = snapAngle15(start, end);
+    expect(snapped).toEqual(end);
+  });
+});


### PR DESCRIPTION
## Summary

Completes the final acceptance criterion for #39: holding <kbd>Shift</kbd> while dragging with the line tool now constrains the line's angle to the nearest 15° increment, preserving the drag length.

Closes #39.

## Snap math

Pure function `snapAngle15(start, end)` lives in `src/lib/tools/lineSnap.ts`:

1. `dx, dy = end - start`
2. `length = hypot(dx, dy)` — returned unchanged if zero
3. `angle = atan2(dy, dx)`
4. `snapped = round(angle / (π/12)) * (π/12)` — π/12 rad = 15°
5. `end' = start + length * (cos(snapped), sin(snapped))`

The snap preserves length and works for any angle in `[-π, π]`, including negative (upward) drags.

## Wiring

`ShapeLiveLayer.svelte` tracks `e.shiftKey` on `pointerdown` / `pointermove` / `pointerup`. When the line tool is active and Shift is held, `previewObject()` applies `snapAngle15` before emitting the preview and the committed `LineObject`. Preview and final stroke stay in sync.

Only the `line` tool is affected — rect, ellipse, and numberline drags are untouched.

## Test coverage (`tests/line-snap.test.ts`)

- 0°, 15°, 30°, 45°, 90°, 180°, −75° each snap to the exact multiple of 15°
- near-horizontal noise snaps to 0°
- sweep across `-180°..180°` in 7° steps — every output angle is an exact multiple of 15°
- drag length is preserved after snapping
- zero-length drag (start == end) returns the end point unchanged

## Testing

- `pnpm lint` ✅
- `pnpm test` ✅ (278 tests, +11 new)