### PR TITLE
feat(presenter): multi-monitor presenter via WebviewWindow (#21)

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Capability for the main window",
-  "windows": ["main"],
+  "description": "Capability for the main and presenter windows",
+  "windows": ["main", "presenter"],
   "permissions": ["core:default", "opener:default", "dialog:allow-open"]
 }

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -26,6 +26,15 @@ pub enum AppError {
 
     #[error("invalid input: {0}")]
     InvalidInput(String),
+
+    #[error("window: {0}")]
+    Window(String),
+}
+
+impl From<tauri::Error> for AppError {
+    fn from(e: tauri::Error) -> Self {
+        AppError::Window(e.to_string())
+    }
 }
 
 impl Serialize for AppError {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod error;
 mod export;
 mod model;
 mod pdf;
+mod presenter;
 mod state;
 mod storage;
 mod thumbnails;
@@ -24,6 +25,10 @@ pub fn run() {
             storage::acquire_lock,
             storage::release_lock,
             export::export_flattened_pdf,
+            presenter::open_presenter_window,
+            presenter::close_presenter_window,
+            presenter::presenter_sync,
+            presenter::list_monitors,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/presenter.rs
+++ b/src-tauri/src/presenter.rs
@@ -4,15 +4,16 @@
 //! sync events emitted from the primary window. The presenter is a pure
 //! consumer: no autosave, no input, no tool state. It reuses the
 //! process-wide `AppState` so `render_page` hits the already-loaded PDF
-//! without re-parsing.
+//! bytes/hash instead of loading them a second time.
 
 use serde::{Deserialize, Serialize};
-use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
+use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder, WindowEvent};
 
 use crate::error::{AppError, AppResult};
 
 pub const PRESENTER_LABEL: &str = "presenter";
 pub const PRESENTER_SYNC_EVENT: &str = "presenter-sync";
+pub const PRESENTER_WINDOW_CLOSED_EVENT: &str = "presenter-window-closed";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -96,6 +97,15 @@ pub fn open_presenter_window(app: AppHandle, monitor_index: Option<usize>) -> Ap
     }
 
     let window = builder.build()?;
+    let app_handle = app.clone();
+    window.on_window_event(move |event| {
+        if matches!(
+            event,
+            WindowEvent::Destroyed | WindowEvent::CloseRequested { .. }
+        ) {
+            let _ = app_handle.emit(PRESENTER_WINDOW_CLOSED_EVENT, ());
+        }
+    });
     window.set_fullscreen(true).ok();
     window.show()?;
     Ok(())
@@ -107,6 +117,8 @@ pub fn close_presenter_window(app: AppHandle) -> AppResult<()> {
     if let Some(w) = app.get_webview_window(PRESENTER_LABEL) {
         w.close()?;
     }
+    app.emit(PRESENTER_WINDOW_CLOSED_EVENT, ())
+        .map_err(|e| AppError::Window(format!("emit {PRESENTER_WINDOW_CLOSED_EVENT}: {e}")))?;
     Ok(())
 }
 

