### PR TITLE
feat(app): command palette (Ctrl+K) (#57)

### DIFF
--- a/src/lib/app/actions.ts
+++ b/src/lib/app/actions.ts
@@ -1,0 +1,46 @@
+import { get } from 'svelte/store';
+import { viewport } from '$lib/store/viewport';
+import { documentStore, currentDocument } from '$lib/store/document';
+import { sampleCanvasBackground } from '$lib/canvas/bgSample';
+
+/**
+ * Shared action helpers used by both the global shortcut registry and the
+ * command palette. Keeping them in one place prevents the two surfaces from
+ * drifting apart.
+ */
+
+export function currentPage(): number {
+  return viewport.snapshot().currentPageIndex;
+}
+
+export function currentPageCount(): number {
+  return get(currentDocument)?.pages.length ?? 0;
+}
+
+export function toggleFullscreen(): void {
+  if (typeof document === 'undefined') return;
+  if (document.fullscreenElement) {
+    void document.exitFullscreen();
+  } else {
+    void document.documentElement.requestFullscreen();
+  }
+}
+
+export function sampleCurrentPageBackground(): string | undefined {
+  if (typeof document === 'undefined') return undefined;
+  const canvas = document.querySelector<HTMLCanvasElement>(
+    '.pdf-slot canvas[aria-label="Rendered PDF page"]',
+  );
+  if (!canvas) return undefined;
+  return sampleCanvasBackground(canvas) ?? undefined;
+}
+
+export function insertBlankAfterCurrent(): void {
+  const doc = get(currentDocument);
+  if (!doc) return;
+  const idx = currentPage();
+  const page = doc.pages[idx];
+  if (!page) return;
+  const background = page.type === 'pdf' ? sampleCurrentPageBackground() : page.background;
+  documentStore.insertBlankPageAfter(idx, page.width, page.height, background);
+}

--- a/src/lib/app/shortcutRegistry.ts
+++ b/src/lib/app/shortcutRegistry.ts
@@ -1,10 +1,15 @@
-import { get } from 'svelte/store';
 import { sidebar, styleKeyFor } from '$lib/store/sidebar';
-import { documentStore, currentDocument } from '$lib/store/document';
+import { documentStore } from '$lib/store/document';
 import { viewport } from '$lib/store/viewport';
 import { presenter } from '$lib/store/presenter';
 import { zen } from '$lib/store/zen';
-import { sampleCanvasBackground } from '$lib/canvas/bgSample';
+import { commandPalette } from '$lib/command/store';
+import {
+  currentPage,
+  currentPageCount,
+  insertBlankAfterCurrent,
+  toggleFullscreen,
+} from './actions';
 
 export type ShortcutId =
   | 'tool.pen'
@@ -30,6 +35,7 @@ export type ShortcutId =
   | 'view.togglePresenter'
   | 'view.toggleZen'
   | 'sidebar.togglePin'
+  | 'commandPalette.open'
   | 'edit.undo'
   | 'edit.redo'
   | 'preset.1'
@@ -59,15 +65,6 @@ export interface ShortcutCommand {
   preventDefault?: boolean;
 }
 
-function currentPage(): number {
-  return viewport.snapshot().currentPageIndex;
-}
-
-function currentPageCount(): number {
-  const doc = get(currentDocument);
-  return doc?.pages.length ?? 0;
-}
-
 function currentWidth(): number | null {
   const snap = sidebar.snapshot();
   const key = styleKeyFor(snap.activeTool);
@@ -79,34 +76,6 @@ function adjustWidth(delta: number): void {
   if (w === null) return;
   const next = Math.max(1, Math.min(40, Math.round(w + delta)));
   sidebar.setWidth(next);
-}
-
-function toggleFullscreen(): void {
-  if (typeof document === 'undefined') return;
-  if (document.fullscreenElement) {
-    void document.exitFullscreen();
-  } else {
-    void document.documentElement.requestFullscreen();
-  }
-}
-
-function sampleCurrentPageBackground(): string | undefined {
-  if (typeof document === 'undefined') return undefined;
-  const canvas = document.querySelector<HTMLCanvasElement>(
-    '.pdf-slot canvas[aria-label="Rendered PDF page"]',
-  );
-  if (!canvas) return undefined;
-  return sampleCanvasBackground(canvas) ?? undefined;
-}
-
-function insertBlankAfterCurrent(): void {
-  const doc = get(currentDocument);
-  if (!doc) return;
-  const idx = currentPage();
-  const page = doc.pages[idx];
-  if (!page) return;
-  const background = page.type === 'pdf' ? sampleCurrentPageBackground() : page.background;
-  documentStore.insertBlankPageAfter(idx, page.width, page.height, background);
 }
 
 function pickPaletteSlot(slot: number): void {
@@ -204,6 +173,13 @@ function buildCommands(): ShortcutCommand[] {
       label: 'Toggle sidebar pin',
       defaultSpec: 'Tab',
       run: () => sidebar.togglePin(),
+      preventDefault: true,
+    },
+    {
+      id: 'commandPalette.open',
+      label: 'Open command palette',
+      defaultSpec: 'Mod+K',
+      run: () => commandPalette.toggle(),
       preventDefault: true,
     },
     {

--- a/src/lib/command/CommandPalette.svelte
+++ b/src/lib/command/CommandPalette.svelte
@@ -8,14 +8,17 @@
   let selected = $state(0);
   let inputEl: HTMLInputElement | null = $state(null);
   let listEl: HTMLUListElement | null = $state(null);
+  let paletteEl: HTMLDivElement | null = $state(null);
+  let previouslyFocused: HTMLElement | null = null;
 
   let allCommands: Command[] = $state([]);
 
   const filtered = $derived.by<Array<{ cmd: Command; score: number }>>(() => {
-    if (query.trim() === '') return allCommands.map((cmd) => ({ cmd, score: 0 }));
+    const normalized = query.trim().replace(/\s+/g, ' ');
+    if (normalized === '') return allCommands.map((cmd) => ({ cmd, score: 0 }));
     const results: Array<{ cmd: Command; score: number }> = [];
     for (const cmd of allCommands) {
-      const s = score(query, cmd.title);
+      const s = score(normalized, cmd.title);
       if (s !== null) results.push({ cmd, score: s });
     }
     results.sort((a, b) => b.score - a.score);
@@ -27,7 +30,15 @@
       query = '';
       selected = 0;
       allCommands = getCommands();
+      previouslyFocused =
+        typeof document !== 'undefined' && document.activeElement instanceof HTMLElement
+          ? document.activeElement
+          : null;
       void tick().then(() => inputEl?.focus());
+    } else if (previouslyFocused) {
+      const el = previouslyFocused;
+      previouslyFocused = null;
+      void tick().then(() => el.focus());
     }
   });
 
@@ -49,7 +60,46 @@
     entry.cmd.run();
   }
 
+  function focusableElements(): HTMLElement[] {
+    if (!paletteEl) return [];
+    const selector =
+      'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+    return Array.from(paletteEl.querySelectorAll<HTMLElement>(selector)).filter(
+      (el) => !el.hasAttribute('disabled') && el.offsetParent !== null,
+    );
+  }
+
+  function trapTab(event: KeyboardEvent): void {
+    const focusables = focusableElements();
+    if (focusables.length === 0) {
+      event.preventDefault();
+      return;
+    }
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    const active = document.activeElement as HTMLElement | null;
+    if (event.shiftKey) {
+      if (active === first || !paletteEl?.contains(active)) {
+        event.preventDefault();
+        last.focus();
+      }
+    } else if (active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
   function onKey(event: KeyboardEvent) {
+    if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'k' && !event.altKey) {
+      event.preventDefault();
+      event.stopPropagation();
+      closeCommandPalette();
+      return;
+    }
+    if (event.key === 'Tab') {
+      trapTab(event);
+      return;
+    }
     if (event.key === 'Escape') {
       event.preventDefault();
       closeCommandPalette();
@@ -86,7 +136,13 @@
     role="presentation"
     tabindex="-1"
   >
-    <div class="palette" role="dialog" aria-modal="true" aria-label="Command palette">
+    <div
+      bind:this={paletteEl}
+      class="palette"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Command palette"
+    >
       <input
         bind:this={inputEl}
         bind:value={query}
@@ -110,7 +166,7 @@
               <button
                 type="button"
                 class="row"
-                onmousemove={() => (selected = i)}
+                onmouseenter={() => (selected = i)}
                 onclick={() => runAt(i)}
               >
                 <span class="title">{entry.cmd.title}</span>

--- a/src/lib/command/CommandPalette.svelte
+++ b/src/lib/command/CommandPalette.svelte
@@ -1,0 +1,202 @@
+<script lang="ts">
+  import { tick } from 'svelte';
+  import { commandPaletteStore, closeCommandPalette } from './store';
+  import { getCommands, type Command } from './commands';
+  import { score } from './fuzzy';
+
+  let query = $state('');
+  let selected = $state(0);
+  let inputEl: HTMLInputElement | null = $state(null);
+  let listEl: HTMLUListElement | null = $state(null);
+
+  let allCommands: Command[] = $state([]);
+
+  const filtered = $derived.by<Array<{ cmd: Command; score: number }>>(() => {
+    if (query.trim() === '') return allCommands.map((cmd) => ({ cmd, score: 0 }));
+    const results: Array<{ cmd: Command; score: number }> = [];
+    for (const cmd of allCommands) {
+      const s = score(query, cmd.title);
+      if (s !== null) results.push({ cmd, score: s });
+    }
+    results.sort((a, b) => b.score - a.score);
+    return results;
+  });
+
+  $effect(() => {
+    if ($commandPaletteStore.open) {
+      query = '';
+      selected = 0;
+      allCommands = getCommands();
+      void tick().then(() => inputEl?.focus());
+    }
+  });
+
+  $effect(() => {
+    void query;
+    selected = 0;
+  });
+
+  $effect(() => {
+    if (!$commandPaletteStore.open) return;
+    const item = listEl?.querySelector<HTMLElement>(`[data-index="${selected}"]`);
+    item?.scrollIntoView({ block: 'nearest' });
+  });
+
+  function runAt(index: number) {
+    const entry = filtered[index];
+    if (!entry) return;
+    closeCommandPalette();
+    entry.cmd.run();
+  }
+
+  function onKey(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      closeCommandPalette();
+      return;
+    }
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      if (filtered.length === 0) return;
+      selected = (selected + 1) % filtered.length;
+      return;
+    }
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      if (filtered.length === 0) return;
+      selected = (selected - 1 + filtered.length) % filtered.length;
+      return;
+    }
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      runAt(selected);
+    }
+  }
+
+  function onBackdropClick(event: MouseEvent) {
+    if (event.target === event.currentTarget) closeCommandPalette();
+  }
+</script>
+
+{#if $commandPaletteStore.open}
+  <div
+    class="backdrop"
+    onclick={onBackdropClick}
+    onkeydown={onKey}
+    role="presentation"
+    tabindex="-1"
+  >
+    <div class="palette" role="dialog" aria-modal="true" aria-label="Command palette">
+      <input
+        bind:this={inputEl}
+        bind:value={query}
+        type="text"
+        class="input"
+        placeholder="Type a command…"
+        spellcheck="false"
+        autocomplete="off"
+      />
+      {#if filtered.length === 0}
+        <div class="empty">No matching commands</div>
+      {:else}
+        <ul bind:this={listEl} class="list" role="listbox">
+          {#each filtered as entry, i (entry.cmd.id)}
+            <li
+              role="option"
+              aria-selected={i === selected}
+              class:selected={i === selected}
+              data-index={i}
+            >
+              <button
+                type="button"
+                class="row"
+                onmousemove={() => (selected = i)}
+                onclick={() => runAt(i)}
+              >
+                <span class="title">{entry.cmd.title}</span>
+                {#if entry.cmd.shortcut}
+                  <span class="shortcut">{entry.cmd.shortcut}</span>
+                {/if}
+              </button>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </div>
+  </div>
+{/if}
+
+<style>
+  .backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding-top: 12vh;
+    z-index: 1000;
+  }
+  .palette {
+    width: min(560px, 92vw);
+    max-height: 60vh;
+    background: #252525;
+    color: #eee;
+    border: 1px solid #3a3a3a;
+    border-radius: 8px;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+  .input {
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid #3a3a3a;
+    color: #eee;
+    font: inherit;
+    font-size: 15px;
+    padding: 12px 14px;
+    outline: none;
+  }
+  .input::placeholder {
+    color: #888;
+  }
+  .list {
+    list-style: none;
+    margin: 0;
+    padding: 4px 0;
+    overflow-y: auto;
+  }
+  .row {
+    width: 100%;
+    background: transparent;
+    border: none;
+    color: inherit;
+    font: inherit;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 14px;
+    cursor: pointer;
+    text-align: left;
+  }
+  .selected .row,
+  .row:hover {
+    background: #2f3a4a;
+  }
+  .title {
+    color: #eee;
+  }
+  .shortcut {
+    color: #9aa;
+    font-size: 12px;
+    letter-spacing: 0.02em;
+  }
+  .empty {
+    padding: 16px;
+    color: #888;
+    text-align: center;
+    font-size: 13px;
+  }
+</style>

--- a/src/lib/command/commands.ts
+++ b/src/lib/command/commands.ts
@@ -1,0 +1,106 @@
+import type { ToolKind } from '$lib/types';
+import { sidebar } from '$lib/store/sidebar';
+import { documentStore } from '$lib/store/document';
+import { viewport } from '$lib/store/viewport';
+import { presenter } from '$lib/store/presenter';
+import { zen } from '$lib/store/zen';
+import {
+  currentPage,
+  currentPageCount,
+  insertBlankAfterCurrent,
+  toggleFullscreen,
+} from '$lib/app/actions';
+
+export interface Command {
+  id: string;
+  title: string;
+  shortcut?: string;
+  run: () => void;
+}
+
+function toolCommand(id: string, title: string, tool: ToolKind, shortcut?: string): Command {
+  return { id, title, shortcut, run: () => sidebar.setTool(tool) };
+}
+
+export function getCommands(): Command[] {
+  return [
+    toolCommand('tool.pen', 'Pen', 'pen', 'P'),
+    toolCommand('tool.highlighter', 'Highlighter', 'highlighter', 'H'),
+    toolCommand('tool.eraser', 'Eraser', 'eraser', 'E'),
+    toolCommand('tool.line', 'Line', 'line', 'L'),
+    toolCommand('tool.text', 'Text', 'text', 'T'),
+    toolCommand('tool.rect', 'Rectangle', 'rect', 'R'),
+    toolCommand('tool.ellipse', 'Ellipse', 'ellipse', 'O'),
+    toolCommand('tool.numberline', 'Number line', 'numberline', 'N'),
+    toolCommand('tool.graph', 'Graph', 'graph', 'G'),
+    toolCommand('tool.protractor', 'Protractor', 'protractor', 'A'),
+    toolCommand('tool.ruler', 'Ruler', 'ruler', 'U'),
+    toolCommand('tool.laser', 'Laser pointer', 'laser', 'X'),
+    toolCommand('tool.temp-ink', 'Temporary ink', 'temp-ink', 'Y'),
+    {
+      id: 'edit.undo',
+      title: 'Undo',
+      shortcut: 'Ctrl+Z',
+      run: () => documentStore.undo(currentPage()),
+    },
+    {
+      id: 'edit.redo',
+      title: 'Redo',
+      shortcut: 'Ctrl+Shift+Z',
+      run: () => documentStore.redo(currentPage()),
+    },
+    {
+      id: 'view.toggle-pin',
+      title: 'Toggle sidebar pin',
+      shortcut: 'Tab',
+      run: () => sidebar.togglePin(),
+    },
+    {
+      id: 'view.toggle-zen',
+      title: 'Toggle zen mode',
+      shortcut: 'Shift+Z',
+      run: () => zen.toggle(),
+    },
+    {
+      id: 'view.toggle-fullscreen',
+      title: 'Toggle fullscreen',
+      shortcut: 'F',
+      run: toggleFullscreen,
+    },
+    {
+      id: 'presenter.toggle',
+      title: 'Toggle presenter view',
+      shortcut: 'F5',
+      run: () => presenter.toggle(),
+    },
+    {
+      id: 'presenter.exit',
+      title: 'Exit presenter view',
+      run: () => presenter.exit(),
+    },
+    {
+      id: 'page.next',
+      title: 'Next page',
+      shortcut: '→',
+      run: () => viewport.nextPage(currentPageCount()),
+    },
+    {
+      id: 'page.prev',
+      title: 'Previous page',
+      shortcut: '←',
+      run: () => viewport.prevPage(),
+    },
+    {
+      id: 'page.blank',
+      title: 'Insert blank page after current',
+      shortcut: 'B',
+      run: insertBlankAfterCurrent,
+    },
+    {
+      id: 'style.cycle-dash',
+      title: 'Cycle dash style',
+      shortcut: 'D',
+      run: () => sidebar.cycleDash(),
+    },
+  ];
+}

--- a/src/lib/command/fuzzy.ts
+++ b/src/lib/command/fuzzy.ts
@@ -6,7 +6,7 @@
  * - Empty query matches everything with a neutral score of 0.
  * - Earlier matches score higher (first-match position is penalized).
  * - Contiguous matches score higher (gaps between matched chars are penalized).
- * - Matches on word boundaries (start, after space/-/_) get a small bonus.
+ * - Matches on word boundaries (start, after space/-/_//) get a small bonus.
  */
 export function score(query: string, title: string): number | null {
   if (query.length === 0) return 0;

--- a/src/lib/command/fuzzy.ts
+++ b/src/lib/command/fuzzy.ts
@@ -1,0 +1,50 @@
+/**
+ * Subsequence-based fuzzy match. Returns a numeric score where higher is a
+ * better match, or `null` when `query` is not a subsequence of `title`.
+ *
+ * Ranking rules:
+ * - Empty query matches everything with a neutral score of 0.
+ * - Earlier matches score higher (first-match position is penalized).
+ * - Contiguous matches score higher (gaps between matched chars are penalized).
+ * - Matches on word boundaries (start, after space/-/_) get a small bonus.
+ */
+export function score(query: string, title: string): number | null {
+  if (query.length === 0) return 0;
+
+  const q = query.toLowerCase();
+  const t = title.toLowerCase();
+
+  const positions: number[] = [];
+  let ti = 0;
+  for (let qi = 0; qi < q.length; qi++) {
+    const ch = q[qi];
+    let found = -1;
+    while (ti < t.length) {
+      if (t[ti] === ch) {
+        found = ti;
+        ti++;
+        break;
+      }
+      ti++;
+    }
+    if (found === -1) return null;
+    positions.push(found);
+  }
+
+  let s = -positions[0];
+  for (let i = 1; i < positions.length; i++) {
+    const gap = positions[i] - positions[i - 1] - 1;
+    s -= gap;
+  }
+
+  for (const pos of positions) {
+    if (pos === 0) {
+      s += 5;
+      continue;
+    }
+    const prev = title[pos - 1];
+    if (prev === ' ' || prev === '-' || prev === '_' || prev === '/') s += 2;
+  }
+
+  return s;
+}

--- a/src/lib/command/index.ts
+++ b/src/lib/command/index.ts
@@ -1,0 +1,10 @@
+export { default as CommandPalette } from './CommandPalette.svelte';
+export {
+  commandPalette,
+  commandPaletteStore,
+  openCommandPalette,
+  closeCommandPalette,
+  type CommandPaletteState,
+} from './store';
+export { getCommands, type Command } from './commands';
+export { score } from './fuzzy';

--- a/src/lib/command/store.ts
+++ b/src/lib/command/store.ts
@@ -1,0 +1,48 @@
+import { get, writable, type Readable } from 'svelte/store';
+
+export interface CommandPaletteState {
+  open: boolean;
+}
+
+function createCommandPalette() {
+  const store = writable<CommandPaletteState>({ open: false });
+  const { subscribe, set, update } = store;
+
+  return {
+    subscribe,
+
+    isOpen(): boolean {
+      return get(store).open;
+    },
+
+    open(): void {
+      update((s) => (s.open ? s : { ...s, open: true }));
+    },
+
+    close(): void {
+      update((s) => (s.open ? { ...s, open: false } : s));
+    },
+
+    toggle(): void {
+      update((s) => ({ ...s, open: !s.open }));
+    },
+
+    reset(): void {
+      set({ open: false });
+    },
+  };
+}
+
+export const commandPalette = createCommandPalette();
+
+export const commandPaletteStore: Readable<CommandPaletteState> = {
+  subscribe: commandPalette.subscribe,
+};
+
+export function openCommandPalette(): void {
+  commandPalette.open();
+}
+
+export function closeCommandPalette(): void {
+  commandPalette.close();
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -29,6 +29,7 @@
   import { activeGraph, clearActiveGraph, setActiveGraph } from '$lib/store/activeGraph';
   import { createGraphObject } from '$lib/graph/graphObject';
   import GraphEditor from '$lib/graph/GraphEditor.svelte';
+  import { CommandPalette } from '$lib/command';
   import { log } from '$lib/log';
   import type {
     AngleMarkObject,
@@ -579,6 +580,7 @@
       >
     </div>
   {/if}
+  <CommandPalette />
 </main>
 
 <style>

--- a/tests/command-fuzzy.test.ts
+++ b/tests/command-fuzzy.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { score } from '../src/lib/command/fuzzy';
+
+describe('fuzzy score', () => {
+  it('returns 0 for empty query (match everything)', () => {
+    expect(score('', 'Pen')).toBe(0);
+    expect(score('', '')).toBe(0);
+  });
+
+  it('returns null when query chars are not a subsequence', () => {
+    expect(score('xyz', 'Pen')).toBeNull();
+    expect(score('ab', 'a')).toBeNull();
+  });
+
+  it('matches case-insensitively', () => {
+    expect(score('PEN', 'pen')).not.toBeNull();
+    expect(score('pen', 'PEN')).not.toBeNull();
+  });
+
+  it('ranks earlier matches higher than later matches', () => {
+    const early = score('r', 'Ruler')!;
+    const late = score('r', 'Eraser')!;
+    expect(early).toBeGreaterThan(late);
+  });
+
+  it('ranks contiguous matches higher than scattered matches', () => {
+    const contiguous = score('gr', 'Graph')!;
+    const scattered = score('gr', 'Gather rune')!;
+    expect(contiguous).toBeGreaterThan(scattered);
+  });
+
+  it('ranks prefix matches highest', () => {
+    const prefix = score('un', 'Undo')!;
+    const middle = score('un', 'Thunder')!;
+    expect(prefix).toBeGreaterThan(middle);
+  });
+
+  it('returns a number for any valid subsequence match', () => {
+    const s = score('tl', 'Toggle');
+    expect(typeof s).toBe('number');
+  });
+});

--- a/tests/command-store.test.ts
+++ b/tests/command-store.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+import { commandPalette, openCommandPalette, closeCommandPalette } from '../src/lib/command/store';
+
+describe('commandPalette store', () => {
+  beforeEach(() => commandPalette.reset());
+
+  it('starts closed', () => {
+    expect(get(commandPalette).open).toBe(false);
+    expect(commandPalette.isOpen()).toBe(false);
+  });
+
+  it('openCommandPalette sets open to true', () => {
+    openCommandPalette();
+    expect(commandPalette.isOpen()).toBe(true);
+  });
+
+  it('closeCommandPalette sets open to false', () => {
+    openCommandPalette();
+    closeCommandPalette();
+    expect(commandPalette.isOpen()).toBe(false);
+  });
+
+  it('toggle flips state', () => {
+    commandPalette.toggle();
+    expect(commandPalette.isOpen()).toBe(true);
+    commandPalette.toggle();
+    expect(commandPalette.isOpen()).toBe(false);
+  });
+
+  it('open is idempotent', () => {
+    openCommandPalette();
+    openCommandPalette();
+    expect(commandPalette.isOpen()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a Ctrl+K / Cmd+K command palette overlay with fuzzy search, arrow-key
navigation, and Enter to execute.

Closes #57.

## What

- `src/lib/command/fuzzy.ts` — pure `score(query, title)` subsequence matcher.
  Higher score = earlier, more contiguous, word-boundary matches. Returns
  `null` on no match, `0` for empty query.
- `src/lib/command/store.ts` — `commandPalette` store with
  `openCommandPalette()`, `closeCommandPalette()`, `toggle()`, `reset()`.
- `src/lib/command/commands.ts` — `getCommands()` rebuilds the list each call
  so it reflects live store state.
- `src/lib/command/CommandPalette.svelte` — centered dark modal, input on top,
  scrollable list, hover/keyboard highlight, Esc closes, backdrop click closes.
- `src/lib/app/shortcuts.ts` — Ctrl/Cmd+K toggles the palette (bypasses text
  inputs via the #75 helper already in place).
- Mounted in `src/routes/+page.svelte`.

## Command set

Tool switches: Pen, Highlighter, Eraser, Line, Text, Rectangle, Ellipse,
Number line, Graph, Protractor, Ruler, Laser pointer, Temporary ink.

Actions: Undo, Redo, Toggle sidebar pin, Toggle zen mode, Toggle fullscreen,
Toggle presenter view, Exit presenter view, Next page, Previous page, Insert
blank page after current, Cycle dash style.

## Tests

- `tests/command-fuzzy.test.ts` — empty query, no match, case-insensitivity,
  earlier/contiguous/prefix ranking.
- `tests/command-store.test.ts` — open/close/toggle/idempotency.

`pnpm lint && pnpm test` pass (324 tests).