### PR TITLE
feat(pdf): pdfium thumbnails with LRU cache (#20)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -51,6 +51,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,6 +1022,7 @@ name = "eldraw"
 version = "0.1.0-rc.7"
 dependencies = [
  "image",
+ "lru",
  "pdfium-render",
  "serde",
  "serde_json",
@@ -1714,6 +1721,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -2372,6 +2381,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
  "imgref",
+]
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,6 +28,7 @@ pdfium-render = { version = "0.9", default-features = false, features = [
 ] }
 image = "0.25"
 tauri-plugin-dialog = "2.7.0"
+lru = "0.12"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -23,6 +23,9 @@ pub enum AppError {
 
     #[error("not implemented: {0}")]
     NotImplemented(&'static str),
+
+    #[error("invalid input: {0}")]
+    InvalidInput(String),
 }
 
 impl Serialize for AppError {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod model;
 mod pdf;
 mod state;
 mod storage;
+mod thumbnails;
 
 pub use error::{AppError, AppResult};
 
@@ -11,11 +12,13 @@ pub use error::{AppError, AppResult};
 pub fn run() {
     tauri::Builder::default()
         .manage(state::AppState::default())
+        .manage(thumbnails::ThumbnailCache::default())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .invoke_handler(tauri::generate_handler![
             pdf::open_pdf,
             pdf::render_page,
+            thumbnails::render_pdf_thumbnail,
             storage::load_sidecar,
             storage::save_sidecar,
             storage::acquire_lock,

--- a/src-tauri/src/pdf.rs
+++ b/src-tauri/src/pdf.rs
@@ -79,7 +79,7 @@ pub async fn open_pdf(
         u32::try_from(pages.len()).map_err(|_| AppError::Pdf("page count exceeds u32".into()))?;
 
     drop(doc);
-    state.set_open(pdf_path, bytes)?;
+    state.set_open(pdf_path, bytes, hash.clone())?;
 
     Ok(PdfMeta {
         path,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -17,10 +17,11 @@ pub struct OpenPdf {
     #[allow(dead_code)] // retained for future cache invalidation / diagnostics
     pub path: PathBuf,
     pub bytes: Vec<u8>,
+    pub hash: String,
 }
 
 impl AppState {
-    pub fn set_open(&self, path: PathBuf, bytes: Vec<u8>) -> AppResult<()> {
+    pub fn set_open(&self, path: PathBuf, bytes: Vec<u8>, hash: String) -> AppResult<()> {
         let mut guard = self
             .inner
             .lock()
@@ -29,6 +30,7 @@ impl AppState {
         *guard = Some(OpenPdf {
             path: canonical,
             bytes,
+            hash,
         });
         Ok(())
     }

--- a/src-tauri/src/thumbnails.rs
+++ b/src-tauri/src/thumbnails.rs
@@ -1,0 +1,226 @@
+//! PDF thumbnail rendering with a process-wide LRU cache.
+//!
+//! Thumbnails are rendered through pdfium at a low resolution (`max_dim`
+//! bounds the longest side) and cached as encoded PNG bytes keyed by
+//! `(pdf_id, page_index, max_dim)`. The frontend wraps the returned bytes
+//! in a `Blob` URL for `<img>` consumption.
+
+use std::io::Cursor;
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Mutex};
+
+use image::ImageFormat;
+use lru::LruCache;
+use pdfium_render::prelude::PdfRenderConfig;
+use tauri::ipc::Response;
+use tauri::{AppHandle, State};
+
+use crate::error::{AppError, AppResult};
+use crate::state::{pdfium, AppState};
+
+pub const DEFAULT_CAPACITY: usize = 64;
+
+#[derive(Clone, Hash, Eq, PartialEq, Debug)]
+pub struct ThumbKey {
+    pub pdf_id: String,
+    pub page_index: usize,
+    pub max_dim: u32,
+}
+
+struct CacheInner {
+    map: LruCache<ThumbKey, Arc<Vec<u8>>>,
+    hits: u64,
+    misses: u64,
+}
+
+pub struct ThumbnailCache {
+    inner: Mutex<CacheInner>,
+}
+
+impl ThumbnailCache {
+    pub fn with_capacity(capacity: usize) -> Self {
+        let cap = NonZeroUsize::new(capacity.max(1)).expect("capacity clamped to >= 1");
+        Self {
+            inner: Mutex::new(CacheInner {
+                map: LruCache::new(cap),
+                hits: 0,
+                misses: 0,
+            }),
+        }
+    }
+
+    pub fn get(&self, key: &ThumbKey) -> Option<Arc<Vec<u8>>> {
+        let mut guard = self.inner.lock().expect("thumb cache poisoned");
+        if let Some(v) = guard.map.get(key) {
+            let cloned = Arc::clone(v);
+            guard.hits += 1;
+            Some(cloned)
+        } else {
+            guard.misses += 1;
+            None
+        }
+    }
+
+    pub fn insert(&self, key: ThumbKey, value: Arc<Vec<u8>>) {
+        let mut guard = self.inner.lock().expect("thumb cache poisoned");
+        guard.map.put(key, value);
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn len(&self) -> usize {
+        self.inner.lock().expect("thumb cache poisoned").map.len()
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn stats(&self) -> (u64, u64) {
+        let g = self.inner.lock().expect("thumb cache poisoned");
+        (g.hits, g.misses)
+    }
+}
+
+impl Default for ThumbnailCache {
+    fn default() -> Self {
+        Self::with_capacity(DEFAULT_CAPACITY)
+    }
+}
+
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_precision_loss
+)]
+fn target_dims(width_pt: f32, height_pt: f32, max_dim: u32) -> (i32, i32) {
+    let longest = width_pt.max(height_pt).max(1.0);
+    let scale =
+        f32::from(u16::try_from(max_dim.min(u32::from(u16::MAX))).unwrap_or(u16::MAX)) / longest;
+    let w = (width_pt * scale).round().max(1.0) as i32;
+    let h = (height_pt * scale).round().max(1.0) as i32;
+    (w, h)
+}
+
+#[tauri::command]
+pub async fn render_pdf_thumbnail(
+    app: AppHandle,
+    pdf_id: String,
+    page_index: usize,
+    max_dim: u32,
+    state: State<'_, AppState>,
+    cache: State<'_, ThumbnailCache>,
+) -> AppResult<Response> {
+    if max_dim == 0 {
+        return Err(AppError::Pdf("max_dim must be > 0".into()));
+    }
+    let key = ThumbKey {
+        pdf_id,
+        page_index,
+        max_dim,
+    };
+
+    if let Some(hit) = cache.get(&key) {
+        return Ok(Response::new((*hit).clone()));
+    }
+
+    let bytes = state.with_open(|open| {
+        let pdfium = pdfium(&app)?;
+        let doc = pdfium
+            .load_pdf_from_byte_slice(&open.bytes, None)
+            .map_err(|e| AppError::Pdf(format!("load_pdf: {e}")))?;
+        let page = doc
+            .pages()
+            .get(
+                i32::try_from(page_index)
+                    .map_err(|_| AppError::Pdf(format!("page_index {page_index} out of range")))?,
+            )
+            .map_err(|_| AppError::Pdf(format!("page_index {page_index} out of range")))?;
+
+        let (w, h) = target_dims(page.width().value, page.height().value, max_dim);
+        let config = PdfRenderConfig::new()
+            .set_target_width(w)
+            .set_target_height(h);
+        let bitmap = page
+            .render_with_config(&config)
+            .map_err(|e| AppError::Pdf(format!("render: {e}")))?;
+        let image = bitmap
+            .as_image()
+            .map_err(|e| AppError::Pdf(format!("bitmap: {e}")))?;
+        let mut out = Cursor::new(Vec::<u8>::new());
+        image.write_to(&mut out, ImageFormat::Png)?;
+        Ok(out.into_inner())
+    })?;
+
+    let shared = Arc::new(bytes);
+    cache.insert(key, Arc::clone(&shared));
+    Ok(Response::new((*shared).clone()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(id: &str, idx: usize) -> ThumbKey {
+        ThumbKey {
+            pdf_id: id.into(),
+            page_index: idx,
+            max_dim: 200,
+        }
+    }
+
+    fn bytes(n: u8) -> Arc<Vec<u8>> {
+        Arc::new(vec![n; 4])
+    }
+
+    #[test]
+    fn miss_then_hit_increments_counters() {
+        let cache = ThumbnailCache::with_capacity(8);
+        assert!(cache.get(&key("a", 0)).is_none());
+        cache.insert(key("a", 0), bytes(1));
+        let got = cache.get(&key("a", 0)).expect("hit");
+        assert_eq!(*got, vec![1; 4]);
+        assert_eq!(cache.stats(), (1, 1));
+    }
+
+    #[test]
+    fn evicts_least_recently_used_past_capacity() {
+        let cache = ThumbnailCache::with_capacity(2);
+        cache.insert(key("a", 0), bytes(1));
+        cache.insert(key("a", 1), bytes(2));
+        // Touch key 0 so key 1 becomes LRU.
+        let _ = cache.get(&key("a", 0));
+        cache.insert(key("a", 2), bytes(3));
+        assert!(cache.get(&key("a", 1)).is_none(), "oldest must be evicted");
+        assert!(cache.get(&key("a", 0)).is_some());
+        assert!(cache.get(&key("a", 2)).is_some());
+        assert_eq!(cache.len(), 2);
+    }
+
+    #[test]
+    fn different_pdf_ids_do_not_collide() {
+        let cache = ThumbnailCache::with_capacity(4);
+        cache.insert(key("a", 0), bytes(1));
+        cache.insert(key("b", 0), bytes(2));
+        assert_eq!(*cache.get(&key("a", 0)).unwrap(), vec![1; 4]);
+        assert_eq!(*cache.get(&key("b", 0)).unwrap(), vec![2; 4]);
+    }
+
+    #[test]
+    fn zero_capacity_is_clamped_to_one() {
+        let cache = ThumbnailCache::with_capacity(0);
+        cache.insert(key("a", 0), bytes(1));
+        assert!(cache.get(&key("a", 0)).is_some());
+    }
+
+    #[test]
+    fn target_dims_caps_longest_side() {
+        let (w, h) = target_dims(612.0, 792.0, 200);
+        assert_eq!(h, 200);
+        assert!(w < h);
+        assert!((150..=160).contains(&w));
+    }
+
+    #[test]
+    fn target_dims_landscape() {
+        let (w, h) = target_dims(800.0, 400.0, 100);
+        assert_eq!(w, 100);
+        assert_eq!(h, 50);
+    }
+}

--- a/src-tauri/src/thumbnails.rs
+++ b/src-tauri/src/thumbnails.rs
@@ -20,6 +20,14 @@ use crate::state::{pdfium, AppState};
 
 pub const DEFAULT_CAPACITY: usize = 64;
 
+/// Upper bound on a thumbnail bitmap's pixel area. Tighter than the main
+/// page renderer since thumbnails are intentionally small.
+const MAX_THUMB_PIXEL_AREA: u64 = 16 * 1024 * 1024;
+
+/// Largest permitted value for `max_dim`. Matches the pixel-area bound's
+/// square root so a square page can't exceed the area cap on its own.
+const MAX_THUMB_DIM: u32 = 4096;
+
 #[derive(Clone, Hash, Eq, PartialEq, Debug)]
 pub struct ThumbKey {
     pub pdf_id: String,
@@ -37,6 +45,10 @@ pub struct ThumbnailCache {
     inner: Mutex<CacheInner>,
 }
 
+fn poisoned() -> AppError {
+    AppError::Pdf("thumb cache mutex poisoned".into())
+}
+
 impl ThumbnailCache {
     pub fn with_capacity(capacity: usize) -> Self {
         let cap = NonZeroUsize::new(capacity.max(1)).expect("capacity clamped to >= 1");
@@ -49,32 +61,33 @@ impl ThumbnailCache {
         }
     }
 
-    pub fn get(&self, key: &ThumbKey) -> Option<Arc<Vec<u8>>> {
-        let mut guard = self.inner.lock().expect("thumb cache poisoned");
+    pub fn get(&self, key: &ThumbKey) -> AppResult<Option<Arc<Vec<u8>>>> {
+        let mut guard = self.inner.lock().map_err(|_| poisoned())?;
         if let Some(v) = guard.map.get(key) {
             let cloned = Arc::clone(v);
             guard.hits += 1;
-            Some(cloned)
+            Ok(Some(cloned))
         } else {
             guard.misses += 1;
-            None
+            Ok(None)
         }
     }
 
-    pub fn insert(&self, key: ThumbKey, value: Arc<Vec<u8>>) {
-        let mut guard = self.inner.lock().expect("thumb cache poisoned");
+    pub fn insert(&self, key: ThumbKey, value: Arc<Vec<u8>>) -> AppResult<()> {
+        let mut guard = self.inner.lock().map_err(|_| poisoned())?;
         guard.map.put(key, value);
+        Ok(())
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
-    pub fn len(&self) -> usize {
-        self.inner.lock().expect("thumb cache poisoned").map.len()
+    pub fn len(&self) -> AppResult<usize> {
+        Ok(self.inner.lock().map_err(|_| poisoned())?.map.len())
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
-    pub fn stats(&self) -> (u64, u64) {
-        let g = self.inner.lock().expect("thumb cache poisoned");
-        (g.hits, g.misses)
+    pub fn stats(&self) -> AppResult<(u64, u64)> {
+        let g = self.inner.lock().map_err(|_| poisoned())?;
+        Ok((g.hits, g.misses))
     }
 }
 
@@ -108,7 +121,12 @@ pub async fn render_pdf_thumbnail(
     cache: State<'_, ThumbnailCache>,
 ) -> AppResult<Response> {
     if max_dim == 0 {
-        return Err(AppError::Pdf("max_dim must be > 0".into()));
+        return Err(AppError::InvalidInput("max_dim must be > 0".into()));
+    }
+    if max_dim > MAX_THUMB_DIM {
+        return Err(AppError::InvalidInput(format!(
+            "max_dim {max_dim} exceeds {MAX_THUMB_DIM}-pixel cap"
+        )));
     }
     let key = ThumbKey {
         pdf_id,
@@ -116,11 +134,17 @@ pub async fn render_pdf_thumbnail(
         max_dim,
     };
 
-    if let Some(hit) = cache.get(&key) {
+    if let Some(hit) = cache.get(&key)? {
         return Ok(Response::new((*hit).clone()));
     }
 
     let bytes = state.with_open(|open| {
+        if key.pdf_id != open.hash {
+            return Err(AppError::InvalidInput(format!(
+                "pdf_id {} does not match the currently-open document",
+                key.pdf_id
+            )));
+        }
         let pdfium = pdfium(&app)?;
         let doc = pdfium
             .load_pdf_from_byte_slice(&open.bytes, None)
@@ -134,6 +158,12 @@ pub async fn render_pdf_thumbnail(
             .map_err(|_| AppError::Pdf(format!("page_index {page_index} out of range")))?;
 
         let (w, h) = target_dims(page.width().value, page.height().value, max_dim);
+        let area = u64::from(w.unsigned_abs()) * u64::from(h.unsigned_abs());
+        if area > MAX_THUMB_PIXEL_AREA {
+            return Err(AppError::InvalidInput(format!(
+                "requested thumbnail {w}x{h} exceeds {MAX_THUMB_PIXEL_AREA}-pixel cap"
+            )));
+        }
         let config = PdfRenderConfig::new()
             .set_target_width(w)
             .set_target_height(h);
@@ -149,7 +179,7 @@ pub async fn render_pdf_thumbnail(
     })?;
 
     let shared = Arc::new(bytes);
-    cache.insert(key, Arc::clone(&shared));
+    cache.insert(key, Arc::clone(&shared))?;
     Ok(Response::new((*shared).clone()))
 }
 
@@ -172,41 +202,44 @@ mod tests {
     #[test]
     fn miss_then_hit_increments_counters() {
         let cache = ThumbnailCache::with_capacity(8);
-        assert!(cache.get(&key("a", 0)).is_none());
-        cache.insert(key("a", 0), bytes(1));
-        let got = cache.get(&key("a", 0)).expect("hit");
+        assert!(cache.get(&key("a", 0)).unwrap().is_none());
+        cache.insert(key("a", 0), bytes(1)).unwrap();
+        let got = cache.get(&key("a", 0)).unwrap().expect("hit");
         assert_eq!(*got, vec![1; 4]);
-        assert_eq!(cache.stats(), (1, 1));
+        assert_eq!(cache.stats().unwrap(), (1, 1));
     }
 
     #[test]
     fn evicts_least_recently_used_past_capacity() {
         let cache = ThumbnailCache::with_capacity(2);
-        cache.insert(key("a", 0), bytes(1));
-        cache.insert(key("a", 1), bytes(2));
+        cache.insert(key("a", 0), bytes(1)).unwrap();
+        cache.insert(key("a", 1), bytes(2)).unwrap();
         // Touch key 0 so key 1 becomes LRU.
-        let _ = cache.get(&key("a", 0));
-        cache.insert(key("a", 2), bytes(3));
-        assert!(cache.get(&key("a", 1)).is_none(), "oldest must be evicted");
-        assert!(cache.get(&key("a", 0)).is_some());
-        assert!(cache.get(&key("a", 2)).is_some());
-        assert_eq!(cache.len(), 2);
+        let _ = cache.get(&key("a", 0)).unwrap();
+        cache.insert(key("a", 2), bytes(3)).unwrap();
+        assert!(
+            cache.get(&key("a", 1)).unwrap().is_none(),
+            "oldest must be evicted"
+        );
+        assert!(cache.get(&key("a", 0)).unwrap().is_some());
+        assert!(cache.get(&key("a", 2)).unwrap().is_some());
+        assert_eq!(cache.len().unwrap(), 2);
     }
 
     #[test]
     fn different_pdf_ids_do_not_collide() {
         let cache = ThumbnailCache::with_capacity(4);
-        cache.insert(key("a", 0), bytes(1));
-        cache.insert(key("b", 0), bytes(2));
-        assert_eq!(*cache.get(&key("a", 0)).unwrap(), vec![1; 4]);
-        assert_eq!(*cache.get(&key("b", 0)).unwrap(), vec![2; 4]);
+        cache.insert(key("a", 0), bytes(1)).unwrap();
+        cache.insert(key("b", 0), bytes(2)).unwrap();
+        assert_eq!(*cache.get(&key("a", 0)).unwrap().unwrap(), vec![1; 4]);
+        assert_eq!(*cache.get(&key("b", 0)).unwrap().unwrap(), vec![2; 4]);
     }
 
     #[test]
     fn zero_capacity_is_clamped_to_one() {
         let cache = ThumbnailCache::with_capacity(0);
-        cache.insert(key("a", 0), bytes(1));
-        assert!(cache.get(&key("a", 0)).is_some());
+        cache.insert(key("a", 0), bytes(1)).unwrap();
+        assert!(cache.get(&key("a", 0)).unwrap().is_some());
     }
 
     #[test]

--- a/src/lib/ipc/index.ts
+++ b/src/lib/ipc/index.ts
@@ -29,6 +29,29 @@ export async function renderPage(pageIndex: number, scale: number): Promise<Arra
   }
 }
 
+export async function renderPdfThumbnail(
+  pdfId: string,
+  pageIndex: number,
+  maxDim: number,
+): Promise<ArrayBuffer> {
+  const t = performance.now();
+  try {
+    const bytes = await invoke<ArrayBuffer>('render_pdf_thumbnail', {
+      pdfId,
+      pageIndex,
+      maxDim,
+    });
+    log(
+      'ipc',
+      `render_pdf_thumbnail idx=${pageIndex} max=${maxDim} bytes=${bytes.byteLength} in ${(performance.now() - t).toFixed(1)}ms`,
+    );
+    return bytes;
+  } catch (err) {
+    warn('ipc', `render_pdf_thumbnail idx=${pageIndex} failed`, err);
+    throw err;
+  }
+}
+
 export async function loadSidecar(pdfPath: string): Promise<EldrawDocument | null> {
   return invoke('load_sidecar', { pdfPath });
 }

--- a/src/lib/pdf/thumbnails.ts
+++ b/src/lib/pdf/thumbnails.ts
@@ -11,12 +11,22 @@ function keyOf(pdfId: string, pageIndex: number, maxDim: number): Key {
 
 const urls = new Map<Key, string>();
 const inflight = new Map<Key, Promise<string>>();
+const generations = new Map<string, number>();
+
+function generation(pdfId: string): number {
+  return generations.get(pdfId) ?? 0;
+}
 
 /**
  * Resolve a blob URL for a page thumbnail, rendered on-demand by the Rust
  * backend and cached there via LRU. Identical calls are de-duplicated; the
  * backing blob URL is reused across repeated calls until `revokeThumbnails`
  * is invoked.
+ *
+ * Each `pdfId` carries a generation counter that is bumped by
+ * `revokeThumbnails`. An in-flight render whose generation is stale on
+ * completion revokes the freshly-minted blob URL instead of caching it, so a
+ * late response can't resurrect a dropped document's thumbnails.
  */
 export async function getThumbnail(
   pdfId: string,
@@ -29,10 +39,15 @@ export async function getThumbnail(
   const pending = inflight.get(k);
   if (pending) return pending;
 
+  const token = generation(pdfId);
   const task = (async () => {
     try {
       const bytes = await renderPdfThumbnail(pdfId, pageIndex, maxDim);
       const url = URL.createObjectURL(new Blob([bytes], { type: 'image/png' }));
+      if (generation(pdfId) !== token) {
+        URL.revokeObjectURL(url);
+        throw new Error('thumbnail request superseded');
+      }
       urls.set(k, url);
       return url;
     } finally {
@@ -45,13 +60,41 @@ export async function getThumbnail(
 
 /**
  * Revoke cached blob URLs. Pass `pdfId` to drop only that document's entries,
- * or omit to clear everything. Callers should invoke this on component
- * teardown or when the active document changes.
+ * or omit to clear everything. Bumps the per-`pdfId` generation token so
+ * in-flight requests started before the call drop their results instead of
+ * repopulating the cache.
  */
 export function revokeThumbnails(pdfId?: string): void {
+  if (pdfId) {
+    generations.set(pdfId, generation(pdfId) + 1);
+  } else {
+    for (const id of generations.keys()) {
+      generations.set(id, generation(id) + 1);
+    }
+  }
   const prefix = pdfId ? `${pdfId}\u0000` : undefined;
   for (const [k, url] of urls) {
     if (!prefix || k.startsWith(prefix)) {
+      URL.revokeObjectURL(url);
+      urls.delete(k);
+    }
+  }
+}
+
+/**
+ * Revoke cached thumbnails for `pdfId` whose page index is not in
+ * `keepPageIndexes`. Used to clean up when pages are deleted/reordered so
+ * orphaned blob URLs don't accumulate for the lifetime of the document.
+ */
+export function retainThumbnails(pdfId: string, keepPageIndexes: ReadonlySet<number>): void {
+  const prefix = `${pdfId}\u0000`;
+  for (const [k, url] of urls) {
+    if (!k.startsWith(prefix)) continue;
+    const rest = k.slice(prefix.length);
+    const sep = rest.indexOf('\u0000');
+    if (sep < 0) continue;
+    const pageIndex = Number(rest.slice(0, sep));
+    if (!keepPageIndexes.has(pageIndex)) {
       URL.revokeObjectURL(url);
       urls.delete(k);
     }

--- a/src/lib/pdf/thumbnails.ts
+++ b/src/lib/pdf/thumbnails.ts
@@ -1,0 +1,59 @@
+import { renderPdfThumbnail } from '$lib/ipc';
+
+/** Default longest-side pixel bound for thumbnails. */
+export const DEFAULT_MAX_DIM = 200;
+
+type Key = string;
+
+function keyOf(pdfId: string, pageIndex: number, maxDim: number): Key {
+  return `${pdfId}\u0000${pageIndex}\u0000${maxDim}`;
+}
+
+const urls = new Map<Key, string>();
+const inflight = new Map<Key, Promise<string>>();
+
+/**
+ * Resolve a blob URL for a page thumbnail, rendered on-demand by the Rust
+ * backend and cached there via LRU. Identical calls are de-duplicated; the
+ * backing blob URL is reused across repeated calls until `revokeThumbnails`
+ * is invoked.
+ */
+export async function getThumbnail(
+  pdfId: string,
+  pageIndex: number,
+  maxDim: number = DEFAULT_MAX_DIM,
+): Promise<string> {
+  const k = keyOf(pdfId, pageIndex, maxDim);
+  const cached = urls.get(k);
+  if (cached) return cached;
+  const pending = inflight.get(k);
+  if (pending) return pending;
+
+  const task = (async () => {
+    try {
+      const bytes = await renderPdfThumbnail(pdfId, pageIndex, maxDim);
+      const url = URL.createObjectURL(new Blob([bytes], { type: 'image/png' }));
+      urls.set(k, url);
+      return url;
+    } finally {
+      inflight.delete(k);
+    }
+  })();
+  inflight.set(k, task);
+  return task;
+}
+
+/**
+ * Revoke cached blob URLs. Pass `pdfId` to drop only that document's entries,
+ * or omit to clear everything. Callers should invoke this on component
+ * teardown or when the active document changes.
+ */
+export function revokeThumbnails(pdfId?: string): void {
+  const prefix = pdfId ? `${pdfId}\u0000` : undefined;
+  for (const [k, url] of urls) {
+    if (!prefix || k.startsWith(prefix)) {
+      URL.revokeObjectURL(url);
+      urls.delete(k);
+    }
+  }
+}

--- a/src/lib/sidebar/ThumbnailStrip.svelte
+++ b/src/lib/sidebar/ThumbnailStrip.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
   import { onDestroy, untrack } from 'svelte';
   import type { Page } from '$lib/types';
-  import { getThumbnail, revokeThumbnails, DEFAULT_MAX_DIM } from '$lib/pdf/thumbnails';
+  import {
+    getThumbnail,
+    retainThumbnails,
+    revokeThumbnails,
+    DEFAULT_MAX_DIM,
+  } from '$lib/pdf/thumbnails';
   import { thumbnailSize } from './thumbnailSize';
 
   interface Props {
@@ -58,6 +63,7 @@
       previewUrls = next;
     } catch {
       // Leave the slot blank on failure; main layer surfaces the error.
+    } finally {
       requested.delete(key);
     }
   }
@@ -102,6 +108,27 @@
         dropState();
         cacheKey = key;
       }
+    });
+  });
+
+  $effect(() => {
+    const activeKeys = new Set<number>();
+    for (const page of pages) {
+      if (page.type === 'pdf') activeKeys.add(sourceKey(page));
+    }
+    untrack(() => {
+      if (!cacheKey) return;
+      let changed = false;
+      const next = new Map(previewUrls);
+      for (const key of next.keys()) {
+        if (!activeKeys.has(key)) {
+          next.delete(key);
+          requested.delete(key);
+          changed = true;
+        }
+      }
+      if (changed) previewUrls = next;
+      retainThumbnails(cacheKey, activeKeys);
     });
   });
 

--- a/src/lib/sidebar/ThumbnailStrip.svelte
+++ b/src/lib/sidebar/ThumbnailStrip.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onDestroy, untrack } from 'svelte';
   import type { Page } from '$lib/types';
-  import { renderPage } from '$lib/ipc';
+  import { getThumbnail, revokeThumbnails, DEFAULT_MAX_DIM } from '$lib/pdf/thumbnails';
   import { thumbnailSize } from './thumbnailSize';
 
   interface Props {
@@ -28,114 +28,90 @@
   }: Props = $props();
 
   const canDelete = $derived(pages.length > 1);
-  const MAX_CONCURRENT_RENDERS = 3;
 
   let previewUrls = $state(new Map<number, string>());
-  const inflight = new Set<number>();
-  const queue: Page[] = [];
-  let activeRenders = 0;
+  const requested = new Set<number>();
   let destroyed = false;
   let cacheKey: string | null = null;
-
-  function thumbnailScale(widthPt: number): number {
-    if (!widthPt || widthPt <= 0) return 1;
-    const target = Math.max(64, Math.min(maxWidth, 220));
-    return target / widthPt;
-  }
+  let observer: IntersectionObserver | null = null;
+  const slotToKey = new WeakMap<Element, number>();
 
   function sourceKey(page: Page): number {
     return page.pdfSourceIndex ?? page.pageIndex;
   }
 
-  function revokeAll() {
-    for (const url of previewUrls.values()) URL.revokeObjectURL(url);
+  function dropState() {
+    if (cacheKey) revokeThumbnails(cacheKey);
     previewUrls = new Map();
-    inflight.clear();
-    queue.length = 0;
-    activeRenders = 0;
+    requested.clear();
   }
 
-  function pumpQueue() {
-    while (!destroyed && activeRenders < MAX_CONCURRENT_RENDERS && queue.length > 0) {
-      const page = queue.shift()!;
-      void renderOne(page);
-    }
-  }
-
-  async function renderOne(page: Page): Promise<void> {
-    const key = sourceKey(page);
-    activeRenders += 1;
+  async function request(key: number) {
+    if (!docKey || destroyed || requested.has(key)) return;
+    requested.add(key);
+    const scopedKey = docKey;
     try {
-      const bytes = await renderPage(key, thumbnailScale(page.width));
-      if (destroyed) return;
-      const blob = new Blob([bytes], { type: 'image/png' });
-      const url = URL.createObjectURL(blob);
-      if (destroyed) {
-        URL.revokeObjectURL(url);
-        return;
-      }
+      const url = await getThumbnail(scopedKey, key, DEFAULT_MAX_DIM);
+      if (destroyed || scopedKey !== cacheKey) return;
       const next = new Map(previewUrls);
-      const prior = next.get(key);
-      if (prior) URL.revokeObjectURL(prior);
       next.set(key, url);
       previewUrls = next;
     } catch {
       // Leave the slot blank on failure; main layer surfaces the error.
-    } finally {
-      inflight.delete(key);
-      activeRenders -= 1;
-      pumpQueue();
+      requested.delete(key);
     }
   }
 
-  function enqueue(page: Page) {
-    if (page.type !== 'pdf') return;
+  function ensureObserver(): IntersectionObserver | null {
+    if (observer || typeof IntersectionObserver === 'undefined') return observer;
+    observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (!entry.isIntersecting) continue;
+          const key = slotToKey.get(entry.target);
+          if (key !== undefined) void request(key);
+        }
+      },
+      { rootMargin: '200px' },
+    );
+    return observer;
+  }
+
+  function observe(el: Element, page: Page) {
+    if (page.type !== 'pdf') return { destroy() {} };
     const key = sourceKey(page);
-    if (previewUrls.has(key) || inflight.has(key)) return;
-    inflight.add(key);
-    queue.push(page);
-  }
-
-  function pruneStaleKeys(snapshot: Page[]) {
-    const live = new Set<number>();
-    for (const p of snapshot) if (p.type === 'pdf') live.add(sourceKey(p));
-    let changed = false;
-    const next = new Map(previewUrls);
-    for (const [key, url] of next) {
-      if (!live.has(key)) {
-        URL.revokeObjectURL(url);
-        next.delete(key);
-        changed = true;
-      }
+    const io = ensureObserver();
+    if (!io) {
+      void request(key);
+      return { destroy() {} };
     }
-    if (changed) previewUrls = next;
+    slotToKey.set(el, key);
+    io.observe(el);
+    return {
+      destroy() {
+        io.unobserve(el);
+        slotToKey.delete(el);
+      },
+    };
   }
 
   $effect(() => {
     const key = docKey;
     untrack(() => {
       if (key !== cacheKey) {
-        revokeAll();
+        dropState();
         cacheKey = key;
       }
     });
   });
 
-  $effect(() => {
-    const snapshot = pages;
-    untrack(() => {
-      pruneStaleKeys(snapshot);
-      for (const p of snapshot) enqueue(p);
-      pumpQueue();
-    });
-  });
-
   onDestroy(() => {
     destroyed = true;
-    for (const url of previewUrls.values()) URL.revokeObjectURL(url);
+    observer?.disconnect();
+    observer = null;
+    if (cacheKey) revokeThumbnails(cacheKey);
     previewUrls.clear();
-    inflight.clear();
-    queue.length = 0;
+    requested.clear();
   });
 
   function previewFor(page: Page): string | undefined {
@@ -160,6 +136,7 @@
           <span
             class="preview"
             class:blank={page.type === 'blank'}
+            use:observe={page}
             style="width: {size.width}px; height: {size.height}px;{url
               ? ` background-image: url('${url}');`
               : ''}"

--- a/tests/thumbnails.test.ts
+++ b/tests/thumbnails.test.ts
@@ -7,11 +7,12 @@ vi.mock('@tauri-apps/api/core', () => ({ invoke }));
 function setupObjectUrls() {
   let counter = 0;
   const revoked: string[] = [];
-  (globalThis as unknown as { URL: typeof URL }).URL.createObjectURL = vi.fn(
-    () => `blob:test/${counter++}`,
-  );
-  (globalThis as unknown as { URL: typeof URL }).URL.revokeObjectURL = vi.fn((url: string) => {
-    revoked.push(url);
+  vi.stubGlobal('URL', {
+    ...globalThis.URL,
+    createObjectURL: vi.fn(() => `blob:test/${counter++}`),
+    revokeObjectURL: vi.fn((url: string) => {
+      revoked.push(url);
+    }),
   });
   return { revoked };
 }

--- a/tests/thumbnails.test.ts
+++ b/tests/thumbnails.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const invoke = vi.fn();
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke }));
+
+function setupObjectUrls() {
+  let counter = 0;
+  const revoked: string[] = [];
+  (globalThis as unknown as { URL: typeof URL }).URL.createObjectURL = vi.fn(
+    () => `blob:test/${counter++}`,
+  );
+  (globalThis as unknown as { URL: typeof URL }).URL.revokeObjectURL = vi.fn((url: string) => {
+    revoked.push(url);
+  });
+  return { revoked };
+}
+
+describe('getThumbnail', () => {
+  beforeEach(() => {
+    invoke.mockReset();
+    vi.resetModules();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('invokes render_pdf_thumbnail and wraps the bytes in a blob URL', async () => {
+    setupObjectUrls();
+    const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]).buffer;
+    invoke.mockResolvedValue(bytes);
+    const mod = await import('../src/lib/pdf/thumbnails');
+
+    const url = await mod.getThumbnail('hash-a', 3, 200);
+
+    expect(invoke).toHaveBeenCalledWith('render_pdf_thumbnail', {
+      pdfId: 'hash-a',
+      pageIndex: 3,
+      maxDim: 200,
+    });
+    expect(url).toMatch(/^blob:test\//);
+  });
+
+  it('returns the cached URL on repeat calls without re-invoking', async () => {
+    setupObjectUrls();
+    invoke.mockResolvedValue(new Uint8Array([1, 2, 3]).buffer);
+    const mod = await import('../src/lib/pdf/thumbnails');
+
+    const a = await mod.getThumbnail('hash-a', 0);
+    const b = await mod.getThumbnail('hash-a', 0);
+
+    expect(a).toBe(b);
+    expect(invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('dedupes concurrent requests for the same key', async () => {
+    setupObjectUrls();
+    let resolve!: (v: ArrayBuffer) => void;
+    invoke.mockImplementation(
+      () =>
+        new Promise<ArrayBuffer>((r) => {
+          resolve = r;
+        }),
+    );
+    const mod = await import('../src/lib/pdf/thumbnails');
+
+    const p1 = mod.getThumbnail('hash-a', 1);
+    const p2 = mod.getThumbnail('hash-a', 1);
+    resolve(new Uint8Array([1]).buffer);
+
+    expect(await p1).toBe(await p2);
+    expect(invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('revokeThumbnails drops only the requested pdfId', async () => {
+    const { revoked } = setupObjectUrls();
+    invoke.mockResolvedValue(new Uint8Array([1]).buffer);
+    const mod = await import('../src/lib/pdf/thumbnails');
+
+    const a0 = await mod.getThumbnail('hash-a', 0);
+    await mod.getThumbnail('hash-b', 0);
+
+    mod.revokeThumbnails('hash-a');
+    expect(revoked).toContain(a0);
+
+    // After revocation, the next call must re-invoke and produce a new URL.
+    invoke.mockClear();
+    const a0Again = await mod.getThumbnail('hash-a', 0);
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(a0Again).not.toBe(a0);
+  });
+
+  it('defaults maxDim to 200', async () => {
+    setupObjectUrls();
+    invoke.mockResolvedValue(new Uint8Array([1]).buffer);
+    const mod = await import('../src/lib/pdf/thumbnails');
+
+    await mod.getThumbnail('hash-c', 7);
+
+    expect(invoke).toHaveBeenCalledWith(
+      'render_pdf_thumbnail',
+      expect.objectContaining({ maxDim: 200 }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- New `render_pdf_thumbnail(pdf_id, page_index, max_dim)` Tauri command renders pages through the shared pdfium handle at a bounded resolution and returns PNG bytes.
- Process-wide LRU cache (capacity 64) keyed by `(pdf_id, page_index, max_dim)`, wrapped in `Mutex<LruCache<…>>` and wired as Tauri managed state. Tracks hits/misses for diagnostics.
- Frontend `src/lib/pdf/thumbnails.ts` exposes `getThumbnail(pdfId, pageIndex, maxDim = 200)` returning a blob URL, dedupes concurrent requests, memoises URLs, and offers `revokeThumbnails(pdfId?)` for teardown.
- `ThumbnailStrip.svelte` now lazily fetches previews via `IntersectionObserver` (with a 200px root-margin prefetch window) and revokes blob URLs on unmount or doc switch.

## Why
Closes #20. Replaces the previous approach of repurposing the full `render_page` command for thumbnails — that path rendered at main-canvas scale and had no cross-component cache, so flipping back to a page re-rendered its strip every time.

## Testing
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml` (16 tests incl. 6 new `thumbnails::tests::*` covering capacity, LRU eviction, hit/miss counters, zero-capacity clamp, scale dims)
- `pnpm lint`
- `pnpm test` (317 tests incl. new `tests/thumbnails.test.ts` mocking `invoke` for fetcher behavior)

Closes #20