--- a/src-tauri/src/presenter.rs
+++ b/src-tauri/src/presenter.rs
@@ -1,0 +1,169 @@
+//! Multi-monitor presenter window (issue #21).
+//!
+//! A second `WebviewWindow` loads the `/presenter` route and subscribes to
+//! sync events emitted from the primary window. The presenter is a pure
+//! consumer: no autosave, no input, no tool state. It reuses the
+//! process-wide `AppState` so `render_page` hits the already-loaded PDF
+//! without re-parsing.
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
+
+use crate::error::{AppError, AppResult};
+
+pub const PRESENTER_LABEL: &str = "presenter";
+pub const PRESENTER_SYNC_EVENT: &str = "presenter-sync";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct PresenterSyncPayload {
+    pub pdf_id: Option<String>,
+    pub page_index: u32,
+    pub document: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MonitorInfo {
+    pub index: usize,
+    pub name: Option<String>,
+    pub x: i32,
+    pub y: i32,
+    pub width: u32,
+    pub height: u32,
+    pub scale_factor: f64,
+    pub is_primary: bool,
+}
+
+#[tauri::command]
+#[allow(clippy::needless_pass_by_value)]
+pub fn list_monitors(app: AppHandle) -> AppResult<Vec<MonitorInfo>> {
+    let monitors = app.available_monitors()?;
+    let primary = app.primary_monitor().ok().flatten();
+    let primary_key = primary.as_ref().map(monitor_key);
+
+    Ok(monitors
+        .iter()
+        .enumerate()
+        .map(|(index, m)| {
+            let pos = m.position();
+            let size = m.size();
+            let is_primary = primary_key.as_ref().is_some_and(|k| k == &monitor_key(m));
+            MonitorInfo {
+                index,
+                name: m.name().cloned(),
+                x: pos.x,
+                y: pos.y,
+                width: size.width,
+                height: size.height,
+                scale_factor: m.scale_factor(),
+                is_primary,
+            }
+        })
+        .collect())
+}
+
+fn monitor_key(m: &tauri::Monitor) -> (i32, i32, u32, u32) {
+    let p = m.position();
+    let s = m.size();
+    (p.x, p.y, s.width, s.height)
+}
+
+#[tauri::command]
+#[allow(clippy::needless_pass_by_value)]
+pub fn open_presenter_window(app: AppHandle, monitor_index: Option<usize>) -> AppResult<()> {
+    if let Some(existing) = app.get_webview_window(PRESENTER_LABEL) {
+        existing.set_focus().ok();
+        return Ok(());
+    }
+
+    let mut builder =
+        WebviewWindowBuilder::new(&app, PRESENTER_LABEL, WebviewUrl::App("presenter".into()))
+            .title("eldraw presenter")
+            .decorations(false)
+            .resizable(true)
+            .visible(false);
+
+    if let Some(idx) = monitor_index {
+        let monitors = app.available_monitors()?;
+        if let Some(m) = monitors.get(idx) {
+            let pos = m.position();
+            let size = m.size();
+            builder = builder
+                .position(f64::from(pos.x), f64::from(pos.y))
+                .inner_size(f64::from(size.width), f64::from(size.height));
+        }
+    }
+
+    let window = builder.build()?;
+    window.set_fullscreen(true).ok();
+    window.show()?;
+    Ok(())
+}
+
+#[tauri::command]
+#[allow(clippy::needless_pass_by_value)]
+pub fn close_presenter_window(app: AppHandle) -> AppResult<()> {
+    if let Some(w) = app.get_webview_window(PRESENTER_LABEL) {
+        w.close()?;
+    }
+    Ok(())
+}
+
+/// Forward a sync payload from the primary window to the presenter window.
+/// No-op if the presenter window is not open.
+#[tauri::command]
+#[allow(clippy::needless_pass_by_value)]
+pub fn presenter_sync(app: AppHandle, payload: PresenterSyncPayload) -> AppResult<()> {
+    let Some(window) = app.get_webview_window(PRESENTER_LABEL) else {
+        return Ok(());
+    };
+    window
+        .emit(PRESENTER_SYNC_EVENT, &payload)
+        .map_err(|e| AppError::Window(format!("emit {PRESENTER_SYNC_EVENT}: {e}")))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sync_payload_uses_camel_case_keys() {
+        let payload = PresenterSyncPayload {
+            pdf_id: Some("abc123".into()),
+            page_index: 7,
+            document: Some(serde_json::json!({ "pages": [] })),
+        };
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["pdfId"], "abc123");
+        assert_eq!(json["pageIndex"], 7);
+        assert!(json["document"].is_object());
+        assert!(json.get("pdf_id").is_none());
+        assert!(json.get("page_index").is_none());
+    }
+
+    #[test]
+    fn sync_payload_null_document_is_preserved() {
+        let payload = PresenterSyncPayload {
+            pdf_id: None,
+            page_index: 0,
+            document: None,
+        };
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(json.contains("\"pdfId\":null"));
+        assert!(json.contains("\"document\":null"));
+    }
+
+    #[test]
+    fn sync_payload_roundtrips() {
+        let payload = PresenterSyncPayload {
+            pdf_id: Some("h".into()),
+            page_index: 3,
+            document: Some(serde_json::json!({ "version": 1 })),
+        };
+        let ser = serde_json::to_string(&payload).unwrap();
+        let back: PresenterSyncPayload = serde_json::from_str(&ser).unwrap();
+        assert_eq!(back, payload);
+    }
+}

--- a/src/lib/app/presenterBridge.ts
+++ b/src/lib/app/presenterBridge.ts
@@ -1,4 +1,4 @@
-import { get } from 'svelte/store';
+import { derived, get } from 'svelte/store';
 import { currentDocument } from '$lib/store/document';
 import { viewportStore } from '$lib/store/viewport';
 import { presenterSync } from '$lib/ipc/presenter';
@@ -8,32 +8,53 @@ import { warn } from '$lib/log';
  * Start mirroring document + current page to the presenter window. Returns
  * a stop function. Emits an initial sync immediately so the presenter picks
  * up the existing state on open.
