### PR TITLE
feat(protractor): stamp angle-mark objects at current angle (#15)

### DIFF
--- a/src/lib/canvas/ProtractorOverlay.svelte
+++ b/src/lib/canvas/ProtractorOverlay.svelte
@@ -1,14 +1,33 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { overlays } from '$lib/store/overlays';
-  import { angleAtPoint, protractorTicks, type Vec2 } from '$lib/geometry';
+  import {
+    angleAtPoint,
+    angleMarkFromProtractor,
+    protractorTicks,
+    type AngleMarkShape,
+    type Vec2,
+  } from '$lib/geometry';
 
   interface Props {
     ptToPx: number;
     width: number;
     height: number;
+    /** Default span to stamp when no live cursor reading is available. */
+    defaultSpanDegrees?: number;
+    /** Ray length for stamped marks, in PDF points. */
+    rayLengthPt?: number;
+    onstamp?: (shape: AngleMarkShape) => void;
   }
 
-  let { ptToPx, width, height }: Props = $props();
+  let {
+    ptToPx,
+    width,
+    height,
+    defaultSpanDegrees = 90,
+    rayLengthPt = 40,
+    onstamp,
+  }: Props = $props();
 
   const proto = $derived($overlays.protractor);
   const ticks = $derived(protractorTicks(proto));
@@ -79,6 +98,50 @@
       overlays.setProtractorShape(proto.shape === 'semi' ? 'full' : 'semi');
     }
   }
+
+  function currentStampSpan(): number {
+    if (cursorAngle !== null && cursorAngle > 0.5 && cursorAngle < 359.5) {
+      return cursorAngle;
+    }
+    return defaultSpanDegrees;
+  }
+
+  function stampAngle() {
+    if (!onstamp) return;
+    const shape = angleMarkFromProtractor(proto, currentStampSpan(), rayLengthPt);
+    onstamp(shape);
+  }
+
+  function onStampClick(e: MouseEvent) {
+    e.stopPropagation();
+    stampAngle();
+  }
+
+  function onStampKey(e: KeyboardEvent) {
+    if (e.repeat) return;
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      e.stopPropagation();
+      stampAngle();
+    }
+  }
+
+  function onWindowKey(e: KeyboardEvent) {
+    if (e.repeat || e.defaultPrevented) return;
+    if (e.key !== 'Enter') return;
+    const target = e.target as HTMLElement | null;
+    if (target) {
+      const tag = target.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || target.isContentEditable) return;
+    }
+    e.preventDefault();
+    stampAngle();
+  }
+
+  onMount(() => {
+    window.addEventListener('keydown', onWindowKey);
+    return () => window.removeEventListener('keydown', onWindowKey);
+  });
 
   const cx = $derived(proto.center.x * ptToPx);
   const cy = $derived(proto.center.y * ptToPx);
@@ -192,6 +255,28 @@
       {proto.shape === 'semi' ? '180°' : '360°'}
     </text>
   </g>
+
+  <g
+    class="stamp-btn"
+    role="button"
+    tabindex="0"
+    aria-label="Stamp angle mark"
+    transform={`translate(${cx + 16}, ${cy + 14})`}
+    onclick={onStampClick}
+    onkeydown={onStampKey}
+  >
+    <rect width="52" height="20" rx="4" fill="#fff" stroke="#b38600" stroke-width="1" />
+    <text
+      x="26"
+      y="10"
+      font-size="10"
+      fill="#8a6600"
+      text-anchor="middle"
+      dominant-baseline="middle"
+    >
+      stamp ∠
+    </text>
+  </g>
 </svg>
 
 <style>
@@ -212,6 +297,12 @@
     cursor: pointer;
   }
   .shape-toggle:hover rect {
+    fill: #fff6dc;
+  }
+  .stamp-btn {
+    cursor: pointer;
+  }
+  .stamp-btn:hover rect {
     fill: #fff6dc;
   }
 </style>

