### PR TITLE
feat(graph): polished axes, grid, tick labels (#49)

### DIFF
--- a/src/lib/canvas/GraphLayer.svelte
+++ b/src/lib/canvas/GraphLayer.svelte
@@ -3,6 +3,7 @@
   import { parseExpression, parseExpressionXY } from '$lib/graph/parser';
   import { plotFunction } from '$lib/graph/plotter';
   import { marchingSquares, stitchSegments } from '$lib/graph/implicit';
+  import { niceStep, generateTicks, formatTick } from '$lib/graph/axes';
 
   interface Props {
     graphs: GraphObject[];
@@ -16,10 +17,16 @@
   let canvas: HTMLCanvasElement;
 
   const AXIS_COLOR = '#444';
-  const GRID_COLOR = '#d8d8d8';
+  const GRID_MAJOR_COLOR = '#cfcfcf';
+  const GRID_MINOR_COLOR = '#ececec';
+  const LABEL_COLOR = '#555';
   const FRAME_COLOR = '#888';
   const MAX_SAMPLES = 2048;
   const IMPLICIT_MAX_RES = 256;
+  const TARGET_MAJOR_TICKS = 8;
+  const MINOR_SUBDIVISIONS = 5;
+  const LABEL_FONT = '10px system-ui, -apple-system, "Segoe UI", sans-serif';
+  const LABEL_PAD = 3;
 
   function dashFor(d: 'solid' | 'dashed' | 'dotted', strokeWidth: number): number[] {
     if (d === 'dashed') return [strokeWidth * 4, strokeWidth * 3];
@@ -54,18 +61,35 @@
     const xToPx = (x: number) => px + ((x - x0) / xSpan) * pw;
     const yToPx = (y: number) => py + (1 - (y - y0) / ySpan) * ph;
 
-    if (g.showGrid && g.gridStep > 0) {
-      ctx.strokeStyle = GRID_COLOR;
+    const majorXStep = g.gridStep > 0 ? g.gridStep : niceStep(xSpan, TARGET_MAJOR_TICKS);
+    const majorYStep = g.gridStep > 0 ? g.gridStep : niceStep(ySpan, TARGET_MAJOR_TICKS);
+    const minorXStep = majorXStep / MINOR_SUBDIVISIONS;
+    const minorYStep = majorYStep / MINOR_SUBDIVISIONS;
+
+    if (g.showGrid) {
       ctx.lineWidth = 1;
+      ctx.strokeStyle = GRID_MINOR_COLOR;
       ctx.beginPath();
-      const startX = Math.ceil(x0 / g.gridStep) * g.gridStep;
-      for (let x = startX; x <= x1 + 1e-9; x += g.gridStep) {
+      for (const x of generateTicks(x0, x1, minorXStep)) {
         const sx = xToPx(x);
         ctx.moveTo(sx, py);
         ctx.lineTo(sx, py + ph);
       }
-      const startY = Math.ceil(y0 / g.gridStep) * g.gridStep;
-      for (let y = startY; y <= y1 + 1e-9; y += g.gridStep) {
+      for (const y of generateTicks(y0, y1, minorYStep)) {
+        const sy = yToPx(y);
+        ctx.moveTo(px, sy);
+        ctx.lineTo(px + pw, sy);
+      }
+      ctx.stroke();
+
+      ctx.strokeStyle = GRID_MAJOR_COLOR;
+      ctx.beginPath();
+      for (const x of generateTicks(x0, x1, majorXStep)) {
+        const sx = xToPx(x);
+        ctx.moveTo(sx, py);
+        ctx.lineTo(sx, py + ph);
+      }
+      for (const y of generateTicks(y0, y1, majorYStep)) {
         const sy = yToPx(y);
         ctx.moveTo(px, sy);
         ctx.lineTo(px + pw, sy);
@@ -73,21 +97,59 @@
       ctx.stroke();
     }
 
+    const xAxisVisible = y0 <= 0 && y1 >= 0;
+    const yAxisVisible = x0 <= 0 && x1 >= 0;
+
     if (g.showAxes) {
       ctx.strokeStyle = AXIS_COLOR;
       ctx.lineWidth = 1.25;
       ctx.beginPath();
-      if (y0 <= 0 && y1 >= 0) {
+      if (xAxisVisible) {
         const axisY = yToPx(0);
         ctx.moveTo(px, axisY);
         ctx.lineTo(px + pw, axisY);
       }
-      if (x0 <= 0 && x1 >= 0) {
+      if (yAxisVisible) {
         const axisX = xToPx(0);
         ctx.moveTo(axisX, py);
         ctx.lineTo(axisX, py + ph);
       }
       ctx.stroke();
+
+      ctx.fillStyle = LABEL_COLOR;
+      ctx.font = LABEL_FONT;
+
+      if (xAxisVisible) {
+        const axisY = yToPx(0);
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'top';
+        for (const x of generateTicks(x0, x1, majorXStep)) {
+          if (yAxisVisible && Math.abs(x) < majorXStep * 1e-6) continue;
+          ctx.fillText(formatTick(x, majorXStep), xToPx(x), axisY + LABEL_PAD);
+        }
+        ctx.textAlign = 'right';
+        ctx.textBaseline = 'alphabetic';
+        ctx.fillText('x', px + pw - LABEL_PAD, axisY - LABEL_PAD);
+      }
+
+      if (yAxisVisible) {
+        const axisX = xToPx(0);
+        ctx.textAlign = 'right';
+        ctx.textBaseline = 'middle';
+        for (const y of generateTicks(y0, y1, majorYStep)) {
+          if (xAxisVisible && Math.abs(y) < majorYStep * 1e-6) continue;
+          ctx.fillText(formatTick(y, majorYStep), axisX - LABEL_PAD, yToPx(y));
+        }
+        ctx.textAlign = 'left';
+        ctx.textBaseline = 'top';
+        ctx.fillText('y', axisX + LABEL_PAD, py + LABEL_PAD);
+      }
+
+      if (xAxisVisible && yAxisVisible) {
+        ctx.textAlign = 'right';
+        ctx.textBaseline = 'top';
+        ctx.fillText('0', xToPx(0) - LABEL_PAD, yToPx(0) + LABEL_PAD);
+      }
     }
 
     const samples = Math.min(MAX_SAMPLES, Math.max(64, Math.ceil(pw)));

--- a/src/lib/canvas/GraphLayer.svelte
+++ b/src/lib/canvas/GraphLayer.svelte
@@ -3,7 +3,7 @@
   import { parseExpression, parseExpressionXY } from '$lib/graph/parser';
   import { plotFunction } from '$lib/graph/plotter';
   import { marchingSquares, stitchSegments } from '$lib/graph/implicit';
-  import { niceStep, generateTicks, formatTick } from '$lib/graph/axes';
+  import { niceStep, generateTicks, formatTick, cappedStep } from '$lib/graph/axes';
 
   interface Props {
     graphs: GraphObject[];
@@ -25,6 +25,7 @@
   const IMPLICIT_MAX_RES = 256;
   const TARGET_MAJOR_TICKS = 8;
   const MINOR_SUBDIVISIONS = 5;
+  const MAX_GRID_LINES_PER_AXIS = 200;
   const LABEL_FONT = '10px system-ui, -apple-system, "Segoe UI", sans-serif';
   const LABEL_PAD = 3;
 
@@ -61,26 +62,43 @@
     const xToPx = (x: number) => px + ((x - x0) / xSpan) * pw;
     const yToPx = (y: number) => py + (1 - (y - y0) / ySpan) * ph;
 
-    const majorXStep = g.gridStep > 0 ? g.gridStep : niceStep(xSpan, TARGET_MAJOR_TICKS);
-    const majorYStep = g.gridStep > 0 ? g.gridStep : niceStep(ySpan, TARGET_MAJOR_TICKS);
-    const minorXStep = majorXStep / MINOR_SUBDIVISIONS;
-    const minorYStep = majorYStep / MINOR_SUBDIVISIONS;
+    const userStep = Number.isFinite(g.gridStep) && g.gridStep > 0 ? g.gridStep : null;
+    const majorXStep = cappedStep(
+      xSpan,
+      userStep ?? niceStep(xSpan, TARGET_MAJOR_TICKS),
+      MAX_GRID_LINES_PER_AXIS,
+    );
+    const majorYStep = cappedStep(
+      ySpan,
+      userStep ?? niceStep(ySpan, TARGET_MAJOR_TICKS),
+      MAX_GRID_LINES_PER_AXIS,
+    );
+    const rawMinorX = majorXStep / MINOR_SUBDIVISIONS;
+    const rawMinorY = majorYStep / MINOR_SUBDIVISIONS;
+    const drawMinorX = rawMinorX > 0 && xSpan / rawMinorX <= MAX_GRID_LINES_PER_AXIS;
+    const drawMinorY = rawMinorY > 0 && ySpan / rawMinorY <= MAX_GRID_LINES_PER_AXIS;
 
     if (g.showGrid) {
       ctx.lineWidth = 1;
-      ctx.strokeStyle = GRID_MINOR_COLOR;
-      ctx.beginPath();
-      for (const x of generateTicks(x0, x1, minorXStep)) {
-        const sx = xToPx(x);
-        ctx.moveTo(sx, py);
-        ctx.lineTo(sx, py + ph);
+      if (drawMinorX || drawMinorY) {
+        ctx.strokeStyle = GRID_MINOR_COLOR;
+        ctx.beginPath();
+        if (drawMinorX) {
+          for (const x of generateTicks(x0, x1, rawMinorX)) {
+            const sx = xToPx(x);
+            ctx.moveTo(sx, py);
+            ctx.lineTo(sx, py + ph);
+          }
+        }
+        if (drawMinorY) {
+          for (const y of generateTicks(y0, y1, rawMinorY)) {
+            const sy = yToPx(y);
+            ctx.moveTo(px, sy);
+            ctx.lineTo(px + pw, sy);
+          }
+        }
+        ctx.stroke();
       }
-      for (const y of generateTicks(y0, y1, minorYStep)) {
-        const sy = yToPx(y);
-        ctx.moveTo(px, sy);
-        ctx.lineTo(px + pw, sy);
-      }
-      ctx.stroke();
 
       ctx.strokeStyle = GRID_MAJOR_COLOR;
       ctx.beginPath();
@@ -121,28 +139,44 @@
 
       if (xAxisVisible) {
         const axisY = yToPx(0);
+        const nearBottom = py + ph - axisY < LABEL_PAD + 12;
+        const tickLabelY = nearBottom
+          ? Math.max(axisY - LABEL_PAD, py + LABEL_PAD)
+          : Math.min(axisY + LABEL_PAD, py + ph - LABEL_PAD);
         ctx.textAlign = 'center';
-        ctx.textBaseline = 'top';
+        ctx.textBaseline = nearBottom ? 'bottom' : 'top';
         for (const x of generateTicks(x0, x1, majorXStep)) {
           if (yAxisVisible && Math.abs(x) < majorXStep * 1e-6) continue;
-          ctx.fillText(formatTick(x, majorXStep), xToPx(x), axisY + LABEL_PAD);
+          ctx.fillText(formatTick(x, majorXStep), xToPx(x), tickLabelY);
         }
+        const nearTop = axisY - py < LABEL_PAD + 12;
+        const xLabelY = nearTop
+          ? Math.min(axisY + LABEL_PAD, py + ph - LABEL_PAD)
+          : Math.max(axisY - LABEL_PAD, py + LABEL_PAD);
         ctx.textAlign = 'right';
-        ctx.textBaseline = 'alphabetic';
-        ctx.fillText('x', px + pw - LABEL_PAD, axisY - LABEL_PAD);
+        ctx.textBaseline = nearTop ? 'top' : 'alphabetic';
+        ctx.fillText('x', px + pw - LABEL_PAD, xLabelY);
       }
 
       if (yAxisVisible) {
         const axisX = xToPx(0);
-        ctx.textAlign = 'right';
+        const nearLeft = axisX - px < LABEL_PAD + 16;
+        const nearRight = px + pw - axisX < LABEL_PAD + 16;
+        const tickLabelX = nearLeft
+          ? Math.min(axisX + LABEL_PAD, px + pw - LABEL_PAD)
+          : Math.max(axisX - LABEL_PAD, px + LABEL_PAD);
+        ctx.textAlign = nearLeft ? 'left' : 'right';
         ctx.textBaseline = 'middle';
         for (const y of generateTicks(y0, y1, majorYStep)) {
           if (xAxisVisible && Math.abs(y) < majorYStep * 1e-6) continue;
-          ctx.fillText(formatTick(y, majorYStep), axisX - LABEL_PAD, yToPx(y));
+          ctx.fillText(formatTick(y, majorYStep), tickLabelX, yToPx(y));
         }
-        ctx.textAlign = 'left';
+        const yLabelX = nearRight
+          ? Math.max(axisX - LABEL_PAD, px + LABEL_PAD)
+          : Math.min(axisX + LABEL_PAD, px + pw - LABEL_PAD);
+        ctx.textAlign = nearRight ? 'right' : 'left';
         ctx.textBaseline = 'top';
-        ctx.fillText('y', axisX + LABEL_PAD, py + LABEL_PAD);
+        ctx.fillText('y', yLabelX, py + LABEL_PAD);
       }
 
       if (xAxisVisible && yAxisVisible) {

--- a/src/lib/graph/GraphEditor.svelte
+++ b/src/lib/graph/GraphEditor.svelte
@@ -37,7 +37,7 @@
   }
 
   function setGridStep(value: number): void {
-    if (!Number.isFinite(value) || value <= 0) return;
+    if (!Number.isFinite(value) || value < 0) return;
     onUpdate({ gridStep: value });
   }
 

--- a/src/lib/graph/axes.ts
+++ b/src/lib/graph/axes.ts
@@ -1,0 +1,78 @@
+/**
+ * Axis tick + grid math for graph objects. Pure functions; no canvas / DOM.
+ */
+
+const NICE_MULTIPLIERS: readonly number[] = [1, 2, 5, 10];
+
+/**
+ * Return a "nice" step size so that `range / step` is close to `targetCount`.
+ * The step is always of the form m × 10^k with m ∈ {1, 2, 5, 10}, giving
+ * human-friendly tick spacing across any scale.
+ */
+export function niceStep(range: number, targetCount: number): number {
+  if (!Number.isFinite(range) || range <= 0) return 1;
+  if (!Number.isFinite(targetCount) || targetCount <= 0) return range;
+
+  const rough = range / targetCount;
+  const exponent = Math.floor(Math.log10(rough));
+  const pow = 10 ** exponent;
+  const mantissa = rough / pow;
+
+  let best = NICE_MULTIPLIERS[0];
+  let bestErr = Infinity;
+  for (const m of NICE_MULTIPLIERS) {
+    const err = Math.abs(Math.log(m / mantissa));
+    if (err < bestErr) {
+      bestErr = err;
+      best = m;
+    }
+  }
+  return best * pow;
+}
+
+/**
+ * Tick values (multiples of `step`, or a `niceStep` of the range when `step`
+ * is omitted) contained in `[min, max]`, in ascending order.
+ */
+export function generateTicks(min: number, max: number, step?: number): number[] {
+  if (!Number.isFinite(min) || !Number.isFinite(max) || max <= min) return [];
+  const s = step ?? niceStep(max - min, 8);
+  if (!(s > 0) || !Number.isFinite(s)) return [];
+
+  const eps = s * 1e-9;
+  const first = Math.ceil(min / s - 1e-9);
+  const last = Math.floor(max / s + 1e-9);
+  const ticks: number[] = [];
+  for (let i = first; i <= last; i += 1) {
+    const v = i * s;
+    if (v >= min - eps && v <= max + eps) ticks.push(v === 0 ? 0 : v);
+  }
+  return ticks;
+}
+
+/**
+ * Decimal places needed to render multiples of `step` without trailing noise.
+ * Derived from the step's own decimal representation so e.g. `0.25` keeps
+ * 2 digits. Capped at 12 for safety.
+ */
+export function tickDecimals(step: number): number {
+  if (!(step > 0) || !Number.isFinite(step)) return 0;
+  const s = step.toString();
+  if (s.includes('e') || s.includes('E')) {
+    const m = /e(-?\d+)/i.exec(s);
+    const exp = m ? parseInt(m[1], 10) : 0;
+    const intPart = s.split('e')[0];
+    const frac = intPart.includes('.') ? intPart.split('.')[1].length : 0;
+    return Math.max(0, Math.min(12, frac - exp));
+  }
+  const dot = s.indexOf('.');
+  return dot === -1 ? 0 : Math.min(12, s.length - dot - 1);
+}
+
+/** Format a tick value with enough precision for the given step. */
+export function formatTick(value: number, step: number): string {
+  const d = tickDecimals(step);
+  const rounded = Number(value.toFixed(d));
+  if (Object.is(rounded, -0)) return '0';
+  return d === 0 ? rounded.toString() : rounded.toFixed(d);
+}

--- a/src/lib/graph/axes.ts
+++ b/src/lib/graph/axes.ts
@@ -14,6 +14,7 @@ export function niceStep(range: number, targetCount: number): number {
   if (!Number.isFinite(targetCount) || targetCount <= 0) return range;
 
   const rough = range / targetCount;
+  if (!Number.isFinite(rough) || rough <= 0) return 1;
   const exponent = Math.floor(Math.log10(rough));
   const pow = 10 ** exponent;
   const mantissa = rough / pow;
@@ -75,4 +76,30 @@ export function formatTick(value: number, step: number): string {
   const rounded = Number(value.toFixed(d));
   if (Object.is(rounded, -0)) return '0';
   return d === 0 ? rounded.toString() : rounded.toFixed(d);
+}
+
+/**
+ * Coarsen `step` until `range / step <= maxLines`. Prevents pathological
+ * line counts when a user sets a tiny grid step against a large range.
+ * Returns a positive step of the form m × 10^k with m ∈ {1, 2, 5}.
+ */
+export function cappedStep(range: number, step: number, maxLines: number): number {
+  if (!Number.isFinite(range) || range <= 0) return Math.max(step, 1);
+  if (!Number.isFinite(step) || step <= 0) return niceStep(range, 8);
+  if (!Number.isFinite(maxLines) || maxLines <= 0) return step;
+  if (range / step <= maxLines) return step;
+
+  const MULTIPLIERS = [1, 2, 5];
+  let exponent = Math.floor(Math.log10(step));
+  let mantissaIdx = 0;
+  for (let safety = 0; safety < 64; safety += 1) {
+    const candidate = MULTIPLIERS[mantissaIdx] * 10 ** exponent;
+    if (candidate >= step && range / candidate <= maxLines) return candidate;
+    mantissaIdx += 1;
+    if (mantissaIdx >= MULTIPLIERS.length) {
+      mantissaIdx = 0;
+      exponent += 1;
+    }
+  }
+  return niceStep(range, 8);
 }

--- a/src/lib/graph/graphObject.ts
+++ b/src/lib/graph/graphObject.ts
@@ -26,7 +26,7 @@ export function createGraphObject(bounds: {
     bounds,
     xRange: [-10, 10],
     yRange: [-10, 10],
-    gridStep: 1,
+    gridStep: 0,
     showAxes: true,
     showGrid: true,
     functions: [starter],

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -114,6 +114,7 @@ export interface GraphObject extends ObjectBase {
   bounds: { x: number; y: number; w: number; h: number };
   xRange: [number, number];
   yRange: [number, number];
+  /** Grid spacing in graph units. `0` means auto (derived from range). */
   gridStep: number;
   showAxes: boolean;
   showGrid: boolean;

--- a/tests/graph-axes.test.ts
+++ b/tests/graph-axes.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { niceStep, generateTicks, formatTick, tickDecimals } from '$lib/graph/axes';
+
+describe('niceStep', () => {
+  const cases: Array<[number, number]> = [
+    [1, 8],
+    [10, 8],
+    [100, 8],
+    [7, 8],
+    [0.5, 8],
+    [0.01, 8],
+    [1234, 10],
+    [0.0037, 6],
+  ];
+
+  it('returns a 1/2/5×10^k value for common ranges', () => {
+    for (const [range, target] of cases) {
+      const step = niceStep(range, target);
+      expect(step).toBeGreaterThan(0);
+      const exp = Math.floor(Math.log10(step));
+      const m = step / 10 ** exp;
+      expect([1, 2, 5]).toContain(Math.round(m));
+    }
+  });
+
+  it('yields a tick count near the target', () => {
+    for (const [range, target] of cases) {
+      const step = niceStep(range, target);
+      const count = range / step;
+      expect(count).toBeGreaterThanOrEqual(Math.max(1, target / 4));
+      expect(count).toBeLessThanOrEqual(target * 2);
+    }
+  });
+
+  it('falls back safely for degenerate input', () => {
+    expect(niceStep(0, 8)).toBe(1);
+    expect(niceStep(-1, 8)).toBe(1);
+    expect(niceStep(Infinity, 8)).toBe(1);
+  });
+});
+
+describe('generateTicks', () => {
+  it('emits ticks at multiples of a nice step across a symmetric range', () => {
+    const ticks = generateTicks(-5, 5);
+    expect(ticks[0]).toBeCloseTo(-5);
+    expect(ticks[ticks.length - 1]).toBeCloseTo(5);
+    expect(ticks).toContain(0);
+    expect(ticks.length).toBeGreaterThanOrEqual(5);
+    expect(ticks.length).toBeLessThanOrEqual(15);
+  });
+
+  it('honours an explicit step', () => {
+    expect(generateTicks(-3, 3, 1)).toEqual([-3, -2, -1, 0, 1, 2, 3]);
+    expect(generateTicks(0, 1, 0.25)).toEqual([0, 0.25, 0.5, 0.75, 1]);
+  });
+
+  it('stays empty for invalid ranges', () => {
+    expect(generateTicks(1, 1)).toEqual([]);
+    expect(generateTicks(5, 1)).toEqual([]);
+    expect(generateTicks(NaN, 1)).toEqual([]);
+  });
+
+  it('keeps tick count within target bounds for common ranges', () => {
+    for (const range of [0.1, 0.5, 1, 7, 10, 100, 1000]) {
+      const ticks = generateTicks(0, range);
+      expect(ticks.length).toBeGreaterThanOrEqual(2);
+      expect(ticks.length).toBeLessThanOrEqual(20);
+    }
+  });
+});
+
+describe('formatTick', () => {
+  it('drops trailing decimals when step is integral', () => {
+    expect(formatTick(5, 1)).toBe('5');
+    expect(formatTick(-0, 1)).toBe('0');
+  });
+
+  it('keeps decimals for sub-unit steps', () => {
+    expect(formatTick(0.25, 0.25)).toBe('0.25');
+    expect(formatTick(0.1, 0.1)).toBe('0.1');
+  });
+
+  it('matches tickDecimals for small steps', () => {
+    expect(tickDecimals(0.001)).toBe(3);
+    expect(tickDecimals(10)).toBe(0);
+  });
+});

--- a/tests/graph-axes.test.ts
+++ b/tests/graph-axes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { niceStep, generateTicks, formatTick, tickDecimals } from '$lib/graph/axes';
+import { niceStep, generateTicks, formatTick, tickDecimals, cappedStep } from '$lib/graph/axes';
 
 describe('niceStep', () => {
   const cases: Array<[number, number]> = [
@@ -36,6 +36,40 @@ describe('niceStep', () => {
     expect(niceStep(0, 8)).toBe(1);
     expect(niceStep(-1, 8)).toBe(1);
     expect(niceStep(Infinity, 8)).toBe(1);
+    expect(niceStep(NaN, 8)).toBe(1);
+    expect(niceStep(Number.MIN_VALUE, 8)).toBe(1);
+    expect(niceStep(1e-300, 1e300)).toBe(1);
+    expect(niceStep(10, 0)).toBeGreaterThan(0);
+    expect(niceStep(10, -1)).toBeGreaterThan(0);
+    expect(niceStep(10, NaN)).toBeGreaterThan(0);
+  });
+});
+
+describe('cappedStep', () => {
+  it('returns the input step when the line count is within budget', () => {
+    expect(cappedStep(10, 1, 200)).toBe(1);
+    expect(cappedStep(100, 10, 200)).toBe(10);
+  });
+
+  it('coarsens when range / step exceeds the cap', () => {
+    const step = cappedStep(10_000, 0.01, 200);
+    expect(10_000 / step).toBeLessThanOrEqual(200);
+    expect(step).toBeGreaterThan(0.01);
+  });
+
+  it('keeps the result of the form m × 10^k with m ∈ {1, 2, 5}', () => {
+    const step = cappedStep(10_000, 0.01, 200);
+    const exp = Math.floor(Math.log10(step));
+    const m = Math.round(step / 10 ** exp);
+    expect([1, 2, 5]).toContain(m);
+  });
+
+  it('handles degenerate inputs', () => {
+    expect(cappedStep(0, 1, 200)).toBeGreaterThan(0);
+    expect(cappedStep(NaN, 1, 200)).toBeGreaterThan(0);
+    expect(cappedStep(10, 0, 200)).toBeGreaterThan(0);
+    expect(cappedStep(10, -1, 200)).toBeGreaterThan(0);
+    expect(cappedStep(10, 1, 0)).toBe(1);
   });
 });
 


### PR DESCRIPTION
## Summary

Polishes graph object rendering (issue #49) with an adaptive grid, numeric
tick labels, and axis labels. Curves continue to render on top.

## What

- New pure module `src/lib/graph/axes.ts`:
  - `niceStep(range, targetCount)` — picks a 1/2/5×10^k step so the range
    yields ≈ `targetCount` major ticks.
  - `generateTicks(min, max, step?)` — tick values in `[min, max]` at
    multiples of `step` (or a `niceStep` fallback).
  - `formatTick` / `tickDecimals` helpers so labels keep only the precision
    the step actually needs (e.g. `0.25`, not `0.3`).
- `GraphLayer.svelte`:
  - Two-tone grid: light minor lines at `majorStep / 5`, slightly darker
    major lines at the nice step. Falls back to the graph's `gridStep`
    when the user has set one explicitly.
  - Numeric labels on major x/y ticks, "x"/"y" axis labels at the ends of
    the visible axes, and a "0" at the origin when both axes are in view.
  - Curves are drawn after the grid + axes so they sit on top.

## Why

Closes #49. Previous rendering had a single-tone grid tied to a fixed
`gridStep` and no labels, making the graph hard to read across different
zoom levels.

## Testing

- `tests/graph-axes.test.ts` covers `niceStep` for ranges 0.01–1234,
  tick-count bounds, explicit step, degenerate input, and `formatTick` /
  `tickDecimals` behaviour.
- `pnpm lint` ✅
- `pnpm test` ✅ (277 tests)

Closes #49.