### PR TITLE
feat(app): customizable keyboard shortcuts (#59)

### DIFF
--- a/src/lib/app/shortcutParser.ts
+++ b/src/lib/app/shortcutParser.ts
@@ -4,14 +4,29 @@ export interface ParsedKey {
   shift: boolean;
   alt: boolean;
   meta: boolean;
+  /** If true, either Ctrl or Meta satisfies the match (mapped from `Mod`/`CmdOrCtrl`). */
+  modOrMeta: boolean;
 }
 
-const MOD_NAMES = new Set(['ctrl', 'control', 'shift', 'alt', 'meta', 'cmd', 'command']);
+const MOD_NAMES = new Set([
+  'ctrl',
+  'control',
+  'shift',
+  'alt',
+  'meta',
+  'cmd',
+  'command',
+  'mod',
+  'cmdorctrl',
+]);
 
 /**
  * Parse a human-readable shortcut string like "Ctrl+Shift+Z" into a structured key.
  * Non-modifier segments after the last `+` are treated as the key (case-preserved for
  * named keys like ArrowLeft, lowercased for single characters).
+ *
+ * The `Mod` (alias `CmdOrCtrl`) modifier matches either Ctrl or Meta, so a single
+ * binding works on both Windows/Linux and macOS.
  */
 export function parseShortcut(spec: string): ParsedKey {
   const parts = spec
@@ -26,6 +41,7 @@ export function parseShortcut(spec: string): ParsedKey {
   let shift = false;
   let alt = false;
   let meta = false;
+  let modOrMeta = false;
   let key: string | null = null;
 
   for (const part of parts) {
@@ -34,6 +50,7 @@ export function parseShortcut(spec: string): ParsedKey {
       if (lower === 'ctrl' || lower === 'control') ctrl = true;
       else if (lower === 'shift') shift = true;
       else if (lower === 'alt') alt = true;
+      else if (lower === 'mod' || lower === 'cmdorctrl') modOrMeta = true;
       else meta = true;
     } else {
       key = part.length === 1 ? part.toLowerCase() : part;
@@ -43,15 +60,19 @@ export function parseShortcut(spec: string): ParsedKey {
   if (key === null) {
     throw new Error(`shortcut "${spec}" has no non-modifier key`);
   }
-  return { key, ctrl, shift, alt, meta };
+  return { key, ctrl, shift, alt, meta, modOrMeta };
 }
 
 /** Does a DOM KeyboardEvent match the parsed shortcut? */
 export function matchesEvent(parsed: ParsedKey, event: KeyboardEvent): boolean {
-  if (parsed.ctrl !== event.ctrlKey) return false;
+  if (parsed.modOrMeta) {
+    if (!(event.ctrlKey || event.metaKey)) return false;
+  } else {
+    if (parsed.ctrl !== event.ctrlKey) return false;
+    if (parsed.meta !== event.metaKey) return false;
+  }
   if (parsed.shift !== event.shiftKey) return false;
   if (parsed.alt !== event.altKey) return false;
-  if (parsed.meta !== event.metaKey) return false;
   const eventKey = event.key.length === 1 ? event.key.toLowerCase() : event.key;
   return eventKey === parsed.key;
 }
@@ -64,4 +85,41 @@ export function isEditableTarget(target: EventTarget | null): boolean {
     if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
   }
   return t.isContentEditable === true;
+}
+
+/**
+ * Format a KeyboardEvent back into a canonical shortcut spec (e.g. "Ctrl+Shift+Z").
+ * Single-character keys are uppercased for display; named keys (ArrowLeft, F5, Tab)
+ * keep their canonical name.
+ */
+export function formatEvent(event: KeyboardEvent): string {
+  const parts: string[] = [];
+  if (event.ctrlKey) parts.push('Ctrl');
+  if (event.metaKey) parts.push('Meta');
+  if (event.altKey) parts.push('Alt');
+  if (event.shiftKey) parts.push('Shift');
+
+  let key = event.key;
+  if (key === ' ') key = 'Space';
+  if (key.length === 1) key = key.toUpperCase();
+  parts.push(key);
+  return parts.join('+');
+}
+
+/** Pretty-print a stored spec (normalizes case on modifiers). */
+export function formatSpec(spec: string): string {
+  try {
+    const parsed = parseShortcut(spec);
+    const parts: string[] = [];
+    if (parsed.modOrMeta) parts.push('Mod');
+    if (parsed.ctrl) parts.push('Ctrl');
+    if (parsed.meta) parts.push('Meta');
+    if (parsed.alt) parts.push('Alt');
+    if (parsed.shift) parts.push('Shift');
+    const key = parsed.key.length === 1 ? parsed.key.toUpperCase() : parsed.key;
+    parts.push(key);
+    return parts.join('+');
+  } catch {
+    return spec;
+  }
 }

--- a/src/lib/app/shortcutParser.ts
+++ b/src/lib/app/shortcutParser.ts
@@ -52,6 +52,8 @@ export function parseShortcut(spec: string): ParsedKey {
       else if (lower === 'alt') alt = true;
       else if (lower === 'mod' || lower === 'cmdorctrl') modOrMeta = true;
       else meta = true;
+    } else if (lower === 'space') {
+      key = ' ';
     } else {
       key = part.length === 1 ? part.toLowerCase() : part;
     }
@@ -116,7 +118,12 @@ export function formatSpec(spec: string): string {
     if (parsed.meta) parts.push('Meta');
     if (parsed.alt) parts.push('Alt');
     if (parsed.shift) parts.push('Shift');
-    const key = parsed.key.length === 1 ? parsed.key.toUpperCase() : parsed.key;
+    const key =
+      parsed.key === ' '
+        ? 'Space'
+        : parsed.key.length === 1
+          ? parsed.key.toUpperCase()
+          : parsed.key;
     parts.push(key);
     return parts.join('+');
   } catch {

--- a/src/lib/app/shortcutRegistry.ts
+++ b/src/lib/app/shortcutRegistry.ts
@@ -1,0 +1,257 @@
+import { get } from 'svelte/store';
+import { sidebar, styleKeyFor } from '$lib/store/sidebar';
+import { documentStore, currentDocument } from '$lib/store/document';
+import { viewport } from '$lib/store/viewport';
+import { presenter } from '$lib/store/presenter';
+import { zen } from '$lib/store/zen';
+import { sampleCanvasBackground } from '$lib/canvas/bgSample';
+
+export type ShortcutId =
+  | 'tool.pen'
+  | 'tool.highlighter'
+  | 'tool.eraser'
+  | 'tool.line'
+  | 'tool.rect'
+  | 'tool.ellipse'
+  | 'tool.numberline'
+  | 'tool.graph'
+  | 'tool.text'
+  | 'tool.laser'
+  | 'tool.tempInk'
+  | 'tool.protractor'
+  | 'tool.ruler'
+  | 'style.cycleDash'
+  | 'style.widthDecrease'
+  | 'style.widthIncrease'
+  | 'page.insertBlank'
+  | 'page.prev'
+  | 'page.next'
+  | 'view.toggleFullscreen'
+  | 'view.togglePresenter'
+  | 'view.toggleZen'
+  | 'sidebar.togglePin'
+  | 'edit.undo'
+  | 'edit.redo'
+  | 'preset.1'
+  | 'preset.2'
+  | 'preset.3'
+  | 'preset.4'
+  | 'preset.5'
+  | 'preset.6'
+  | 'preset.7'
+  | 'preset.8'
+  | 'preset.9'
+  | 'palette.1'
+  | 'palette.2'
+  | 'palette.3'
+  | 'palette.4'
+  | 'palette.5'
+  | 'palette.6'
+  | 'palette.7'
+  | 'palette.8'
+  | 'palette.9';
+
+export interface ShortcutCommand {
+  id: ShortcutId;
+  label: string;
+  defaultSpec: string;
+  run: () => void;
+  preventDefault?: boolean;
+}
+
+function currentPage(): number {
+  return viewport.snapshot().currentPageIndex;
+}
+
+function currentPageCount(): number {
+  const doc = get(currentDocument);
+  return doc?.pages.length ?? 0;
+}
+
+function currentWidth(): number | null {
+  const snap = sidebar.snapshot();
+  const key = styleKeyFor(snap.activeTool);
+  return key ? snap.toolStyles[key].width : null;
+}
+
+function adjustWidth(delta: number): void {
+  const w = currentWidth();
+  if (w === null) return;
+  const next = Math.max(1, Math.min(40, Math.round(w + delta)));
+  sidebar.setWidth(next);
+}
+
+function toggleFullscreen(): void {
+  if (typeof document === 'undefined') return;
+  if (document.fullscreenElement) {
+    void document.exitFullscreen();
+  } else {
+    void document.documentElement.requestFullscreen();
+  }
+}
+
+function sampleCurrentPageBackground(): string | undefined {
+  if (typeof document === 'undefined') return undefined;
+  const canvas = document.querySelector<HTMLCanvasElement>(
+    '.pdf-slot canvas[aria-label="Rendered PDF page"]',
+  );
+  if (!canvas) return undefined;
+  return sampleCanvasBackground(canvas) ?? undefined;
+}
+
+function insertBlankAfterCurrent(): void {
+  const doc = get(currentDocument);
+  if (!doc) return;
+  const idx = currentPage();
+  const page = doc.pages[idx];
+  if (!page) return;
+  const background = page.type === 'pdf' ? sampleCurrentPageBackground() : page.background;
+  documentStore.insertBlankPageAfter(idx, page.width, page.height, background);
+}
+
+function pickPaletteSlot(slot: number): void {
+  const snap = sidebar.snapshot();
+  const presets = snap.palettes.find((p) => p.id === 'presets');
+  const color = presets?.colors[slot - 1];
+  if (color) sidebar.setActiveColor(color);
+}
+
+const TOOL_COMMANDS: Array<{ id: ShortcutId; label: string; spec: string; tool: string }> = [
+  { id: 'tool.pen', label: 'Tool: Pen', spec: 'p', tool: 'pen' },
+  { id: 'tool.highlighter', label: 'Tool: Highlighter', spec: 'h', tool: 'highlighter' },
+  { id: 'tool.eraser', label: 'Tool: Eraser', spec: 'e', tool: 'eraser' },
+  { id: 'tool.line', label: 'Tool: Line', spec: 'l', tool: 'line' },
+  { id: 'tool.rect', label: 'Tool: Rectangle', spec: 'r', tool: 'rect' },
+  { id: 'tool.ellipse', label: 'Tool: Ellipse', spec: 'o', tool: 'ellipse' },
+  { id: 'tool.numberline', label: 'Tool: Number line', spec: 'n', tool: 'numberline' },
+  { id: 'tool.graph', label: 'Tool: Graph', spec: 'g', tool: 'graph' },
+  { id: 'tool.text', label: 'Tool: Text', spec: 't', tool: 'text' },
+  { id: 'tool.laser', label: 'Tool: Laser', spec: 'x', tool: 'laser' },
+  { id: 'tool.tempInk', label: 'Tool: Temp Ink', spec: 'y', tool: 'temp-ink' },
+  { id: 'tool.protractor', label: 'Tool: Protractor', spec: 'a', tool: 'protractor' },
+  { id: 'tool.ruler', label: 'Tool: Ruler', spec: 'u', tool: 'ruler' },
+];
+
+function buildCommands(): ShortcutCommand[] {
+  const list: ShortcutCommand[] = TOOL_COMMANDS.map(({ id, label, spec, tool }) => ({
+    id,
+    label,
+    defaultSpec: spec,
+    run: () => sidebar.setTool(tool as Parameters<typeof sidebar.setTool>[0]),
+  }));
+
+  list.push(
+    {
+      id: 'style.cycleDash',
+      label: 'Cycle dash style',
+      defaultSpec: 'd',
+      run: () => sidebar.cycleDash(),
+    },
+    {
+      id: 'style.widthDecrease',
+      label: 'Decrease stroke width',
+      defaultSpec: '[',
+      run: () => adjustWidth(-1),
+    },
+    {
+      id: 'style.widthIncrease',
+      label: 'Increase stroke width',
+      defaultSpec: ']',
+      run: () => adjustWidth(1),
+    },
+    {
+      id: 'page.insertBlank',
+      label: 'Insert blank page after current',
+      defaultSpec: 'b',
+      run: () => insertBlankAfterCurrent(),
+    },
+    {
+      id: 'page.prev',
+      label: 'Previous page',
+      defaultSpec: 'ArrowLeft',
+      run: () => viewport.prevPage(),
+      preventDefault: true,
+    },
+    {
+      id: 'page.next',
+      label: 'Next page',
+      defaultSpec: 'ArrowRight',
+      run: () => viewport.nextPage(currentPageCount()),
+      preventDefault: true,
+    },
+    {
+      id: 'view.toggleFullscreen',
+      label: 'Toggle fullscreen',
+      defaultSpec: 'f',
+      run: () => toggleFullscreen(),
+    },
+    {
+      id: 'view.togglePresenter',
+      label: 'Toggle presenter mode',
+      defaultSpec: 'F5',
+      run: () => presenter.toggle(),
+      preventDefault: true,
+    },
+    {
+      id: 'view.toggleZen',
+      label: 'Toggle zen mode',
+      defaultSpec: 'Shift+Z',
+      run: () => zen.toggle(),
+      preventDefault: true,
+    },
+    {
+      id: 'sidebar.togglePin',
+      label: 'Toggle sidebar pin',
+      defaultSpec: 'Tab',
+      run: () => sidebar.togglePin(),
+      preventDefault: true,
+    },
+    {
+      id: 'edit.undo',
+      label: 'Undo',
+      defaultSpec: 'Mod+Z',
+      run: () => documentStore.undo(currentPage()),
+      preventDefault: true,
+    },
+    {
+      id: 'edit.redo',
+      label: 'Redo',
+      defaultSpec: 'Mod+Shift+Z',
+      run: () => documentStore.redo(currentPage()),
+      preventDefault: true,
+    },
+  );
+
+  for (let n = 1; n <= 9; n++) {
+    list.push({
+      id: `preset.${n}` as ShortcutId,
+      label: `Apply preset ${n}`,
+      defaultSpec: `Mod+${n}`,
+      run: () => sidebar.applyPresetSlot(n),
+      preventDefault: true,
+    });
+  }
+
+  for (let n = 1; n <= 9; n++) {
+    list.push({
+      id: `palette.${n}` as ShortcutId,
+      label: `Pick palette color ${n}`,
+      defaultSpec: `${n}`,
+      run: () => pickPaletteSlot(n),
+    });
+  }
+
+  return list;
+}
+
+export const SHORTCUT_COMMANDS: ShortcutCommand[] = buildCommands();
+
+export const DEFAULT_BINDINGS: Record<ShortcutId, string> = Object.fromEntries(
+  SHORTCUT_COMMANDS.map((c) => [c.id, c.defaultSpec]),
+) as Record<ShortcutId, string>;
+
+export const SHORTCUT_IDS: ShortcutId[] = SHORTCUT_COMMANDS.map((c) => c.id);
+
+export function commandFor(id: ShortcutId): ShortcutCommand | undefined {
+  return SHORTCUT_COMMANDS.find((c) => c.id === id);
+}

--- a/src/lib/app/shortcuts.ts
+++ b/src/lib/app/shortcuts.ts
@@ -1,246 +1,84 @@
 import type { Action } from 'svelte/action';
-import { get } from 'svelte/store';
-import { sidebar, styleKeyFor } from '$lib/store/sidebar';
-import { documentStore, currentDocument } from '$lib/store/document';
 import { viewport } from '$lib/store/viewport';
 import { presenter } from '$lib/store/presenter';
 import { zen } from '$lib/store/zen';
-import { sampleCanvasBackground } from '$lib/canvas/bgSample';
-import { isEditableTarget } from './shortcutParser';
+import { isEditableTarget, matchesEvent, parseShortcut } from './shortcutParser';
+import type { ParsedKey } from './shortcutParser';
 import { isTextInput } from './focus';
+import { SHORTCUT_COMMANDS, type ShortcutCommand } from './shortcutRegistry';
+import { shortcutsStore } from '$lib/store/shortcuts';
 
 /**
- * Global keyboard shortcuts for the app shell. Listeners are attached to
- * `window` so events fire regardless of focus, unless the target is a text
- * input. The action's host element is only used as the action's lifecycle
- * anchor.
- *
- * Space is tracked separately from the keydown routing to distinguish
- * hold-vs-tap for pan mode.
+ * Global keyboard shortcuts for the app shell. Bindings come from the
+ * customizable shortcuts store; a few stateful keys (Space hold for pan,
+ * Escape exits) stay hard-coded because they do not map cleanly to a single
+ * keydown action.
  */
 export const shortcuts: Action<HTMLElement> = () => {
   let spaceHeld = false;
 
-  function pickPaletteSlot(slot: number): void {
-    const snap = sidebar.snapshot();
-    const presets = snap.palettes.find((p) => p.id === 'presets');
-    const color = presets?.colors[slot - 1];
-    if (color) sidebar.setActiveColor(color);
+  interface Resolved {
+    parsed: ParsedKey;
+    command: ShortcutCommand;
   }
 
-  function currentWidth(): number | null {
-    const snap = sidebar.snapshot();
-    const key = styleKeyFor(snap.activeTool);
-    return key ? snap.toolStyles[key].width : null;
-  }
+  let resolved: Resolved[] = [];
 
-  function adjustWidth(delta: number): void {
-    const w = currentWidth();
-    if (w === null) return;
-    const next = Math.max(1, Math.min(40, Math.round(w + delta)));
-    sidebar.setWidth(next);
-  }
-
-  function currentPageCount(): number {
-    const doc = get(currentDocument);
-    return doc?.pages.length ?? 0;
-  }
-
-  function currentPage(): number {
-    return viewport.snapshot().currentPageIndex;
-  }
-
-  function toggleFullscreen(): void {
-    if (typeof document === 'undefined') return;
-    if (document.fullscreenElement) {
-      void document.exitFullscreen();
-    } else {
-      void document.documentElement.requestFullscreen();
+  function rebuild(): void {
+    const bindings = shortcutsStore.snapshot();
+    const next: Resolved[] = [];
+    for (const command of SHORTCUT_COMMANDS) {
+      const spec = bindings[command.id];
+      if (!spec) continue;
+      try {
+        next.push({ parsed: parseShortcut(spec), command });
+      } catch {
+        // Ignore malformed bindings; the user can re-record them.
+      }
     }
+    resolved = next;
   }
 
-  function sampleCurrentPageBackground(): string | undefined {
-    if (typeof document === 'undefined') return undefined;
-    const canvas = document.querySelector<HTMLCanvasElement>(
-      '.pdf-slot canvas[aria-label="Rendered PDF page"]',
-    );
-    if (!canvas) return undefined;
-    return sampleCanvasBackground(canvas) ?? undefined;
-  }
-
-  function insertBlankAfterCurrent(): void {
-    const doc = get(currentDocument);
-    if (!doc) return;
-    const idx = currentPage();
-    const page = doc.pages[idx];
-    if (!page) return;
-    const background = page.type === 'pdf' ? sampleCurrentPageBackground() : page.background;
-    documentStore.insertBlankPageAfter(idx, page.width, page.height, background);
-  }
+  rebuild();
+  const unsubscribe = shortcutsStore.subscribe(() => rebuild());
 
   function handleKeyDown(event: KeyboardEvent): void {
-    const ctrlOrMeta = event.ctrlKey || event.metaKey;
-    const lower = event.key.toLowerCase();
-
     if (isTextInput(event.target)) {
       // Native text-editing shortcuts (including Ctrl/Cmd+Z/Y) must reach the
-      // input. Document-level undo/redo is intentionally off while a real
-      // text field is focused; the user can blur it and press Ctrl+Z again.
+      // input. Document-level actions are intentionally off while a real
+      // text field is focused; the user can blur it and press again.
       return;
     }
     if (isEditableTarget(event.target)) return;
 
-    const key = event.key;
-
-    if (key === 'F5') {
-      event.preventDefault();
-      presenter.toggle();
-      return;
-    }
-
-    if (key === 'Escape' && presenter.isActive()) {
-      event.preventDefault();
-      presenter.exit();
-      return;
-    }
-
-    if (key === 'Escape' && zen.isActive()) {
-      event.preventDefault();
-      zen.exit();
-      return;
-    }
-
-    if (
-      event.shiftKey &&
-      !event.ctrlKey &&
-      !event.metaKey &&
-      !event.altKey &&
-      (key === 'Z' || key === 'z')
-    ) {
-      event.preventDefault();
-      zen.toggle();
-      return;
-    }
-
-    if (ctrlOrMeta) {
-      if (lower === 'z' && event.shiftKey) {
+    if (event.key === 'Escape') {
+      if (presenter.isActive()) {
         event.preventDefault();
-        documentStore.redo(currentPage());
+        presenter.exit();
         return;
       }
-      if (lower === 'z') {
+      if (zen.isActive()) {
         event.preventDefault();
-        documentStore.undo(currentPage());
+        zen.exit();
         return;
       }
-      if (!event.shiftKey && !event.altKey && key >= '1' && key <= '9') {
-        event.preventDefault();
-        sidebar.applyPresetSlot(Number(key));
-        return;
+    }
+
+    if (event.key === ' ' && !event.ctrlKey && !event.metaKey && !event.altKey) {
+      if (!spaceHeld) {
+        spaceHeld = true;
+        viewport.setPanMode(true);
       }
+      event.preventDefault();
       return;
     }
 
-    if (event.shiftKey || event.altKey) return;
-
-    switch (key) {
-      case 'p':
-      case 'P':
-        sidebar.setTool('pen');
+    for (const { parsed, command } of resolved) {
+      if (matchesEvent(parsed, event)) {
+        if (command.preventDefault) event.preventDefault();
+        command.run();
         return;
-      case 'h':
-      case 'H':
-        sidebar.setTool('highlighter');
-        return;
-      case 'e':
-      case 'E':
-        sidebar.setTool('eraser');
-        return;
-      case 'l':
-      case 'L':
-        sidebar.setTool('line');
-        return;
-      case 'r':
-      case 'R':
-        sidebar.setTool('rect');
-        return;
-      case 'o':
-      case 'O':
-        sidebar.setTool('ellipse');
-        return;
-      case 'n':
-      case 'N':
-        sidebar.setTool('numberline');
-        return;
-      case 'g':
-      case 'G':
-        sidebar.setTool('graph');
-        return;
-      case 't':
-      case 'T':
-        sidebar.setTool('text');
-        return;
-      case 'x':
-      case 'X':
-        sidebar.setTool('laser');
-        return;
-      case 'y':
-      case 'Y':
-        sidebar.setTool('temp-ink');
-        return;
-      case 'a':
-      case 'A':
-        sidebar.setTool('protractor');
-        return;
-      case 'u':
-      case 'U':
-        sidebar.setTool('ruler');
-        return;
-      case 'd':
-      case 'D':
-        sidebar.cycleDash();
-        return;
-      case 'b':
-      case 'B':
-        insertBlankAfterCurrent();
-        return;
-      case 'f':
-      case 'F':
-        toggleFullscreen();
-        return;
-      case 'Tab':
-        event.preventDefault();
-        sidebar.togglePin();
-        return;
-      case '[':
-        adjustWidth(-1);
-        return;
-      case ']':
-        adjustWidth(1);
-        return;
-      case 'ArrowLeft':
-      case 'PageUp':
-        event.preventDefault();
-        viewport.prevPage();
-        return;
-      case 'ArrowRight':
-      case 'PageDown':
-        event.preventDefault();
-        viewport.nextPage(currentPageCount());
-        return;
-      case ' ':
-        if (!spaceHeld) {
-          spaceHeld = true;
-          viewport.setPanMode(true);
-        }
-        event.preventDefault();
-        return;
-      default:
-        break;
-    }
-
-    if (key.length === 1 && key >= '1' && key <= '9') {
-      pickPaletteSlot(Number(key));
+      }
     }
   }
 
@@ -258,6 +96,7 @@ export const shortcuts: Action<HTMLElement> = () => {
 
   return {
     destroy(): void {
+      unsubscribe();
       if (typeof window !== 'undefined') {
         window.removeEventListener('keydown', handleKeyDown);
         window.removeEventListener('keyup', handleKeyUp);

--- a/src/lib/settings/ShortcutsEditor.svelte
+++ b/src/lib/settings/ShortcutsEditor.svelte
@@ -1,0 +1,229 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { shortcutsStore, shortcutBindings } from '$lib/store/shortcuts';
+  import { SHORTCUT_COMMANDS, type ShortcutId } from '$lib/app/shortcutRegistry';
+  import { formatEvent, formatSpec } from '$lib/app/shortcutParser';
+
+  interface Props {
+    onClose?: () => void;
+  }
+
+  let { onClose }: Props = $props();
+
+  const bindings = $derived($shortcutBindings);
+  let recordingId: ShortcutId | null = $state(null);
+  let dialog: HTMLDivElement | null = $state(null);
+
+  function startRecording(id: ShortcutId): void {
+    recordingId = id;
+  }
+
+  function cancelRecording(): void {
+    recordingId = null;
+  }
+
+  function onRecordingKeyDown(event: KeyboardEvent): void {
+    if (!recordingId) return;
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (event.key === 'Escape') {
+      recordingId = null;
+      return;
+    }
+
+    // Wait for a non-modifier-only press.
+    if (['Control', 'Shift', 'Alt', 'Meta'].includes(event.key)) return;
+
+    const spec = formatEvent(event);
+    shortcutsStore.setBinding(recordingId, spec);
+    recordingId = null;
+  }
+
+  function reset(id: ShortcutId): void {
+    shortcutsStore.resetBinding(id);
+  }
+
+  function resetAll(): void {
+    shortcutsStore.resetAll();
+  }
+
+  onMount(() => {
+    dialog?.focus();
+  });
+
+  function onBackdropKey(event: KeyboardEvent): void {
+    if (event.key === 'Escape' && !recordingId) {
+      onClose?.();
+    }
+  }
+</script>
+
+<div
+  class="backdrop"
+  role="button"
+  tabindex="-1"
+  aria-label="Close shortcuts settings"
+  onclick={() => onClose?.()}
+  onkeydown={onBackdropKey}
+></div>
+
+<div
+  class="dialog"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="shortcuts-title"
+  bind:this={dialog}
+  tabindex="-1"
+  onkeydown={onRecordingKeyDown}
+>
+  <header class="dialog-header">
+    <h2 id="shortcuts-title">Keyboard shortcuts</h2>
+    <div class="header-actions">
+      <button type="button" class="secondary" onclick={resetAll}>Reset all</button>
+      <button type="button" class="secondary" onclick={() => onClose?.()} aria-label="Close">
+        ✕
+      </button>
+    </div>
+  </header>
+
+  <ul class="list">
+    {#each SHORTCUT_COMMANDS as cmd (cmd.id)}
+      {@const current = bindings[cmd.id]}
+      {@const isRecording = recordingId === cmd.id}
+      {@const isDefault = current === cmd.defaultSpec}
+      <li class="row">
+        <span class="label">{cmd.label}</span>
+        <div class="controls">
+          <button
+            type="button"
+            class="binding"
+            class:recording={isRecording}
+            aria-pressed={isRecording}
+            onclick={() => (isRecording ? cancelRecording() : startRecording(cmd.id))}
+          >
+            {#if isRecording}
+              Press a key…
+            {:else}
+              {formatSpec(current)}
+            {/if}
+          </button>
+          <button
+            type="button"
+            class="reset"
+            disabled={isDefault}
+            title={isDefault ? 'Already default' : `Reset to ${formatSpec(cmd.defaultSpec)}`}
+            onclick={() => reset(cmd.id)}
+          >
+            Reset
+          </button>
+        </div>
+      </li>
+    {/each}
+  </ul>
+</div>
+
+<style>
+  .backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    z-index: 1000;
+    border: 0;
+    padding: 0;
+  }
+  .dialog {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: min(620px, 90vw);
+    max-height: 80vh;
+    display: flex;
+    flex-direction: column;
+    background: #1b1b1b;
+    color: #ddd;
+    border: 1px solid #333;
+    border-radius: 8px;
+    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.6);
+    z-index: 1001;
+  }
+  .dialog:focus {
+    outline: none;
+  }
+  .dialog-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 16px;
+    border-bottom: 1px solid #333;
+  }
+  .dialog-header h2 {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+  }
+  .header-actions {
+    display: flex;
+    gap: 8px;
+  }
+  .list {
+    list-style: none;
+    margin: 0;
+    padding: 8px 0;
+    overflow-y: auto;
+    flex: 1;
+  }
+  .row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 6px 16px;
+  }
+  .row:hover {
+    background: #222;
+  }
+  .label {
+    font-size: 13px;
+  }
+  .controls {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  button {
+    font: inherit;
+    background: #2a2a2a;
+    color: #ddd;
+    border: 1px solid #444;
+    border-radius: 4px;
+    padding: 4px 10px;
+    cursor: pointer;
+  }
+  button:hover:not(:disabled) {
+    border-color: #666;
+  }
+  button:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+  .binding {
+    min-width: 140px;
+    text-align: center;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+  }
+  .binding.recording {
+    border-color: #7ab7ff;
+    background: #2a3847;
+    color: #fff;
+  }
+  .secondary {
+    background: transparent;
+  }
+  .reset {
+    font-size: 12px;
+  }
+</style>

--- a/src/lib/settings/ShortcutsEditor.svelte
+++ b/src/lib/settings/ShortcutsEditor.svelte
@@ -22,17 +22,22 @@
     recordingId = null;
   }
 
-  function onRecordingKeyDown(event: KeyboardEvent): void {
-    if (!recordingId) return;
-    event.preventDefault();
+  function onDialogKeyDown(event: KeyboardEvent): void {
     event.stopPropagation();
 
     if (event.key === 'Escape') {
-      recordingId = null;
+      event.preventDefault();
+      if (recordingId) {
+        recordingId = null;
+      } else {
+        onClose?.();
+      }
       return;
     }
 
-    // Wait for a non-modifier-only press.
+    if (!recordingId) return;
+    event.preventDefault();
+
     if (['Control', 'Shift', 'Alt', 'Meta'].includes(event.key)) return;
 
     const spec = formatEvent(event);
@@ -51,22 +56,14 @@
   onMount(() => {
     dialog?.focus();
   });
-
-  function onBackdropKey(event: KeyboardEvent): void {
-    if (event.key === 'Escape' && !recordingId) {
-      onClose?.();
-    }
-  }
 </script>
 
-<div
+<button
+  type="button"
   class="backdrop"
-  role="button"
-  tabindex="-1"
   aria-label="Close shortcuts settings"
   onclick={() => onClose?.()}
-  onkeydown={onBackdropKey}
-></div>
+></button>
 
 <div
   class="dialog"
@@ -75,7 +72,7 @@
   aria-labelledby="shortcuts-title"
   bind:this={dialog}
   tabindex="-1"
-  onkeydown={onRecordingKeyDown}
+  onkeydown={onDialogKeyDown}
 >
   <header class="dialog-header">
     <h2 id="shortcuts-title">Keyboard shortcuts</h2>

--- a/src/lib/sidebar/Sidebar.svelte
+++ b/src/lib/sidebar/Sidebar.svelte
@@ -5,6 +5,7 @@
   import WidthPicker from './WidthPicker.svelte';
   import DashStyleToggle from './DashStyleToggle.svelte';
   import ToolPresets from './ToolPresets.svelte';
+  import ShortcutsEditor from '$lib/settings/ShortcutsEditor.svelte';
   import { applySnap, clampToViewport } from './snap';
 
   interface Props {
@@ -78,6 +79,8 @@
     sidebar.togglePin();
     onPinChange?.(sidebar.snapshot().pinned);
   }
+
+  let shortcutsOpen = $state(false);
 
   function onCapturePreset() {
     sidebar.capturePreset();
@@ -215,6 +218,15 @@
     <button
       type="button"
       class="pin"
+      aria-label="Shortcuts settings"
+      title="Customize keyboard shortcuts"
+      onclick={() => (shortcutsOpen = true)}
+    >
+      <span aria-hidden="true">⚙</span>
+    </button>
+    <button
+      type="button"
+      class="pin"
       aria-pressed={sidebarState.pinned}
       aria-label={sidebarState.pinned ? 'Unpin sidebar' : 'Pin sidebar'}
       title={sidebarState.pinned ? 'Unpin sidebar' : 'Pin sidebar'}
@@ -300,6 +312,10 @@
     </section>
   {/if}
 </aside>
+
+{#if shortcutsOpen}
+  <ShortcutsEditor onClose={() => (shortcutsOpen = false)} />
+{/if}
 
 <style>
   .sidebar {

--- a/src/lib/store/shortcuts.ts
+++ b/src/lib/store/shortcuts.ts
@@ -1,0 +1,108 @@
+import { writable, type Readable } from 'svelte/store';
+import { DEFAULT_BINDINGS, SHORTCUT_IDS, type ShortcutId } from '$lib/app/shortcutRegistry';
+
+const STORAGE_KEY = 'eldraw.shortcuts.v1';
+
+export type ShortcutBindings = Record<ShortcutId, string>;
+
+function cloneDefaults(): ShortcutBindings {
+  return { ...DEFAULT_BINDINGS };
+}
+
+function sanitize(raw: unknown): ShortcutBindings {
+  const result = cloneDefaults();
+  if (!raw || typeof raw !== 'object') return result;
+  const record = raw as Record<string, unknown>;
+  for (const id of SHORTCUT_IDS) {
+    const v = record[id];
+    if (typeof v === 'string' && v.length > 0) {
+      result[id] = v;
+    }
+  }
+  return result;
+}
+
+function readStorage(): ShortcutBindings {
+  if (typeof localStorage === 'undefined') return cloneDefaults();
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return cloneDefaults();
+    return sanitize(JSON.parse(raw));
+  } catch {
+    return cloneDefaults();
+  }
+}
+
+function writeStorage(bindings: ShortcutBindings): void {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(bindings));
+  } catch {
+    // Storage may be unavailable (private mode, quota). Non-fatal.
+  }
+}
+
+function createShortcutsStore() {
+  const store = writable<ShortcutBindings>(readStorage());
+  const { subscribe, update, set } = store;
+
+  function persist(next: ShortcutBindings): void {
+    writeStorage(next);
+  }
+
+  return {
+    subscribe,
+
+    snapshot(): ShortcutBindings {
+      let current: ShortcutBindings = cloneDefaults();
+      subscribe((v) => (current = v))();
+      return current;
+    },
+
+    setBinding(id: ShortcutId, spec: string): void {
+      update((s) => {
+        const next = { ...s, [id]: spec };
+        persist(next);
+        return next;
+      });
+    },
+
+    resetBinding(id: ShortcutId): void {
+      update((s) => {
+        const next = { ...s, [id]: DEFAULT_BINDINGS[id] };
+        persist(next);
+        return next;
+      });
+    },
+
+    resetAll(): void {
+      const next = cloneDefaults();
+      persist(next);
+      set(next);
+    },
+
+    hydrate(): void {
+      set(readStorage());
+    },
+
+    /** Test-only: drop persisted state and restore defaults in memory. */
+    _reset(): void {
+      if (typeof localStorage !== 'undefined') {
+        try {
+          localStorage.removeItem(STORAGE_KEY);
+        } catch {
+          // ignore
+        }
+      }
+      set(cloneDefaults());
+    },
+  };
+}
+
+export const shortcutsStore = createShortcutsStore();
+
+export const shortcutBindings: Readable<ShortcutBindings> = {
+  subscribe: shortcutsStore.subscribe,
+};
+
+export const SHORTCUTS_STORAGE_KEY = STORAGE_KEY;

--- a/tests/shortcut-parser.test.ts
+++ b/tests/shortcut-parser.test.ts
@@ -17,7 +17,14 @@ function kb(
 describe('parseShortcut', () => {
   it('parses a single character as lowercase key', () => {
     const p = parseShortcut('P');
-    expect(p).toEqual({ key: 'p', ctrl: false, shift: false, alt: false, meta: false });
+    expect(p).toEqual({
+      key: 'p',
+      ctrl: false,
+      shift: false,
+      alt: false,
+      meta: false,
+      modOrMeta: false,
+    });
   });
 
   it('parses Ctrl+Z', () => {
@@ -27,6 +34,7 @@ describe('parseShortcut', () => {
       shift: false,
       alt: false,
       meta: false,
+      modOrMeta: false,
     });
   });
 
@@ -37,6 +45,7 @@ describe('parseShortcut', () => {
       shift: true,
       alt: false,
       meta: false,
+      modOrMeta: false,
     });
   });
 
@@ -63,6 +72,13 @@ describe('parseShortcut', () => {
   it('throws when only modifiers given', () => {
     expect(() => parseShortcut('Ctrl+Shift')).toThrow();
   });
+
+  it('parses Mod as modOrMeta', () => {
+    const p = parseShortcut('Mod+Z');
+    expect(p.modOrMeta).toBe(true);
+    expect(p.ctrl).toBe(false);
+    expect(p.meta).toBe(false);
+  });
 });
 
 describe('matchesEvent', () => {
@@ -80,6 +96,13 @@ describe('matchesEvent', () => {
   it('matches named keys', () => {
     expect(matchesEvent(parseShortcut('ArrowLeft'), kb('ArrowLeft'))).toBe(true);
     expect(matchesEvent(parseShortcut('ArrowLeft'), kb('ArrowRight'))).toBe(false);
+  });
+
+  it('Mod matches either Ctrl or Meta', () => {
+    const p = parseShortcut('Mod+Z');
+    expect(matchesEvent(p, kb('z', { ctrl: true }))).toBe(true);
+    expect(matchesEvent(p, kb('z', { meta: true }))).toBe(true);
+    expect(matchesEvent(p, kb('z'))).toBe(false);
   });
 });
 

--- a/tests/shortcut-parser.test.ts
+++ b/tests/shortcut-parser.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { isEditableTarget, matchesEvent, parseShortcut } from '../src/lib/app/shortcutParser';
+import {
+  formatSpec,
+  isEditableTarget,
+  matchesEvent,
+  parseShortcut,
+} from '../src/lib/app/shortcutParser';
 
 function kb(
   key: string,
@@ -103,6 +108,14 @@ describe('matchesEvent', () => {
     expect(matchesEvent(p, kb('z', { ctrl: true }))).toBe(true);
     expect(matchesEvent(p, kb('z', { meta: true }))).toBe(true);
     expect(matchesEvent(p, kb('z'))).toBe(false);
+  });
+
+  it('Space spec matches a Space keydown and round-trips through formatSpec', () => {
+    const p = parseShortcut('Space');
+    expect(p.key).toBe(' ');
+    expect(matchesEvent(p, kb(' '))).toBe(true);
+    expect(formatSpec('Space')).toBe('Space');
+    expect(matchesEvent(parseShortcut('Shift+Space'), kb(' ', { shift: true }))).toBe(true);
   });
 });
 

--- a/tests/shortcut-store.test.ts
+++ b/tests/shortcut-store.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+import {
+  shortcutsStore,
+  shortcutBindings,
+  SHORTCUTS_STORAGE_KEY,
+} from '../src/lib/store/shortcuts';
+import { DEFAULT_BINDINGS } from '../src/lib/app/shortcutRegistry';
+
+class MemoryStorage {
+  private map = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.map.has(key) ? (this.map.get(key) as string) : null;
+  }
+  setItem(key: string, value: string): void {
+    this.map.set(key, String(value));
+  }
+  removeItem(key: string): void {
+    this.map.delete(key);
+  }
+  clear(): void {
+    this.map.clear();
+  }
+  key(i: number): string | null {
+    return Array.from(this.map.keys())[i] ?? null;
+  }
+  get length(): number {
+    return this.map.size;
+  }
+}
+
+const memory = new MemoryStorage();
+Object.defineProperty(globalThis, 'localStorage', {
+  value: memory,
+  writable: true,
+  configurable: true,
+});
+
+describe('shortcuts store', () => {
+  beforeEach(() => {
+    memory.clear();
+    shortcutsStore._reset();
+  });
+
+  it('hydrates with default bindings when storage is empty', () => {
+    shortcutsStore.hydrate();
+    const snap = shortcutsStore.snapshot();
+    expect(snap).toEqual(DEFAULT_BINDINGS);
+    expect(get(shortcutBindings)).toEqual(DEFAULT_BINDINGS);
+  });
+
+  it('setBinding updates the store and persists to localStorage', () => {
+    shortcutsStore.setBinding('tool.pen', 'Shift+P');
+    expect(shortcutsStore.snapshot()['tool.pen']).toBe('Shift+P');
+
+    const raw = memory.getItem(SHORTCUTS_STORAGE_KEY);
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw as string);
+    expect(parsed['tool.pen']).toBe('Shift+P');
+  });
+
+  it('resetBinding restores only that command to default', () => {
+    shortcutsStore.setBinding('tool.pen', 'Shift+P');
+    shortcutsStore.setBinding('tool.highlighter', 'Shift+H');
+    shortcutsStore.resetBinding('tool.pen');
+
+    const snap = shortcutsStore.snapshot();
+    expect(snap['tool.pen']).toBe(DEFAULT_BINDINGS['tool.pen']);
+    expect(snap['tool.highlighter']).toBe('Shift+H');
+  });
+
+  it('resetAll clears all custom bindings', () => {
+    shortcutsStore.setBinding('tool.pen', 'Shift+P');
+    shortcutsStore.setBinding('edit.undo', 'Ctrl+Y');
+    shortcutsStore.resetAll();
+    expect(shortcutsStore.snapshot()).toEqual(DEFAULT_BINDINGS);
+  });
+
+  it('persistence round-trip: hydrate picks up previously stored bindings', () => {
+    shortcutsStore.setBinding('tool.pen', 'Shift+P');
+    shortcutsStore.setBinding('tool.eraser', 'Alt+E');
+
+    // Simulate a fresh session: keep storage, forget in-memory state.
+    shortcutsStore._reset();
+    // _reset wipes storage too, so re-seed it.
+    memory.setItem(
+      SHORTCUTS_STORAGE_KEY,
+      JSON.stringify({ 'tool.pen': 'Shift+P', 'tool.eraser': 'Alt+E' }),
+    );
+    shortcutsStore.hydrate();
+
+    const snap = shortcutsStore.snapshot();
+    expect(snap['tool.pen']).toBe('Shift+P');
+    expect(snap['tool.eraser']).toBe('Alt+E');
+    // Unspecified ids fall back to defaults.
+    expect(snap['tool.highlighter']).toBe(DEFAULT_BINDINGS['tool.highlighter']);
+  });
+
+  it('ignores malformed storage payloads', () => {
+    memory.setItem(SHORTCUTS_STORAGE_KEY, '{not json');
+    shortcutsStore.hydrate();
+    expect(shortcutsStore.snapshot()).toEqual(DEFAULT_BINDINGS);
+  });
+
+  it('ignores unknown ids and non-string values in storage', () => {
+    memory.setItem(
+      SHORTCUTS_STORAGE_KEY,
+      JSON.stringify({ 'tool.pen': 42, 'totally.unknown': 'x', 'tool.eraser': 'Alt+E' }),
+    );
+    shortcutsStore.hydrate();
+    const snap = shortcutsStore.snapshot();
+    expect(snap['tool.pen']).toBe(DEFAULT_BINDINGS['tool.pen']);
+    expect(snap['tool.eraser']).toBe('Alt+E');
+  });
+});


### PR DESCRIPTION
## Summary

Let users remap global keyboard shortcuts via a settings UI and persist the mapping in `localStorage`.

- New `src/lib/app/shortcutRegistry.ts` holds the single source of truth: a table of `ShortcutCommand`s (id, label, defaultSpec, run, preventDefault) covering tool picks, dash cycle, width +/-, undo/redo, page nav, fullscreen/presenter/zen toggles, sidebar pin, and preset/palette 1–9.
- New `src/lib/store/shortcuts.ts` Svelte store (`eldraw.shortcuts.v1`) with `setBinding`, `resetBinding`, `resetAll`, `snapshot`, `hydrate`. Sanitizes storage payloads.
- `src/lib/app/shortcuts.ts` is now table-driven — it subscribes to the bindings store, parses each spec once, and dispatches on `keydown`. Existing text-input gating is preserved. Space-hold (pan) and Escape (presenter/zen exit) stay hard-coded because they don't map to a single discrete action.
- `src/lib/app/shortcutParser.ts` gained `Mod`/`CmdOrCtrl` (matches Ctrl **or** Meta, so the default `Mod+Z` undo works on Win/Linux and macOS) plus `formatEvent`/`formatSpec` helpers for the editor UI.
- New `src/lib/settings/ShortcutsEditor.svelte` modal: scrollable list of commands, click a row to "Record" the next keydown, per-row Reset and a "Reset all" button. Escape cancels recording or closes the modal.
- `Sidebar.svelte` adds a small ⚙ button next to the pin to open the editor. Per task instructions, **no** command-palette integration (reserved for a follow-up once #57 lands).

## Testing

- `pnpm lint` — prettier + eslint + svelte-check: green
- `pnpm test` — 35 files / 321 tests pass, including:
  - new `tests/shortcut-store.test.ts`: defaults, setBinding, per-id and global reset, persistence round-trip, malformed-payload tolerance
  - extended `tests/shortcut-parser.test.ts`: `Mod` parsing and Ctrl/Meta matching

## Scope

- No command-palette entry (#57 is in flight in parallel; a follow-up PR can add one).
- Ctrl+Z/Ctrl+Shift+Z defaults migrated to `Mod+Z`/`Mod+Shift+Z` so the dispatcher is platform-agnostic — behavior unchanged for existing users since both `ctrlKey` and `metaKey` already triggered undo before.

Closes #59