### PR TITLE
feat(sidebar): detach to second WebviewWindow (#38, #28)

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Capability for the main and presenter windows",
-  "windows": ["main", "presenter"],
+  "description": "Capability for the main, presenter, and sidebar windows",
+  "windows": ["main", "presenter", "sidebar-window"],
   "permissions": ["core:default", "opener:default", "dialog:allow-open"]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod model;
 mod page_cache;
 mod pdf;
 mod presenter;
+mod sidebar_window;
 mod state;
 mod storage;
 mod thumbnails;
@@ -31,6 +32,10 @@ pub fn run() {
             presenter::close_presenter_window,
             presenter::presenter_sync,
             presenter::list_monitors,
+            sidebar_window::open_sidebar_window,
+            sidebar_window::close_sidebar_window,
+            sidebar_window::sidebar_sync,
+            sidebar_window::sidebar_sync_back,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/sidebar_window.rs
+++ b/src-tauri/src/sidebar_window.rs
@@ -37,7 +37,7 @@ pub fn open_sidebar_window(app: AppHandle) -> AppResult<()> {
         WebviewUrl::App("sidebar-window".into()),
     )
     .title("eldraw sidebar")
-    .decorations(true)
+    .decorations(false)
     .resizable(true)
     .inner_size(DEFAULT_WIDTH, DEFAULT_HEIGHT)
     .min_inner_size(220.0, 400.0)

--- a/src-tauri/src/sidebar_window.rs
+++ b/src-tauri/src/sidebar_window.rs
@@ -1,0 +1,132 @@
+//! Detached sidebar window (issues #38, #28).
+//!
+//! A second `WebviewWindow` loads the `/sidebar-window` route and mirrors
+//! the sidebar state of the main window. The payload is an opaque
+//! `serde_json::Value` so the Rust side doesn't have to mirror the TS
+//! `SidebarState` shape — it's a pure relay.
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder, WindowEvent};
+
+use crate::error::{AppError, AppResult};
+
+pub const SIDEBAR_WINDOW_LABEL: &str = "sidebar-window";
+pub const MAIN_WINDOW_LABEL: &str = "main";
+pub const SIDEBAR_SYNC_EVENT: &str = "sidebar-sync";
+pub const SIDEBAR_SYNC_BACK_EVENT: &str = "sidebar-sync-back";
+pub const SIDEBAR_WINDOW_CLOSED_EVENT: &str = "sidebar-window-closed";
+
+const DEFAULT_WIDTH: f64 = 260.0;
+const DEFAULT_HEIGHT: f64 = 700.0;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(transparent)]
+pub struct SidebarSyncPayload(pub serde_json::Value);
+
+#[tauri::command]
+#[allow(clippy::needless_pass_by_value)]
+pub fn open_sidebar_window(app: AppHandle) -> AppResult<()> {
+    if let Some(existing) = app.get_webview_window(SIDEBAR_WINDOW_LABEL) {
+        existing.set_focus().ok();
+        return Ok(());
+    }
+
+    let window = WebviewWindowBuilder::new(
+        &app,
+        SIDEBAR_WINDOW_LABEL,
+        WebviewUrl::App("sidebar-window".into()),
+    )
+    .title("eldraw sidebar")
+    .decorations(true)
+    .resizable(true)
+    .inner_size(DEFAULT_WIDTH, DEFAULT_HEIGHT)
+    .min_inner_size(220.0, 400.0)
+    .visible(true)
+    .build()?;
+
+    let app_handle = app.clone();
+    window.on_window_event(move |event| {
+        if matches!(
+            event,
+            WindowEvent::Destroyed | WindowEvent::CloseRequested { .. }
+        ) {
+            let _ = app_handle.emit(SIDEBAR_WINDOW_CLOSED_EVENT, ());
+        }
+    });
+    Ok(())
+}
+
+#[tauri::command]
+#[allow(clippy::needless_pass_by_value)]
+pub fn close_sidebar_window(app: AppHandle) -> AppResult<()> {
+    if let Some(w) = app.get_webview_window(SIDEBAR_WINDOW_LABEL) {
+        w.close()?;
+    }
+    app.emit(SIDEBAR_WINDOW_CLOSED_EVENT, ())
+        .map_err(|e| AppError::Window(format!("emit {SIDEBAR_WINDOW_CLOSED_EVENT}: {e}")))?;
+    Ok(())
+}
+
+/// Forward a sidebar state snapshot from the main window to the detached
+/// window. No-op if the detached window is not open.
+#[tauri::command]
+#[allow(clippy::needless_pass_by_value)]
+pub fn sidebar_sync(app: AppHandle, payload: SidebarSyncPayload) -> AppResult<()> {
+    let Some(window) = app.get_webview_window(SIDEBAR_WINDOW_LABEL) else {
+        return Ok(());
+    };
+    window
+        .emit(SIDEBAR_SYNC_EVENT, &payload)
+        .map_err(|e| AppError::Window(format!("emit {SIDEBAR_SYNC_EVENT}: {e}")))?;
+    Ok(())
+}
+
+/// Forward a sidebar state snapshot from the detached window back to the
+/// main window.
+#[tauri::command]
+#[allow(clippy::needless_pass_by_value)]
+pub fn sidebar_sync_back(app: AppHandle, payload: SidebarSyncPayload) -> AppResult<()> {
+    let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) else {
+        return Ok(());
+    };
+    window
+        .emit(SIDEBAR_SYNC_BACK_EVENT, &payload)
+        .map_err(|e| AppError::Window(format!("emit {SIDEBAR_SYNC_BACK_EVENT}: {e}")))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sync_payload_is_transparent() {
+        let payload = SidebarSyncPayload(serde_json::json!({
+            "activeTool": "pen",
+            "pinned": true,
+        }));
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["activeTool"], "pen");
+        assert_eq!(json["pinned"], true);
+    }
+
+    #[test]
+    fn sync_payload_roundtrips() {
+        let payload = SidebarSyncPayload(serde_json::json!({
+            "activeTool": "highlighter",
+            "activeColor": "#fdd835",
+            "presets": [],
+        }));
+        let ser = serde_json::to_string(&payload).unwrap();
+        let back: SidebarSyncPayload = serde_json::from_str(&ser).unwrap();
+        assert_eq!(back, payload);
+    }
+
+    #[test]
+    fn event_names_are_stable() {
+        assert_eq!(SIDEBAR_WINDOW_LABEL, "sidebar-window");
+        assert_eq!(SIDEBAR_SYNC_EVENT, "sidebar-sync");
+        assert_eq!(SIDEBAR_SYNC_BACK_EVENT, "sidebar-sync-back");
+        assert_eq!(SIDEBAR_WINDOW_CLOSED_EVENT, "sidebar-window-closed");
+    }
+}