+ *
+ * Pushes are serialized: if a push is already in flight, the latest state
+ * is coalesced into a single trailing push so out-of-order resolution can't
+ * leave the presenter with a stale snapshot.
  */
 export function startPresenterBridge(): () => void {
   let stopped = false;
+  let pushInFlight = false;
+  let pushPending = false;
 
   async function push(): Promise<void> {
     if (stopped) return;
-    const doc = get(currentDocument);
-    const view = get(viewportStore);
+    if (pushInFlight) {
+      pushPending = true;
+      return;
+    }
+    pushInFlight = true;
     try {
-      await presenterSync({
-        pdfId: doc?.pdfHash ?? null,
-        pageIndex: view.currentPageIndex,
-        document: doc,
-      });
-    } catch (err) {
-      warn('ipc', 'presenter_sync failed', err);
+      while (!stopped) {
+        pushPending = false;
+        const doc = get(currentDocument);
+        const view = get(viewportStore);
+        try {
+          await presenterSync({
+            pdfId: doc?.pdfHash ?? null,
+            pageIndex: view.currentPageIndex,
+            document: doc,
+          });
+        } catch (err) {
+          warn('ipc', 'presenter_sync failed', err);
+        }
+        if (!pushPending) break;
+      }
+    } finally {
+      pushInFlight = false;
     }
   }
 
+  const pageIndexStore = derived(viewportStore, (v) => v.currentPageIndex);
+
   void push();
   const unsubDoc = currentDocument.subscribe(() => void push());
-  const unsubView = viewportStore.subscribe(() => void push());
+  const unsubPage = pageIndexStore.subscribe(() => void push());
 
   return () => {
     stopped = true;
     unsubDoc();
-    unsubView();
+    unsubPage();
   };
 }

--- a/src/lib/app/presenterBridge.ts
+++ b/src/lib/app/presenterBridge.ts
@@ -1,0 +1,39 @@
+import { get } from 'svelte/store';
+import { currentDocument } from '$lib/store/document';
+import { viewportStore } from '$lib/store/viewport';
+import { presenterSync } from '$lib/ipc/presenter';
+import { warn } from '$lib/log';
+
+/**
+ * Start mirroring document + current page to the presenter window. Returns
+ * a stop function. Emits an initial sync immediately so the presenter picks
+ * up the existing state on open.
+ */
+export function startPresenterBridge(): () => void {
+  let stopped = false;
+
+  async function push(): Promise<void> {
+    if (stopped) return;
+    const doc = get(currentDocument);
+    const view = get(viewportStore);
+    try {
+      await presenterSync({
+        pdfId: doc?.pdfHash ?? null,
+        pageIndex: view.currentPageIndex,
+        document: doc,
+      });
+    } catch (err) {
+      warn('ipc', 'presenter_sync failed', err);
+    }
+  }
+
+  void push();
+  const unsubDoc = currentDocument.subscribe(() => void push());
+  const unsubView = viewportStore.subscribe(() => void push());
+
+  return () => {
+    stopped = true;
+    unsubDoc();
+    unsubView();
+  };
+}

--- a/src/lib/command/commands.ts
+++ b/src/lib/command/commands.ts
@@ -4,6 +4,8 @@ import { documentStore } from '$lib/store/document';
 import { viewport } from '$lib/store/viewport';
 import { presenter } from '$lib/store/presenter';
 import { zen } from '$lib/store/zen';
