### PR TITLE
chore(ci): cache apt + pdfium and strip release binaries (#27)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,17 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
+      # Avoids reinstalling webkit/gtk on every CI run (~30-60s per run).
       - name: Install Linux build deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libssl-dev
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libssl-dev
+          version: 1.0
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+          shared-key: tauri-release
+          cache-on-failure: true
       - run: cargo fmt --manifest-path src-tauri/Cargo.toml --check
       - run: cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
       - run: cargo test --manifest-path src-tauri/Cargo.toml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,19 +83,36 @@ jobs:
         with:
           targets: ${{ matrix.rust-target }}
 
+      # Caches ~/.cargo registry + src-tauri/target across runs. Biggest
+      # single win for release build time; restore-keys fall back on version
+      # bumps so only eldraw itself recompiles.
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+          shared-key: tauri-release
+          cache-on-failure: true
 
+      # Avoids reinstalling webkit/gtk on every release (~30-60s per run).
       - name: Install Linux build deps
         if: matrix.platform == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libssl-dev
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libssl-dev
+          version: 1.0
 
       - run: pnpm install --frozen-lockfile
 
+      # Cache the pdfium native lib; key is the fetch script so any change to
+      # the pinned tag or checksums busts the cache automatically.
+      - name: Cache pdfium
+        id: cache-pdfium
+        uses: actions/cache@v4
+        with:
+          path: src-tauri/pdfium
+          key: pdfium-${{ runner.os }}-${{ hashFiles('scripts/fetch-pdfium.sh') }}
+
       - name: Fetch pdfium
+        if: steps.cache-pdfium.outputs.cache-hit != 'true'
         shell: bash
         run: |
           case "${{ runner.os }}" in

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,3 +40,6 @@ pedantic = { level = "warn", priority = -1 }
 module_name_repetitions = "allow"
 missing_errors_doc = "allow"
 missing_panics_doc = "allow"
+
+[profile.release]
+strip = "symbols"


### PR DESCRIPTION
## Summary

Closes #27. Trims the release workflow runtime with conservative caching + artifact tweaks.

The rc.6 release run took ~20 min. Expected savings on warm-cache runs:

| Change | Est. savings / release job |
| --- | --- |
| Cache apt webkit/gtk deps (Linux) | ~30–60s |
| Cache pdfium native lib | ~10–30s |
| `shared-key` on rust-cache so CI `main` cache seeds release builds | ~3–6 min on the Linux job (deps already compiled) |
| `cache-on-failure: true` | rescues cache when a bundler step flakes |
| `strip = "symbols"` in `[profile.release]` | no build-time cost; smaller `.deb` / `.msi` / AppImage |

Net expected savings on a warm cache: **~5–8 min** per matrix job, most of it on the Linux build (which today recompiles the full tauri tree because the CI backend job and the release job didn't share cache keys).

## What changed

- `.github/workflows/release.yml`
  - `Swatinem/rust-cache@v2` gains `shared-key: tauri-release` and `cache-on-failure: true`
  - Linux deps installed via `awalsh128/cache-apt-pkgs-action@v1`
  - `src-tauri/pdfium` cached with `actions/cache@v4`, keyed on the fetch script hash so the pinned tag / checksums invalidate automatically
- `.github/workflows/ci.yml` — same cache apt + rust-cache `shared-key` so the CI backend job seeds the same cache the release job later reads
- `src-tauri/Cargo.toml` — add `[profile.release] strip = "symbols"`

## Not changed

- No change to what gets built or the tag trigger mechanics
- Didn't touch `codegen-units` / `lto` — per the issue brief, those are a binary-size trade-off and would add build time, so I stayed conservative
- `@tauri-apps/cli` is already a devDependency (ships prebuilt native binary), so `tauri-action` does not `cargo install tauri-cli` — no binstall step needed

## Testing

- `python3 -c "import yaml; yaml.safe_load(...)"` on both workflow files: OK
- `actionlint .github/workflows/*.yml`: clean
- `cargo metadata --manifest-path src-tauri/Cargo.toml --no-deps`: OK (profile parses)

Can't exercise CI from here; will observe the next tag push for actual timing.