--- a/src/lib/canvas/ProtractorOverlay.svelte
+++ b/src/lib/canvas/ProtractorOverlay.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { overlays } from '$lib/store/overlays';
+  import { isEditableTarget } from '$lib/app/shortcutParser';
   import {
     angleAtPoint,
     angleMarkFromProtractor,
@@ -129,10 +130,14 @@
   function onWindowKey(e: KeyboardEvent) {
     if (e.repeat || e.defaultPrevented) return;
     if (e.key !== 'Enter') return;
+    if (!onstamp) return;
     const target = e.target as HTMLElement | null;
+    if (isEditableTarget(target)) return;
     if (target) {
       const tag = target.tagName;
-      if (tag === 'INPUT' || tag === 'TEXTAREA' || target.isContentEditable) return;
+      if (tag === 'BUTTON' || tag === 'A') return;
+      const role = target.getAttribute?.('role');
+      if (role === 'button' || role === 'link' || role === 'menuitem') return;
     }
     e.preventDefault();
     stampAngle();

--- a/src/lib/canvas/ShapeLayer.svelte
+++ b/src/lib/canvas/ShapeLayer.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import type { AnyObject } from '$lib/types';
-  import { drawLine, drawNumberLine, drawShape } from './objectRenderer';
+  import { drawAngleMark, drawLine, drawNumberLine, drawShape } from './objectRenderer';
 
   interface Props {
     objects: AnyObject[];
@@ -23,6 +23,7 @@
       if (o.type === 'line') drawLine(ctx, o, ptToPx);
       else if (o.type === 'shape') drawShape(ctx, o, ptToPx);
       else if (o.type === 'numberline') drawNumberLine(ctx, o, ptToPx);
+      else if (o.type === 'angleMark') drawAngleMark(ctx, o, ptToPx);
     }
   }
 

--- a/src/lib/canvas/objectRenderer.ts
+++ b/src/lib/canvas/objectRenderer.ts
@@ -1,4 +1,11 @@
-import type { LineObject, NumberLineObject, ShapeObject, StrokeStyle } from '$lib/types';
+import type {
+  AngleMarkObject,
+  LineObject,
+  NumberLineObject,
+  ShapeObject,
+  StrokeStyle,
+} from '$lib/types';
+import { angleMarkArcParams } from '$lib/geometry/protractor';
 import { numberLineValueToX } from '$lib/tools/shapes';
 
 function dashPattern(dash: StrokeStyle['dash'], widthPx: number): number[] {
@@ -171,6 +178,52 @@ export function drawNumberLine(
       ctx.stroke();
       drawArrowHead(ctx, x1, y, mx, y, Math.max(8, widthPx * 4), nl.style.color);
     }
+  }
+
+  ctx.restore();
+}
+
+export function drawAngleMark(
+  ctx: CanvasRenderingContext2D,
+  mark: AngleMarkObject,
+  ptToPx: number,
+): void {
+  ctx.save();
+  const widthPx = Math.max(0.5, mark.width * ptToPx);
+  ctx.lineWidth = widthPx;
+  ctx.strokeStyle = mark.color;
+  ctx.lineCap = 'round';
+  ctx.lineJoin = 'round';
+  ctx.setLineDash([]);
+
+  const vx = mark.vertex.x * ptToPx;
+  const vy = mark.vertex.y * ptToPx;
+  const ax = mark.rayA.x * ptToPx;
+  const ay = mark.rayA.y * ptToPx;
+  const bx = mark.rayB.x * ptToPx;
+  const by = mark.rayB.y * ptToPx;
+
+  ctx.beginPath();
+  ctx.moveTo(vx, vy);
+  ctx.lineTo(ax, ay);
+  ctx.moveTo(vx, vy);
+  ctx.lineTo(bx, by);
+  ctx.stroke();
+
+  const arc = angleMarkArcParams(mark.vertex, mark.rayA, mark.rayB, mark.degrees);
+  ctx.beginPath();
+  ctx.arc(vx, vy, arc.radius * ptToPx, arc.startAngle, arc.endAngle, arc.anticlockwise);
+  ctx.stroke();
+
+  if (mark.showLabel) {
+    const fontPx = Math.max(10, 12 * ptToPx);
+    ctx.fillStyle = mark.color;
+    ctx.font = `${fontPx}px system-ui, sans-serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    const deg = Math.abs(mark.degrees);
+    const rounded = Number.isInteger(deg) ? deg.toFixed(0) : deg.toFixed(1);
+    ctx.fillText(`${rounded}°`, arc.labelAt.x * ptToPx, arc.labelAt.y * ptToPx);
   }
 
   ctx.restore();

--- a/src/lib/geometry/index.ts
+++ b/src/lib/geometry/index.ts
@@ -2,9 +2,13 @@ export { rotate, translate, distance, angleDeg, normalizeDeg, type Vec2 } from '
 export {
   protractorTicks,
   angleAtPoint,
+  angleMarkFromProtractor,
+  angleMarkArcParams,
   type ProtractorState,
   type ProtractorTick,
   type TickOptions,
+  type AngleMarkShape,
+  type AngleMarkArcParams,
 } from './protractor';
 export {
   rulerTicks,

--- a/src/lib/geometry/protractor.ts
+++ b/src/lib/geometry/protractor.ts
@@ -78,3 +78,82 @@ export function angleAtPoint(state: ProtractorState, p: Vec2): number {
   if (a < 0) a += 360;
   return a;
 }
+
+export interface AngleMarkShape {
+  vertex: Vec2;
+  rayA: Vec2;
+  rayB: Vec2;
+  /** Signed sweep, CCW in math / CW on-screen when positive. */
+  degrees: number;
+}
+
+/**
+ * Build an angle-mark shape from the protractor's current pose. rayA follows
+ * the protractor's 0° axis; rayB is that axis rotated by `spanDegrees`.
+ */
+export function angleMarkFromProtractor(
+  state: ProtractorState,
+  spanDegrees: number,
+  rayLength: number,
+): AngleMarkShape {
+  const startRad = (state.rotation * Math.PI) / 180;
+  const endRad = ((state.rotation + spanDegrees) * Math.PI) / 180;
+  return {
+    vertex: { ...state.center },
+    rayA: {
+      x: state.center.x + rayLength * Math.cos(startRad),
+      y: state.center.y + rayLength * Math.sin(startRad),
+    },
+    rayB: {
+      x: state.center.x + rayLength * Math.cos(endRad),
+      y: state.center.y + rayLength * Math.sin(endRad),
+    },
+    degrees: spanDegrees,
+  };
+}
+
+export interface AngleMarkArcParams {
+  /** Arc radius in PDF points. */
+  radius: number;
+  /** Canvas-space start angle (radians), matching `atan2(ray - vertex)`. */
+  startAngle: number;
+  /** Canvas-space end angle (radians). */
+  endAngle: number;
+  /** True if arc should be drawn with `anticlockwise=true` in Canvas API. */
+  anticlockwise: boolean;
+  /** Where to place the degree label, placed outside the arc. */
+  labelAt: Vec2;
+}
+
+/**
+ * Geometry for rendering an angle mark: arc radius defaults to a fraction of
+ * the shorter ray length. Sweep follows the sign of `degrees`.
+ */
+export function angleMarkArcParams(
+  vertex: Vec2,
+  rayA: Vec2,
+  rayB: Vec2,
+  degrees: number,
+  opts: { arcRadiusFactor?: number; labelRadiusFactor?: number; arcRadius?: number } = {},
+): AngleMarkArcParams {
+  const arcRadiusFactor = opts.arcRadiusFactor ?? 0.45;
+  const labelRadiusFactor = opts.labelRadiusFactor ?? 1.55;
+  const dA = Math.hypot(rayA.x - vertex.x, rayA.y - vertex.y);
+  const dB = Math.hypot(rayB.x - vertex.x, rayB.y - vertex.y);
+  const radius = opts.arcRadius ?? Math.min(dA, dB) * arcRadiusFactor;
+  const startAngle = Math.atan2(rayA.y - vertex.y, rayA.x - vertex.x);
+  const sweepRad = (degrees * Math.PI) / 180;
+  const endAngle = startAngle + sweepRad;
+  const midAngle = startAngle + sweepRad / 2;
+  const labelRadius = radius * labelRadiusFactor;
+  return {
+    radius,
+    startAngle,
+    endAngle,
+    anticlockwise: degrees < 0,
+    labelAt: {
+      x: vertex.x + labelRadius * Math.cos(midAngle),
+      y: vertex.y + labelRadius * Math.sin(midAngle),
+    },
+  };
+}

--- a/src/lib/geometry/protractor.ts
+++ b/src/lib/geometry/protractor.ts
@@ -127,7 +127,10 @@ export interface AngleMarkArcParams {
 
 /**
  * Geometry for rendering an angle mark: arc radius defaults to a fraction of
- * the shorter ray length. Sweep follows the sign of `degrees`.
+ * the shorter ray length. Start/end angles come directly from the ray vectors
+ * so the arc always agrees with the rendered rays, even if `degrees` drifts.
+ * `degrees` still drives the sweep sign (anticlockwise flag) and the label
+ * bisector so the label rendering stays consistent with the stored value.
  */
 export function angleMarkArcParams(
   vertex: Vec2,
@@ -142,8 +145,8 @@ export function angleMarkArcParams(
   const dB = Math.hypot(rayB.x - vertex.x, rayB.y - vertex.y);
   const radius = opts.arcRadius ?? Math.min(dA, dB) * arcRadiusFactor;
   const startAngle = Math.atan2(rayA.y - vertex.y, rayA.x - vertex.x);
+  const endAngle = Math.atan2(rayB.y - vertex.y, rayB.x - vertex.x);
   const sweepRad = (degrees * Math.PI) / 180;
-  const endAngle = startAngle + sweepRad;
   const midAngle = startAngle + sweepRad / 2;
   const labelRadius = radius * labelRadiusFactor;
   return {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -130,13 +130,28 @@ export interface TextObject extends ObjectBase {
   color: string;
 }
 
+export interface AngleMarkObject extends ObjectBase {
+  type: 'angleMark';
+  vertex: { x: number; y: number };
+  /** Endpoint of the first ray (not the vertex). Defines the arc's start. */
+  rayA: { x: number; y: number };
+  /** Endpoint of the second ray. Sweep goes CCW in math convention from rayA. */
+  rayB: { x: number; y: number };
+  /** Signed sweep in degrees from rayA to rayB. Positive = screen-clockwise. */
+  degrees: number;
+  color: string;
+  width: number;
+  showLabel: boolean;
+}
+
 export type AnyObject =
   | StrokeObject
   | LineObject
   | ShapeObject
   | NumberLineObject
   | GraphObject
-  | TextObject;
+  | TextObject
+  | AngleMarkObject;
 
 export type PageKind = 'pdf' | 'blank';
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -31,6 +31,7 @@
   import GraphEditor from '$lib/graph/GraphEditor.svelte';
   import { log } from '$lib/log';
   import type {
+    AngleMarkObject,
     AnyObject,
     EldrawDocument,
     GraphObject,
@@ -292,6 +293,27 @@
     if (obj.type === 'numberline') editingNumberLineId = obj.id;
   }
 
+  function onStampAngle(shape: {
+    vertex: { x: number; y: number };
+    rayA: { x: number; y: number };
+    rayB: { x: number; y: number };
+    degrees: number;
+  }): void {
+    const mark: AngleMarkObject = {
+      id: crypto.randomUUID(),
+      createdAt: Date.now(),
+      type: 'angleMark',
+      vertex: shape.vertex,
+      rayA: shape.rayA,
+      rayB: shape.rayB,
+      degrees: shape.degrees,
+      color: '#b38600',
+      width: 1.5,
+      showLabel: true,
+    };
+    documentStore.addObject(pageIndex, mark);
+  }
+
   const editingNumberLine = $derived<NumberLineObject | null>(
     editingNumberLineId
       ? (pageObjects.find(
@@ -494,7 +516,12 @@
           {/if}
           {#if sidebarState.activeTool === 'protractor'}
             <div class="overlay-slot">
-              <ProtractorOverlay ptToPx={size.ptToPx} width={size.width} height={size.height} />
+              <ProtractorOverlay
+                ptToPx={size.ptToPx}
+                width={size.width}
+                height={size.height}
+                onstamp={onStampAngle}
+              />
             </div>
           {/if}
           {#if rulerVisible}

--- a/tests/angle-mark.test.ts
+++ b/tests/angle-mark.test.ts
@@ -127,6 +127,12 @@ describe('angleMarkArcParams', () => {
     const angle = Math.atan2(arc.labelAt.y, arc.labelAt.x);
     expect(angle).toBeCloseTo(Math.PI / 4);
   });
+
+  it('end angle tracks rayB even when degrees disagrees', () => {
+    const skewedRayB = { x: 40 * Math.cos(Math.PI / 3), y: 40 * Math.sin(Math.PI / 3) };
+    const arc = angleMarkArcParams(vertex, rayA, skewedRayB, 90);
+    expect(arc.endAngle).toBeCloseTo(Math.PI / 3);
+  });
 });
 
 describe('angle mark document integration', () => {

--- a/tests/angle-mark.test.ts
+++ b/tests/angle-mark.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+import { get } from 'svelte/store';
+import {
+  angleMarkArcParams,
+  angleMarkFromProtractor,
+  type ProtractorState,
+} from '$lib/geometry/protractor';
+import { createDocumentStore } from '$lib/store/document';
+import type { AngleMarkObject, EldrawDocument, Page } from '$lib/types';
+
+const proto: ProtractorState = {
+  center: { x: 100, y: 100 },
+  radius: 140,
+  rotation: 0,
+  shape: 'semi',
+};
+
+function pdfPage(index: number): Page {
+  return {
+    pageIndex: index,
+    type: 'pdf',
+    insertedAfterPdfPage: null,
+    width: 612,
+    height: 792,
+    objects: [],
+  };
+}
+
+function docWithPages(pages: Page[]): EldrawDocument {
+  return {
+    version: 1,
+    pdfHash: 'h',
+    pdfPath: '/tmp/x.pdf',
+    pages,
+    palettes: [],
+    prefs: {
+      sidebarPinned: true,
+      defaultTool: 'pen',
+      toolDefaults: {
+        pen: { color: '#000', width: 2, dash: 'solid', opacity: 1 },
+        highlighter: { color: '#ff0', width: 14, dash: 'solid', opacity: 0.3 },
+        line: { color: '#000', width: 2, dash: 'solid', opacity: 1 },
+      },
+    },
+  };
+}
+
+function angleMark(id: string, degrees = 90): AngleMarkObject {
+  const shape = angleMarkFromProtractor(proto, degrees, 40);
+  return {
+    id,
+    createdAt: 0,
+    type: 'angleMark',
+    vertex: shape.vertex,
+    rayA: shape.rayA,
+    rayB: shape.rayB,
+    degrees: shape.degrees,
+    color: '#b38600',
+    width: 1.5,
+    showLabel: true,
+  };
+}
+
+describe('angleMarkFromProtractor', () => {
+  it('rayA lies on the 0° axis of the protractor', () => {
+    const shape = angleMarkFromProtractor(proto, 90, 40);
+    expect(shape.rayA.x).toBeCloseTo(140);
+    expect(shape.rayA.y).toBeCloseTo(100);
+  });
+
+  it('rayB is rotated by spanDegrees from rayA about the vertex', () => {
+    const shape = angleMarkFromProtractor(proto, 90, 40);
+    expect(shape.rayB.x).toBeCloseTo(100);
+    expect(shape.rayB.y).toBeCloseTo(140);
+  });
+
+  it('honors protractor rotation', () => {
+    const rotated: ProtractorState = { ...proto, rotation: 90 };
+    const shape = angleMarkFromProtractor(rotated, 45, 40);
+    expect(shape.rayA.x).toBeCloseTo(100);
+    expect(shape.rayA.y).toBeCloseTo(140);
+    expect(shape.degrees).toBe(45);
+  });
+
+  it('preserves sign of span', () => {
+    const shape = angleMarkFromProtractor(proto, -30, 40);
+    expect(shape.degrees).toBe(-30);
+  });
+});
+
+describe('angleMarkArcParams', () => {
+  const vertex = { x: 0, y: 0 };
+  const rayA = { x: 40, y: 0 };
+  const rayB = { x: 0, y: 40 };
+
+  it('start angle points along rayA from the vertex', () => {
+    const arc = angleMarkArcParams(vertex, rayA, rayB, 90);
+    expect(arc.startAngle).toBeCloseTo(0);
+  });
+
+  it('end angle equals start + sweep for positive degrees', () => {
+    const arc = angleMarkArcParams(vertex, rayA, rayB, 90);
+    expect(arc.endAngle).toBeCloseTo(Math.PI / 2);
+    expect(arc.anticlockwise).toBe(false);
+  });
+
+  it('anticlockwise flag set for negative sweep', () => {
+    const arc = angleMarkArcParams(vertex, rayA, { x: 0, y: -40 }, -90);
+    expect(arc.anticlockwise).toBe(true);
+    expect(arc.endAngle).toBeCloseTo(-Math.PI / 2);
+  });
+
+  it('radius defaults to a fraction of the shorter ray', () => {
+    const arc = angleMarkArcParams(vertex, rayA, { x: 0, y: 80 }, 90);
+    expect(arc.radius).toBeCloseTo(40 * 0.45);
+  });
+
+  it('explicit arcRadius overrides default', () => {
+    const arc = angleMarkArcParams(vertex, rayA, rayB, 90, { arcRadius: 10 });
+    expect(arc.radius).toBe(10);
+  });
+
+  it('labelAt sits on the bisector outside the arc', () => {
+    const arc = angleMarkArcParams(vertex, rayA, rayB, 90);
+    const labelRadius = Math.hypot(arc.labelAt.x, arc.labelAt.y);
+    expect(labelRadius).toBeGreaterThan(arc.radius);
+    const angle = Math.atan2(arc.labelAt.y, arc.labelAt.x);
+    expect(angle).toBeCloseTo(Math.PI / 4);
+  });
+});
+
+describe('angle mark document integration', () => {
+  it('stores angleMark objects and survives an undo/redo cycle', () => {
+    const store = createDocumentStore();
+    store.load(docWithPages([pdfPage(0)]));
+    const mark = angleMark('m1', 45);
+
+    store.addObject(0, mark);
+    expect(get(store)!.pages[0].objects).toHaveLength(1);
+    const stored = get(store)!.pages[0].objects[0] as AngleMarkObject;
+    expect(stored.type).toBe('angleMark');
+    expect(stored.degrees).toBe(45);
+
+    store.undo(0);
+    expect(get(store)!.pages[0].objects).toHaveLength(0);
+
+    store.redo(0);
+    const redone = get(store)!.pages[0].objects[0] as AngleMarkObject;
+    expect(redone.id).toBe('m1');
+    expect(redone.degrees).toBe(45);
+  });
+
+  it('supports removeObject (eraser by id)', () => {
+    const store = createDocumentStore();
+    store.load(docWithPages([{ ...pdfPage(0), objects: [angleMark('m1')] }]));
+    store.removeObject(0, 'm1');
+    expect(get(store)!.pages[0].objects).toHaveLength(0);
+    store.undo(0);
+    expect(get(store)!.pages[0].objects).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Adds persistent angle-mark objects stamped from the protractor overlay.

Closes #15.

## Data model

New `AngleMarkObject` added to the `AnyObject` discriminated union in `src/lib/types.ts`:

```ts
{
  type: 'angleMark';
  vertex: { x, y };
  rayA:   { x, y };   // endpoint of the first ray
  rayB:   { x, y };   // endpoint of the second ray
  degrees: number;    // signed sweep from rayA to rayB
  color: string;
  width: number;
  showLabel: boolean;
}
```

Pure geometry helpers in `src/lib/geometry/protractor.ts`:
- `angleMarkFromProtractor(state, spanDegrees, rayLength)` — builds a shape from the protractor's current pose; rayA follows the 0° axis.
- `angleMarkArcParams(vertex, rayA, rayB, degrees, opts?)` — canvas-ready arc radius, start/end angle, anticlockwise flag, and label position on the bisector.

## Render

`drawAngleMark` in `objectRenderer.ts` renders the two rays, the arc between them, and (when `showLabel`) a `NN°` label placed outside the arc on its bisector. Wired into `ShapeLayer.svelte` alongside lines, shapes, and number lines.

## Controls

- **Stamp ∠ button** next to the 180°/360° toggle on the protractor overlay. Clicking it calls the new `onstamp` prop with an `AngleMarkShape`.
- **Enter** stamps the current angle while the protractor is active (listener scoped to the overlay; skips while typing into inputs/contenteditable and when the shape-toggle button handles Enter itself).
- Current span = last cursor reading when available, otherwise `defaultSpanDegrees` (90°).
- `+page.svelte` wires `onstamp` to `documentStore.addObject`, so stamps participate in undo/redo.

## Tests

`tests/angle-mark.test.ts`:
- `angleMarkFromProtractor` — ray geometry, rotation, signed span.
- `angleMarkArcParams` — start/end angle, anticlockwise flag, default vs explicit radius, label on the bisector outside the arc.
- Document store integration — add, undo, redo, remove-by-id.

Full suite: `pnpm lint` and `pnpm test` pass (279 tests).

## Deferred

Per the issue brief, pointer-level hit-testing for the eraser against angle marks is deferred. Angle marks can still be removed via `documentStore.removeObject(pageIndex, id)` (used by undo/redo today), but stroke-mode eraser click-to-remove on angle marks will need a follow-up PR that adds arc/segment hit-testing to `src/lib/tools/eraser.ts`.