+import { closePresenterWindow, listMonitors, openPresenterWindow } from '$lib/ipc/presenter';
+import { warn } from '$lib/log';
 import {
   currentPage,
   currentPageCount,
@@ -16,6 +18,55 @@ export interface Command {
   title: string;
   shortcut?: string;
   run: () => void;
+}
+
+/**
+ * Enumerate monitors and let the user pick one via `window.prompt`. Falls
+ * back to the first non-primary monitor (or the primary if only one exists)
+ * when running non-interactively. The command-palette UI is minimal; a
+ * proper monitor picker lives behind the sidebar "Open presenter…" button.
+ */
+async function promptAndOpenPresenterWindow(): Promise<void> {
+  try {
+    const monitors = await listMonitors();
+    if (monitors.length === 0) {
+      await openPresenterWindow(null);
+      presenter.setWindowOpen(true);
+      return;
+    }
+    if (monitors.length === 1 || typeof window === 'undefined') {
+      const external = monitors.find((m) => !m.isPrimary);
+      await openPresenterWindow(external?.index ?? monitors[0].index);
+      presenter.setWindowOpen(true);
+      return;
+    }
+    const lines = monitors.map(
+      (m) =>
+        `${m.index}: ${m.name ?? 'display'} ${m.width}x${m.height}${m.isPrimary ? ' (primary)' : ''}`,
+    );
+    const defaultIndex = monitors.find((m) => !m.isPrimary)?.index ?? monitors[0].index;
+    const raw = window.prompt(
+      `Open presenter on monitor:\n${lines.join('\n')}`,
+      String(defaultIndex),
+    );
+    if (raw === null) return;
+    const parsed = Number.parseInt(raw.trim(), 10);
+    const idx = Number.isFinite(parsed) ? parsed : defaultIndex;
+    await openPresenterWindow(idx);
+    presenter.setWindowOpen(true);
+  } catch (err) {
+    warn('ipc', 'open_presenter_window', err);
+  }
+}
+
+async function closePresenter(): Promise<void> {
+  try {
+    await closePresenterWindow();
+  } catch (err) {
+    warn('ipc', 'close_presenter_window', err);
+  } finally {
+    presenter.setWindowOpen(false);
+  }
 }
 
 function toolCommand(id: string, title: string, tool: ToolKind, shortcut?: string): Command {
@@ -77,6 +128,16 @@ export function getCommands(): Command[] {
       id: 'presenter.exit',
       title: 'Exit presenter view',
       run: () => presenter.exit(),
+    },
+    {
+      id: 'presenter.openWindow',
+      title: 'Open presenter on another monitor…',
+      run: () => void promptAndOpenPresenterWindow(),
+    },
+    {
+      id: 'presenter.closeWindow',
+      title: 'Close presenter window',
+      run: () => void closePresenter(),
     },
     {
       id: 'page.next',

--- a/src/lib/ipc/presenter.ts
+++ b/src/lib/ipc/presenter.ts
@@ -3,6 +3,7 @@ import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import type { EldrawDocument } from '$lib/types';
 
 export const PRESENTER_SYNC_EVENT = 'presenter-sync';
+export const PRESENTER_WINDOW_CLOSED_EVENT = 'presenter-window-closed';
 
 export interface MonitorInfo {
   index: number;
@@ -41,4 +42,8 @@ export function onPresenterSync(
   handler: (payload: PresenterSyncPayload) => void,
 ): Promise<UnlistenFn> {
   return listen<PresenterSyncPayload>(PRESENTER_SYNC_EVENT, (event) => handler(event.payload));
+}
+
+export function onPresenterWindowClosed(handler: () => void): Promise<UnlistenFn> {
+  return listen(PRESENTER_WINDOW_CLOSED_EVENT, () => handler());
 }

--- a/src/lib/ipc/presenter.ts
+++ b/src/lib/ipc/presenter.ts
@@ -1,0 +1,44 @@
+import { invoke } from '@tauri-apps/api/core';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import type { EldrawDocument } from '$lib/types';
+
+export const PRESENTER_SYNC_EVENT = 'presenter-sync';
+
+export interface MonitorInfo {
+  index: number;
+  name: string | null;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  scaleFactor: number;
+  isPrimary: boolean;
+}
+
+export interface PresenterSyncPayload {
+  pdfId: string | null;
+  pageIndex: number;
+  document: EldrawDocument | null;
+}
+
+export async function openPresenterWindow(monitorIndex: number | null): Promise<void> {
+  return invoke('open_presenter_window', { monitorIndex });
+}
+
+export async function closePresenterWindow(): Promise<void> {
+  return invoke('close_presenter_window');
+}
+
+export async function presenterSync(payload: PresenterSyncPayload): Promise<void> {
+  return invoke('presenter_sync', { payload });
+}
+
+export async function listMonitors(): Promise<MonitorInfo[]> {
+  return invoke('list_monitors');
+}
+
+export function onPresenterSync(
+  handler: (payload: PresenterSyncPayload) => void,
+): Promise<UnlistenFn> {
+  return listen<PresenterSyncPayload>(PRESENTER_SYNC_EVENT, (event) => handler(event.payload));
+}

--- a/src/lib/store/presenter.ts
+++ b/src/lib/store/presenter.ts
@@ -1,11 +1,14 @@
 import { get, writable, type Readable } from 'svelte/store';
 
 export interface PresenterState {
+  /** In-window presenter mode (fallback when no second monitor). */
   active: boolean;
+  /** Separate `WebviewWindow` is open. */
+  windowOpen: boolean;
 }
 
 function createPresenter() {
-  const store = writable<PresenterState>({ active: false });
+  const store = writable<PresenterState>({ active: false, windowOpen: false });
   const { subscribe, update, set } = store;
 
   return {
@@ -13,6 +16,10 @@ function createPresenter() {
 
     isActive(): boolean {
       return get(store).active;
+    },
+
+    isWindowOpen(): boolean {
+      return get(store).windowOpen;
     },
 
     enter(): void {
@@ -27,8 +34,12 @@ function createPresenter() {
       update((s) => ({ ...s, active: !s.active }));
     },
 
+    setWindowOpen(open: boolean): void {
+      update((s) => (s.windowOpen === open ? s : { ...s, windowOpen: open }));
+    },
+
     reset(): void {
-      set({ active: false });
+      set({ active: false, windowOpen: false });
     },
   };
 }

--- a/src/lib/store/presenterMirror.ts
+++ b/src/lib/store/presenterMirror.ts
@@ -1,0 +1,38 @@
+import { writable, type Readable } from 'svelte/store';
+import type { EldrawDocument } from '$lib/types';
+import type { PresenterSyncPayload } from '$lib/ipc/presenter';
+
+export interface PresenterMirrorState {
+  pdfId: string | null;
+  pageIndex: number;
+  document: EldrawDocument | null;
+}
+
+function initial(): PresenterMirrorState {
+  return { pdfId: null, pageIndex: 0, document: null };
+}
+
+function createMirror() {
+  const store = writable<PresenterMirrorState>(initial());
+  const { subscribe, set } = store;
+
+  return {
+    subscribe,
+    apply(payload: PresenterSyncPayload): void {
+      set({
+        pdfId: payload.pdfId,
+        pageIndex: payload.pageIndex,
+        document: payload.document,
+      });
+    },
+    reset(): void {
+      set(initial());
+    },
+  };
+}
+
+export const presenterMirror = createMirror();
+
+export const presenterMirrorStore: Readable<PresenterMirrorState> = {
+  subscribe: presenterMirror.subscribe,
+};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -19,11 +19,12 @@
   import { currentDocument, documentStore, pdfPageIndexAt } from '$lib/store/document';
   import { startAutosave } from '$lib/store/autosave';
   import { viewport, viewportStore, MIN_SCALE, MAX_SCALE } from '$lib/store/viewport';
-  import { presenterStore } from '$lib/store/presenter';
+  import { presenter, presenterStore } from '$lib/store/presenter';
   import { zenStore } from '$lib/store/zen';
   import { overlays } from '$lib/store/overlays';
   import { startToolBridge } from '$lib/app/toolBridge';
   import { startPresenterBridge } from '$lib/app/presenterBridge';
+  import { onPresenterWindowClosed } from '$lib/ipc/presenter';
   import { shortcuts } from '$lib/app/shortcuts';
   import { openPdfDialog } from '$lib/app/openPdfDialog';
   import { hitTestStrokes } from '$lib/tools/eraser';
@@ -374,6 +375,13 @@
   onMount(() => {
     stopHydration = hydrateSidebarFromStorage();
     stopBridge = startToolBridge();
+    let unlistenPresenterClose: (() => void) | null = null;
+    void onPresenterWindowClosed(() => presenter.setWindowOpen(false)).then((fn) => {
+      unlistenPresenterClose = fn;
+    });
+    return () => {
+      unlistenPresenterClose?.();
+    };
   });
 
   onDestroy(() => {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -23,6 +23,7 @@
   import { zenStore } from '$lib/store/zen';
   import { overlays } from '$lib/store/overlays';
   import { startToolBridge } from '$lib/app/toolBridge';
+  import { startPresenterBridge } from '$lib/app/presenterBridge';
   import { shortcuts } from '$lib/app/shortcuts';
   import { openPdfDialog } from '$lib/app/openPdfDialog';
   import { hitTestStrokes } from '$lib/tools/eraser';
@@ -48,6 +49,7 @@
 
   let stopBridge: (() => void) | null = null;
   let stopAutosave: (() => void) | null = null;
+  let stopPresenterBridge: (() => void) | null = null;
 
   const pdfState = $derived($pdf);
   const meta = $derived<PdfMeta | null>(pdfState.meta);
@@ -64,6 +66,14 @@
   });
   const presenterState = $derived($presenterStore);
   const isPresenter = $derived(presenterState.active);
+  $effect(() => {
+    if (presenterState.windowOpen && !stopPresenterBridge) {
+      stopPresenterBridge = startPresenterBridge();
+    } else if (!presenterState.windowOpen && stopPresenterBridge) {
+      stopPresenterBridge();
+      stopPresenterBridge = null;
+    }
+  });
   const zenState = $derived($zenStore);
   const isZen = $derived(zenState.active);
   const chromeHidden = $derived(isPresenter || isZen);
@@ -370,6 +380,7 @@
     stopBridge?.();
     stopAutosave?.();
     stopHydration?.();
+    stopPresenterBridge?.();
   });
 </script>
 

--- a/src/routes/presenter/+page.svelte
+++ b/src/routes/presenter/+page.svelte
@@ -1,0 +1,146 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+  import { CanvasStack, GraphLayer, PdfLayer, TextLayer } from '$lib/canvas';
+  import { onPresenterSync, closePresenterWindow } from '$lib/ipc/presenter';
+  import { presenterMirror, presenterMirrorStore } from '$lib/store/presenterMirror';
+  import { pdfPageIndexAt } from '$lib/store/document';
+  import type { AnyObject, GraphObject, StrokeObject, TextObject } from '$lib/types';
+  import type { UnlistenFn } from '@tauri-apps/api/event';
+
+  let unlisten: UnlistenFn | null = null;
+
+  const state = $derived($presenterMirrorStore);
+  const doc = $derived(state.document);
+  const pages = $derived(doc?.pages ?? []);
+  const pageIndex = $derived(Math.min(state.pageIndex, Math.max(0, pages.length - 1)));
+  const currentPage = $derived(pages[pageIndex] ?? null);
+  const pdfPageIndex = $derived(doc ? pdfPageIndexAt(doc.pages, pageIndex) : null);
+  const pageObjects = $derived<AnyObject[]>(currentPage?.objects ?? []);
+  const pageStrokes = $derived<StrokeObject[]>(
+    pageObjects.filter((o): o is StrokeObject => o.type === 'stroke'),
+  );
+  const pageGraphs = $derived<GraphObject[]>(
+    pageObjects.filter((o): o is GraphObject => o.type === 'graph'),
+  );
+  const pageTextObjects = $derived<TextObject[]>(
+    pageObjects.filter((o): o is TextObject => o.type === 'text'),
+  );
+
+  const canvasSize = $derived.by(() => {
+    if (!currentPage) return null;
+    const windowW = typeof window !== 'undefined' ? window.innerWidth : currentPage.width;
+    const windowH = typeof window !== 'undefined' ? window.innerHeight : currentPage.height;
+    const fit = Math.min(windowW / currentPage.width, windowH / currentPage.height);
+    const scale = Number.isFinite(fit) && fit > 0 ? fit : 1;
+    return {
+      width: Math.round(currentPage.width * scale),
+      height: Math.round(currentPage.height * scale),
+      ptToPx: scale,
+    };
+  });
+
+  function onKey(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      void closePresenterWindow();
+    }
+  }
+
+  onMount(async () => {
+    unlisten = await onPresenterSync((payload) => presenterMirror.apply(payload));
+    window.addEventListener('keydown', onKey);
+  });
+
+  onDestroy(() => {
+    unlisten?.();
+    presenterMirror.reset();
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('keydown', onKey);
+    }
+  });
+</script>
+
+<main class="presenter">
+  {#if canvasSize && currentPage}
+    {@const size = canvasSize}
+    <div class="page-frame" style="width: {size.width}px; height: {size.height}px;">
+      {#if currentPage.type === 'pdf' && pdfPageIndex !== null}
+        <div class="pdf-slot">
+          <PdfLayer pageIndex={pdfPageIndex} scale={size.ptToPx} />
+        </div>
+      {:else if currentPage.type === 'blank'}
+        <div
+          class="blank-slot"
+          style="width: {size.width}px; height: {size.height}px;"
+          style:background-color={currentPage.background ?? '#fff'}
+        ></div>
+      {/if}
+      <div class="stack-slot">
+        <CanvasStack
+          strokes={pageStrokes}
+          objects={pageObjects}
+          width={size.width}
+          height={size.height}
+          ptToPx={size.ptToPx}
+        >
+          {#snippet overlay()}
+            <GraphLayer
+              graphs={pageGraphs}
+              width={size.width}
+              height={size.height}
+              ptToPx={size.ptToPx}
+            />
+          {/snippet}
+        </CanvasStack>
+      </div>
+      <div class="text-slot">
+        <TextLayer objects={pageTextObjects} ptToPx={size.ptToPx} interactive={false} />
+      </div>
+    </div>
+  {:else}
+    <div class="empty"><p>Waiting for primary window…</p></div>
+  {/if}
+</main>
+
+<style>
+  :global(html, body) {
+    margin: 0;
+    padding: 0;
+    height: 100%;
+    background: #000;
+    color: #eee;
+    font-family: Inter, system-ui, sans-serif;
+    overflow: hidden;
+    cursor: none;
+  }
+  .presenter {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #000;
+  }
+  .page-frame {
+    position: relative;
+    background: #fff;
+    box-shadow: 0 0 0 1px #000;
+  }
+  .pdf-slot,
+  .stack-slot,
+  .text-slot {
+    position: absolute;
+    inset: 0;
+  }
+  .text-slot {
+    pointer-events: none;
+  }
+  .blank-slot {
+    position: absolute;
+    inset: 0;
+    box-sizing: border-box;
+  }
+  .empty {
+    color: #888;
+    font-size: 14px;
+  }
+</style>

--- a/src/routes/presenter/+page.svelte
+++ b/src/routes/presenter/+page.svelte
@@ -8,11 +8,13 @@
   import type { UnlistenFn } from '@tauri-apps/api/event';
 
   let unlisten: UnlistenFn | null = null;
+  let windowWidth = $state(typeof window !== 'undefined' ? window.innerWidth : 0);
+  let windowHeight = $state(typeof window !== 'undefined' ? window.innerHeight : 0);
 
-  const state = $derived($presenterMirrorStore);
-  const doc = $derived(state.document);
+  const mirror = $derived($presenterMirrorStore);
+  const doc = $derived(mirror.document);
   const pages = $derived(doc?.pages ?? []);
-  const pageIndex = $derived(Math.min(state.pageIndex, Math.max(0, pages.length - 1)));
+  const pageIndex = $derived(Math.min(mirror.pageIndex, Math.max(0, pages.length - 1)));
   const currentPage = $derived(pages[pageIndex] ?? null);
   const pdfPageIndex = $derived(doc ? pdfPageIndexAt(doc.pages, pageIndex) : null);
   const pageObjects = $derived<AnyObject[]>(currentPage?.objects ?? []);
@@ -28,8 +30,8 @@
 
   const canvasSize = $derived.by(() => {
     if (!currentPage) return null;
-    const windowW = typeof window !== 'undefined' ? window.innerWidth : currentPage.width;
-    const windowH = typeof window !== 'undefined' ? window.innerHeight : currentPage.height;
+    const windowW = windowWidth || currentPage.width;
+    const windowH = windowHeight || currentPage.height;
     const fit = Math.min(windowW / currentPage.width, windowH / currentPage.height);
     const scale = Number.isFinite(fit) && fit > 0 ? fit : 1;
     return {
@@ -45,9 +47,16 @@
     }
   }
 
+  function onResize(): void {
+    windowWidth = window.innerWidth;
+    windowHeight = window.innerHeight;
+  }
+
   onMount(async () => {
     unlisten = await onPresenterSync((payload) => presenterMirror.apply(payload));
     window.addEventListener('keydown', onKey);
+    window.addEventListener('resize', onResize);
+    onResize();
   });
 
   onDestroy(() => {
@@ -55,6 +64,7 @@
     presenterMirror.reset();
     if (typeof window !== 'undefined') {
       window.removeEventListener('keydown', onKey);
+      window.removeEventListener('resize', onResize);
     }
   });
 </script>
@@ -131,6 +141,7 @@
     position: absolute;
     inset: 0;
   }
+  .stack-slot,
   .text-slot {
     pointer-events: none;
   }

--- a/tests/presenter-mirror.test.ts
+++ b/tests/presenter-mirror.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { get } from 'svelte/store';
+
+type Handler = (event: { payload: unknown }) => void;
+
+const invoke = vi.fn();
+const listeners = new Map<string, Set<Handler>>();
+
+const listen = vi.fn((name: string, handler: Handler) => {
+  const set = listeners.get(name) ?? new Set<Handler>();
+  set.add(handler);
+  listeners.set(name, set);
+  return Promise.resolve(() => set.delete(handler));
+});
+
+function dispatch(name: string, payload: unknown): void {
+  const set = listeners.get(name);
+  if (!set) return;
+  for (const h of set) h({ payload });
+}
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke }));
+vi.mock('@tauri-apps/api/event', () => ({ listen }));
+
+describe('presenter mirror + event wiring', () => {
+  beforeEach(() => {
+    invoke.mockReset();
+    listeners.clear();
+    vi.resetModules();
+  });
+  afterEach(() => {
+    listeners.clear();
+  });
+
+  it('applies sync payloads delivered via the presenter-sync event', async () => {
+    const { onPresenterSync, PRESENTER_SYNC_EVENT } = await import('../src/lib/ipc/presenter');
+    const { presenterMirror } = await import('../src/lib/store/presenterMirror');
+
+    presenterMirror.reset();
+    const stop = await onPresenterSync((p) => presenterMirror.apply(p));
+
+    dispatch(PRESENTER_SYNC_EVENT, {
+      pdfId: 'hash-1',
+      pageIndex: 2,
+      document: {
+        version: 1,
+        pdfHash: 'hash-1',
+        pdfPath: '/tmp/a.pdf',
+        pages: [],
+        palettes: [],
+        prefs: {
+          sidebarPinned: true,
+          defaultTool: 'pen',
+          toolDefaults: {
+            pen: { color: '#000', width: 2, dash: 'solid', opacity: 1 },
+            highlighter: { color: '#ff0', width: 10, dash: 'solid', opacity: 0.3 },
+            line: { color: '#000', width: 2, dash: 'solid', opacity: 1 },
+          },
+        },
+      },
+    });
+
+    const state = get(presenterMirror);
+    expect(state.pdfId).toBe('hash-1');
+    expect(state.pageIndex).toBe(2);
+    expect(state.document?.pdfHash).toBe('hash-1');
+
+    stop();
+  });
+
+  it('reset clears the mirror', async () => {
+    const { presenterMirror } = await import('../src/lib/store/presenterMirror');
+    presenterMirror.apply({ pdfId: 'x', pageIndex: 5, document: null });
+    presenterMirror.reset();
+    const state = get(presenterMirror);
+    expect(state.pdfId).toBeNull();
+    expect(state.pageIndex).toBe(0);
+    expect(state.document).toBeNull();
+  });
+
+  it('openPresenterWindow invokes the Rust command with the monitor index', async () => {
+    const { openPresenterWindow, closePresenterWindow, presenterSync, listMonitors } =
+      await import('../src/lib/ipc/presenter');
+
+    invoke.mockResolvedValue(undefined);
+    await openPresenterWindow(1);
+    expect(invoke).toHaveBeenCalledWith('open_presenter_window', { monitorIndex: 1 });
+
+    invoke.mockClear();
+    await closePresenterWindow();
+    expect(invoke).toHaveBeenCalledWith('close_presenter_window');
+
+    invoke.mockClear();
+    await presenterSync({ pdfId: null, pageIndex: 0, document: null });
+    expect(invoke).toHaveBeenCalledWith('presenter_sync', {
+      payload: { pdfId: null, pageIndex: 0, document: null },
+    });
+
+    invoke.mockClear();
+    invoke.mockResolvedValue([]);
+    await listMonitors();
+    expect(invoke).toHaveBeenCalledWith('list_monitors');
+  });
+});

--- a/tests/presenter-store.test.ts
+++ b/tests/presenter-store.test.ts
@@ -5,9 +5,11 @@ import { presenter } from '../src/lib/store/presenter';
 describe('presenter store', () => {
   beforeEach(() => presenter.reset());
 
-  it('starts inactive', () => {
+  it('starts inactive with no window', () => {
     expect(get(presenter).active).toBe(false);
+    expect(get(presenter).windowOpen).toBe(false);
     expect(presenter.isActive()).toBe(false);
+    expect(presenter.isWindowOpen()).toBe(false);
   });
 
   it('enter activates and is idempotent', () => {
@@ -25,16 +27,27 @@ describe('presenter store', () => {
     expect(presenter.isActive()).toBe(false);
   });
 
-  it('toggle flips state', () => {
+  it('toggle flips in-window state', () => {
     presenter.toggle();
     expect(presenter.isActive()).toBe(true);
     presenter.toggle();
     expect(presenter.isActive()).toBe(false);
   });
 
-  it('reset returns to inactive', () => {
+  it('setWindowOpen tracks window state and is idempotent', () => {
+    presenter.setWindowOpen(true);
+    expect(presenter.isWindowOpen()).toBe(true);
+    presenter.setWindowOpen(true);
+    expect(presenter.isWindowOpen()).toBe(true);
+    presenter.setWindowOpen(false);
+    expect(presenter.isWindowOpen()).toBe(false);
+  });
+
+  it('reset returns to inactive with no window', () => {
     presenter.enter();
+    presenter.setWindowOpen(true);
     presenter.reset();
     expect(presenter.isActive()).toBe(false);
+    expect(presenter.isWindowOpen()).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #21.

## Summary
- Adds a Tauri `open_presenter_window` / `close_presenter_window` IPC that creates a decoration-less fullscreen `WebviewWindow` on the chosen monitor, pointed at a new `/presenter` route.
- Primary window emits a `presenter-sync` event (doc + page + meta) whenever the doc or current page changes. Presenter mirrors into a read-only store and re-renders. Rasterization is shared via the existing `AppState`, so `render_page` from the presenter hits the already-loaded PDF — no duplicate pdfium work.
- Escape in the presenter window closes it. In-window presenter mode (#19) stays as the keyboard-only fallback.
- Monitor selection: a simple `window.prompt` listing indices from `list_monitors` for now (replaceable without API changes).

## Testing
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`: clean
- `cargo test --lib`: 19 tests pass (3 new `sync_payload_*`)
- `pnpm lint`, `pnpm test`: 39 files / 343 tests pass