--- a/src/lib/app/sidebarBridge.ts
+++ b/src/lib/app/sidebarBridge.ts
@@ -3,6 +3,7 @@ import {
   pickSyncable,
   sidebar,
   syncableEqual,
+  type SidebarState,
   type SyncableSidebarState,
 } from '$lib/store/sidebar';
 import {
@@ -31,7 +32,7 @@ export function startSidebarBridge(side: Side): () => void {
   let stopped = false;
   let pushInFlight = false;
   let pushPending = false;
-  let lastSeen: SyncableSidebarState = pickSyncable(get(sidebar));
+  let lastSeen: SyncableSidebarState | null = null;
 
   const send = side === 'main' ? sidebarSync : sidebarSyncBack;
   const subscribe = side === 'main' ? onSidebarSync : onSidebarSyncBack;
@@ -47,7 +48,7 @@ export function startSidebarBridge(side: Side): () => void {
       while (!stopped) {
         pushPending = false;
         const snap = pickSyncable(get(sidebar));
-        if (syncableEqual(snap, lastSeen)) break;
+        if (lastSeen !== null && syncableEqual(snap, lastSeen)) break;
         lastSeen = snap;
         try {
           await send(snap as unknown as SidebarSyncPayload);
@@ -62,10 +63,11 @@ export function startSidebarBridge(side: Side): () => void {
   }
 
   const unsubStore = sidebar.subscribe(() => void push());
+  void push();
 
   let unsubEvent: (() => void) | null = null;
   void subscribe((payload) => {
-    const incoming = payload as unknown as SyncableSidebarState;
+    const incoming = pickSyncable(payload as unknown as SidebarState);
     lastSeen = incoming;
     sidebar.applyRemote(incoming);
   }).then((fn) => {

--- a/src/lib/app/sidebarBridge.ts
+++ b/src/lib/app/sidebarBridge.ts
@@ -1,0 +1,81 @@
+import { get } from 'svelte/store';
+import {
+  pickSyncable,
+  sidebar,
+  syncableEqual,
+  type SyncableSidebarState,
+} from '$lib/store/sidebar';
+import {
+  onSidebarSync,
+  onSidebarSyncBack,
+  sidebarSync,
+  sidebarSyncBack,
+  type SidebarSyncPayload,
+} from '$lib/ipc/sidebar-window';
+import { warn } from '$lib/log';
+
+type Side = 'main' | 'detached';
+
+/**
+ * Start mirroring sidebar state between the main and detached windows.
+ *
+ * Each window calls this with its own role. The bridge subscribes to the
+ * local sidebar store and forwards the syncable subset to the peer on
+ * change. Incoming snapshots are tracked via `lastSeen` so the echo
+ * (peer applies → re-emits) is dropped without bouncing back. Pushes
+ * are coalesced so only the latest snapshot is ever in flight.
+ *
+ * Returns a stop function.
+ */
+export function startSidebarBridge(side: Side): () => void {
+  let stopped = false;
+  let pushInFlight = false;
+  let pushPending = false;
+  let lastSeen: SyncableSidebarState = pickSyncable(get(sidebar));
+
+  const send = side === 'main' ? sidebarSync : sidebarSyncBack;
+  const subscribe = side === 'main' ? onSidebarSync : onSidebarSyncBack;
+
+  async function push(): Promise<void> {
+    if (stopped) return;
+    if (pushInFlight) {
+      pushPending = true;
+      return;
+    }
+    pushInFlight = true;
+    try {
+      while (!stopped) {
+        pushPending = false;
+        const snap = pickSyncable(get(sidebar));
+        if (syncableEqual(snap, lastSeen)) break;
+        lastSeen = snap;
+        try {
+          await send(snap as unknown as SidebarSyncPayload);
+        } catch (err) {
+          warn('ipc', `sidebar_sync (${side}) failed`, err);
+        }
+        if (!pushPending) break;
+      }
+    } finally {
+      pushInFlight = false;
+    }
+  }
+
+  const unsubStore = sidebar.subscribe(() => void push());
+
+  let unsubEvent: (() => void) | null = null;
+  void subscribe((payload) => {
+    const incoming = payload as unknown as SyncableSidebarState;
+    lastSeen = incoming;
+    sidebar.applyRemote(incoming);
+  }).then((fn) => {
+    if (stopped) fn();
+    else unsubEvent = fn;
+  });
+
+  return () => {
+    stopped = true;
+    unsubStore();
+    unsubEvent?.();
+  };
+}

--- a/src/lib/ipc/sidebar-window.ts
+++ b/src/lib/ipc/sidebar-window.ts
@@ -1,0 +1,38 @@
+import { invoke } from '@tauri-apps/api/core';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+
+export const SIDEBAR_SYNC_EVENT = 'sidebar-sync';
+export const SIDEBAR_SYNC_BACK_EVENT = 'sidebar-sync-back';
+export const SIDEBAR_WINDOW_CLOSED_EVENT = 'sidebar-window-closed';
+
+export type SidebarSyncPayload = Record<string, unknown>;
+
+export async function openSidebarWindow(): Promise<void> {
+  return invoke('open_sidebar_window');
+}
+
+export async function closeSidebarWindow(): Promise<void> {
+  return invoke('close_sidebar_window');
+}
+
+export async function sidebarSync(payload: SidebarSyncPayload): Promise<void> {
+  return invoke('sidebar_sync', { payload });
+}
+
+export async function sidebarSyncBack(payload: SidebarSyncPayload): Promise<void> {
+  return invoke('sidebar_sync_back', { payload });
+}
+
+export function onSidebarSync(handler: (payload: SidebarSyncPayload) => void): Promise<UnlistenFn> {
+  return listen<SidebarSyncPayload>(SIDEBAR_SYNC_EVENT, (event) => handler(event.payload));
+}
+
+export function onSidebarSyncBack(
+  handler: (payload: SidebarSyncPayload) => void,
+): Promise<UnlistenFn> {
+  return listen<SidebarSyncPayload>(SIDEBAR_SYNC_BACK_EVENT, (event) => handler(event.payload));
+}
+
+export function onSidebarWindowClosed(handler: () => void): Promise<UnlistenFn> {
+  return listen(SIDEBAR_WINDOW_CLOSED_EVENT, () => handler());
+}

--- a/src/lib/sidebar/Sidebar.svelte
+++ b/src/lib/sidebar/Sidebar.svelte
@@ -12,9 +12,22 @@
     onToolChange?: (tool: ToolKind) => void;
     onStyleChange?: (style: StrokeStyle) => void;
     onPinChange?: (pinned: boolean) => void;
+    onDetachChange?: (detached: boolean) => void;
+    /**
+     * When true, this sidebar is rendered inside the detached window.
+     * The detach button becomes a "dock" button and the pin toggle is
+     * hidden because pinning is a main-window concept only.
+     */
+    mode?: 'inline' | 'detached';
   }
 
-  let { onToolChange, onStyleChange, onPinChange }: Props = $props();
+  let {
+    onToolChange,
+    onStyleChange,
+    onPinChange,
+    onDetachChange,
+    mode = 'inline',
+  }: Props = $props();
 
   interface ToolSpec {
     id: ToolKind;
@@ -78,6 +91,10 @@
   function togglePin() {
     sidebar.togglePin();
     onPinChange?.(sidebar.snapshot().pinned);
+  }
+
+  function onDetachClick() {
+    onDetachChange?.(mode !== 'detached');
   }
 
   let shortcutsOpen = $state(false);
@@ -227,13 +244,24 @@
     <button
       type="button"
       class="pin"
-      aria-pressed={sidebarState.pinned}
-      aria-label={sidebarState.pinned ? 'Unpin sidebar' : 'Pin sidebar'}
-      title={sidebarState.pinned ? 'Unpin sidebar' : 'Pin sidebar'}
-      onclick={togglePin}
+      aria-label={mode === 'detached' ? 'Dock sidebar' : 'Detach sidebar to its own window'}
+      title={mode === 'detached' ? 'Dock sidebar' : 'Detach to window'}
+      onclick={onDetachClick}
     >
-      <span aria-hidden="true">{sidebarState.pinned ? '📌' : '📍'}</span>
+      <span aria-hidden="true">{mode === 'detached' ? '⇲' : '⇱'}</span>
     </button>
+    {#if mode !== 'detached'}
+      <button
+        type="button"
+        class="pin"
+        aria-pressed={sidebarState.pinned}
+        aria-label={sidebarState.pinned ? 'Unpin sidebar' : 'Pin sidebar'}
+        title={sidebarState.pinned ? 'Unpin sidebar' : 'Pin sidebar'}
+        onclick={togglePin}
+      >
+        <span aria-hidden="true">{sidebarState.pinned ? '📌' : '📍'}</span>
+      </button>
+    {/if}
   </header>
 
   <section class="tools" aria-label="Tools">

--- a/src/lib/store/sidebar.ts
+++ b/src/lib/store/sidebar.ts
@@ -39,6 +39,7 @@ const DEFAULT_LINE: StrokeStyle = { color: '#000000', width: 2, dash: 'solid', o
 
 export interface SidebarState {
   pinned: boolean;
+  detached: boolean;
   activeTool: ToolKind;
   toolStyles: Record<StyledTool, StrokeStyle>;
   palettes: ColorPalette[];
@@ -52,6 +53,7 @@ export interface SidebarState {
 function initialState(): SidebarState {
   return {
     pinned: true,
+    detached: false,
     activeTool: 'pen',
     toolStyles: {
       pen: { ...DEFAULT_PEN },
@@ -205,6 +207,31 @@ function createSidebarStore() {
 
     togglePin() {
       update((s) => ({ ...s, pinned: !s.pinned }));
+    },
+
+    setDetached(detached: boolean) {
+      update((s) => (s.detached === detached ? s : { ...s, detached }));
+    },
+
+    /**
+     * Apply a remote snapshot from the paired window. Only touches fields
+     * that are meaningful to share across windows; window-local state like
+     * `detached` and `floatingPos` is preserved so the two windows can
+     * track their own chrome independently.
+     */
+    applyRemote(snapshot: Partial<SidebarState>) {
+      update((s) => {
+        const next: SidebarState = { ...s };
+        if (snapshot.pinned !== undefined) next.pinned = snapshot.pinned;
+        if (snapshot.activeTool !== undefined) next.activeTool = snapshot.activeTool;
+        if (snapshot.toolStyles !== undefined) next.toolStyles = snapshot.toolStyles;
+        if (snapshot.palettes !== undefined) next.palettes = snapshot.palettes;
+        if (snapshot.activeColor !== undefined) next.activeColor = snapshot.activeColor;
+        if (snapshot.laser !== undefined) next.laser = snapshot.laser;
+        if (snapshot.tempInkFadeMs !== undefined) next.tempInkFadeMs = snapshot.tempInkFadeMs;
+        if (snapshot.presets !== undefined) next.presets = snapshot.presets;
+        return next;
+      });
     },
 
     setFloatingPos(pos: { x: number; y: number } | null) {
@@ -401,3 +428,32 @@ export const currentStyle: Readable<StrokeStyle> = derived(sidebar, (s) => {
     : { color: s.activeColor, width: 2, dash: 'solid' as DashStyle, opacity: 1 };
   return { ...base, color: s.activeColor };
 });
+
+export type SyncableSidebarState = Pick<
+  SidebarState,
+  | 'pinned'
+  | 'activeTool'
+  | 'toolStyles'
+  | 'palettes'
+  | 'activeColor'
+  | 'laser'
+  | 'tempInkFadeMs'
+  | 'presets'
+>;
+
+export function pickSyncable(state: SidebarState): SyncableSidebarState {
+  return {
+    pinned: state.pinned,
+    activeTool: state.activeTool,
+    toolStyles: state.toolStyles,
+    palettes: state.palettes,
+    activeColor: state.activeColor,
+    laser: state.laser,
+    tempInkFadeMs: state.tempInkFadeMs,
+    presets: state.presets,
+  };
+}
+
+export function syncableEqual(a: SyncableSidebarState, b: SyncableSidebarState): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}

--- a/src/lib/store/sidebar.ts
+++ b/src/lib/store/sidebar.ts
@@ -455,5 +455,30 @@ export function pickSyncable(state: SidebarState): SyncableSidebarState {
 }
 
 export function syncableEqual(a: SyncableSidebarState, b: SyncableSidebarState): boolean {
-  return JSON.stringify(a) === JSON.stringify(b);
+  return deepEqual(a, b);
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (typeof a !== 'object' || a === null || typeof b !== 'object' || b === null) {
+    return false;
+  }
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b) || a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i += 1) {
+      if (!deepEqual(a[i], b[i])) return false;
+    }
+    return true;
+  }
+  if (Array.isArray(b)) return false;
+  const aObj = a as Record<string, unknown>;
+  const bObj = b as Record<string, unknown>;
+  const aKeys = Object.keys(aObj);
+  const bKeys = Object.keys(bObj);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const key of aKeys) {
+    if (!Object.prototype.hasOwnProperty.call(bObj, key)) return false;
+    if (!deepEqual(aObj[key], bObj[key])) return false;
+  }
+  return true;
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -24,7 +24,13 @@
   import { overlays } from '$lib/store/overlays';
   import { startToolBridge } from '$lib/app/toolBridge';
   import { startPresenterBridge } from '$lib/app/presenterBridge';
+  import { startSidebarBridge } from '$lib/app/sidebarBridge';
   import { onPresenterWindowClosed } from '$lib/ipc/presenter';
+  import {
+    openSidebarWindow,
+    closeSidebarWindow,
+    onSidebarWindowClosed,
+  } from '$lib/ipc/sidebar-window';
   import { shortcuts } from '$lib/app/shortcuts';
   import { openPdfDialog } from '$lib/app/openPdfDialog';
   import { hitTestStrokes } from '$lib/tools/eraser';
@@ -51,6 +57,7 @@
   let stopBridge: (() => void) | null = null;
   let stopAutosave: (() => void) | null = null;
   let stopPresenterBridge: (() => void) | null = null;
+  let stopSidebarBridge: (() => void) | null = null;
 
   const pdfState = $derived($pdf);
   const meta = $derived<PdfMeta | null>(pdfState.meta);
@@ -78,6 +85,35 @@
   const zenState = $derived($zenStore);
   const isZen = $derived(zenState.active);
   const chromeHidden = $derived(isPresenter || isZen);
+  const sidebarDetached = $derived(sidebarState.detached);
+  const sidebarHidden = $derived(chromeHidden || sidebarDetached);
+
+  $effect(() => {
+    if (sidebarDetached && !stopSidebarBridge) {
+      stopSidebarBridge = startSidebarBridge('main');
+    } else if (!sidebarDetached && stopSidebarBridge) {
+      stopSidebarBridge();
+      stopSidebarBridge = null;
+    }
+  });
+
+  async function onSidebarDetachChange(detached: boolean): Promise<void> {
+    if (detached) {
+      try {
+        await openSidebarWindow();
+        sidebar.setDetached(true);
+      } catch (err) {
+        log('ipc', `open_sidebar_window failed ${String(err)}`);
+      }
+    } else {
+      try {
+        await closeSidebarWindow();
+      } catch (err) {
+        log('ipc', `close_sidebar_window failed ${String(err)}`);
+      }
+      sidebar.setDetached(false);
+    }
+  }
 
   let zenHintVisible = $state(false);
   $effect(() => {
@@ -376,11 +412,16 @@
     stopHydration = hydrateSidebarFromStorage();
     stopBridge = startToolBridge();
     let unlistenPresenterClose: (() => void) | null = null;
+    let unlistenSidebarClose: (() => void) | null = null;
     void onPresenterWindowClosed(() => presenter.setWindowOpen(false)).then((fn) => {
       unlistenPresenterClose = fn;
     });
+    void onSidebarWindowClosed(() => sidebar.setDetached(false)).then((fn) => {
+      unlistenSidebarClose = fn;
+    });
     return () => {
       unlistenPresenterClose?.();
+      unlistenSidebarClose?.();
     };
   });
 
@@ -389,6 +430,7 @@
     stopAutosave?.();
     stopHydration?.();
     stopPresenterBridge?.();
+    stopSidebarBridge?.();
   });
 </script>
 
@@ -396,16 +438,17 @@
 
 <main
   class="app"
-  class:pinned={sidebarState.pinned}
+  class:pinned={sidebarState.pinned && !sidebarDetached}
   class:presenter={isPresenter}
   class:zen={isZen}
+  class:sidebar-detached={sidebarDetached}
   class:has-thumbs={!chromeHidden && pages.length > 0}
   use:shortcuts
   tabindex="-1"
   role="application"
 >
-  {#if !chromeHidden}
-    <Sidebar />
+  {#if !sidebarHidden}
+    <Sidebar onDetachChange={onSidebarDetachChange} />
   {/if}
 
   <section class="main">

--- a/src/routes/sidebar-window/+page.svelte
+++ b/src/routes/sidebar-window/+page.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+  import { Sidebar } from '$lib/sidebar';
+  import { startSidebarBridge } from '$lib/app/sidebarBridge';
+  import { closeSidebarWindow } from '$lib/ipc/sidebar-window';
+  import { hydrateSidebarFromStorage } from '$lib/store/sidebar';
+  import { warn } from '$lib/log';
+
+  let stopBridge: (() => void) | null = null;
+  let stopHydration: (() => void) | null = null;
+
+  function onDetachChange(detached: boolean): void {
+    if (!detached) {
+      closeSidebarWindow().catch((err) => warn('ipc', 'close_sidebar_window failed', err));
+    }
+  }
+
+  onMount(() => {
+    stopHydration = hydrateSidebarFromStorage();
+    stopBridge = startSidebarBridge('detached');
+  });
+
+  onDestroy(() => {
+    stopBridge?.();
+    stopHydration?.();
+  });
+</script>
+
+<div class="drag-strip" data-tauri-drag-region></div>
+<main class="detached">
+  <Sidebar mode="detached" {onDetachChange} />
+</main>
+
+<style>
+  :global(html, body) {
+    margin: 0;
+    padding: 0;
+    height: 100%;
+    background: #1e1e1e;
+    color: #eee;
+    font-family: Inter, system-ui, sans-serif;
+    overflow: hidden;
+  }
+  .drag-strip {
+    height: 6px;
+    width: 100%;
+    background: #151515;
+    cursor: grab;
+  }
+  .detached {
+    height: calc(100vh - 6px);
+    overflow: auto;
+  }
+  .detached :global(.sidebar) {
+    height: 100%;
+  }
+</style>

--- a/tests/sidebar-bridge.test.ts
+++ b/tests/sidebar-bridge.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { get } from 'svelte/store';
+
+type Handler = (event: { payload: unknown }) => void;
+
+const invoke = vi.fn();
+const listeners = new Map<string, Set<Handler>>();
+
+const listen = vi.fn((name: string, handler: Handler) => {
+  const set = listeners.get(name) ?? new Set<Handler>();
+  set.add(handler);
+  listeners.set(name, set);
+  return Promise.resolve(() => set.delete(handler));
+});
+
+function dispatch(name: string, payload: unknown): void {
+  const set = listeners.get(name);
+  if (!set) return;
+  for (const h of set) h({ payload });
+}
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke }));
+vi.mock('@tauri-apps/api/event', () => ({ listen }));
+
+async function flush(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('sidebar detached window bridge', () => {
+  beforeEach(() => {
+    invoke.mockReset();
+    invoke.mockResolvedValue(undefined);
+    listeners.clear();
+    vi.resetModules();
+  });
+  afterEach(() => {
+    listeners.clear();
+  });
+
+  it('ipc wrappers invoke the correct commands', async () => {
+    const { openSidebarWindow, closeSidebarWindow, sidebarSync, sidebarSyncBack } =
+      await import('../src/lib/ipc/sidebar-window');
+
+    await openSidebarWindow();
+    expect(invoke).toHaveBeenCalledWith('open_sidebar_window');
+
+    invoke.mockClear();
+    await closeSidebarWindow();
+    expect(invoke).toHaveBeenCalledWith('close_sidebar_window');
+
+    invoke.mockClear();
+    await sidebarSync({ activeTool: 'pen' });
+    expect(invoke).toHaveBeenCalledWith('sidebar_sync', {
+      payload: { activeTool: 'pen' },
+    });
+
+    invoke.mockClear();
+    await sidebarSyncBack({ activeTool: 'line' });
+    expect(invoke).toHaveBeenCalledWith('sidebar_sync_back', {
+      payload: { activeTool: 'line' },
+    });
+  });
+
+  it('main side pushes local changes via sidebar_sync', async () => {
+    const { startSidebarBridge } = await import('../src/lib/app/sidebarBridge');
+    const { sidebar } = await import('../src/lib/store/sidebar');
+
+    sidebar.reset();
+    const stop = startSidebarBridge('main');
+    await flush();
+
+    invoke.mockClear();
+    sidebar.setTool('highlighter');
+    await flush();
+
+    const syncCalls = invoke.mock.calls.filter((c) => c[0] === 'sidebar_sync');
+    expect(syncCalls.length).toBeGreaterThan(0);
+    const payload = syncCalls[syncCalls.length - 1][1] as { payload: { activeTool: string } };
+    expect(payload.payload.activeTool).toBe('highlighter');
+
+    stop();
+  });
+
+  it('applies remote snapshots and does not bounce them back', async () => {
+    const { startSidebarBridge } = await import('../src/lib/app/sidebarBridge');
+    const { sidebar } = await import('../src/lib/store/sidebar');
+    const { SIDEBAR_SYNC_EVENT } = await import('../src/lib/ipc/sidebar-window');
+
+    sidebar.reset();
+    const stop = startSidebarBridge('main');
+    await flush();
+
+    invoke.mockClear();
+    dispatch(SIDEBAR_SYNC_EVENT, {
+      pinned: true,
+      activeTool: 'line',
+      toolStyles: get(sidebar).toolStyles,
+      palettes: get(sidebar).palettes,
+      activeColor: '#abcdef',
+      laser: get(sidebar).laser,
+      tempInkFadeMs: get(sidebar).tempInkFadeMs,
+      presets: [],
+    });
+    await flush();
+
+    expect(get(sidebar).activeTool).toBe('line');
+    expect(get(sidebar).activeColor).toBe('#abcdef');
+    const echoes = invoke.mock.calls.filter((c) => c[0] === 'sidebar_sync');
+    expect(echoes.length).toBe(0);
+
+    stop();
+  });
+
+  it('preserves window-local fields (detached, floatingPos) on remote apply', async () => {
+    const { sidebar } = await import('../src/lib/store/sidebar');
+    sidebar.reset();
+    sidebar.setDetached(true);
+    sidebar.setFloatingPos({ x: 50, y: 50 });
+
+    sidebar.applyRemote({ activeTool: 'eraser', activeColor: '#123456' });
+
+    const s = get(sidebar);
+    expect(s.detached).toBe(true);
+    expect(s.floatingPos).toEqual({ x: 50, y: 50 });
+    expect(s.activeTool).toBe('eraser');
+    expect(s.activeColor).toBe('#123456');
+  });
+
+  it('syncableEqual ignores non-syncable fields', async () => {
+    const { pickSyncable, syncableEqual, sidebar } = await import('../src/lib/store/sidebar');
+    sidebar.reset();
+    const a = pickSyncable(get(sidebar));
+    sidebar.setDetached(true);
+    sidebar.setFloatingPos({ x: 1, y: 2 });
+    const b = pickSyncable(get(sidebar));
+    expect(syncableEqual(a, b)).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #38. Closes #28.

## Summary
- New Tauri `open_sidebar_window` / `close_sidebar_window` commands opening a decoration-less `WebviewWindow` (~260×700) at `/sidebar-window` with a `data-tauri-drag-region` strip.
- Bidirectional IPC sync (`sidebar-sync` / `sidebar-sync-back`) with `lastSeen` echo suppression and coalesced trailing pushes — modeled on the presenter bridge from #82.
- New detach/dock button on the sidebar; `detached` field on the sidebar store; main window hides its inline sidebar when detached and restores on dock.
- OS-level close (window X) emits `sidebar-window-closed`; main listens and clears `detached` automatically.
- `detached` and `floatingPos` are intentionally not synced (window-local chrome state).

## Testing
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`: clean
- `cargo test --lib`: 31 pass (3 new `sidebar_window` tests)
- `pnpm lint`, `pnpm test`: 348/348 pass (5 new bridge tests)
- Note: end-to-end drag behavior requires a real Tauri window; unit/integration coverage only here.