### PR TITLE
chore(release): v0.1.0-rc.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eldraw",
-  "version": "0.1.0-rc.7",
+  "version": "0.1.0-rc.8",
   "description": "PDF annotation tool for live math teaching",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1019,7 +1019,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "eldraw"
-version = "0.1.0-rc.7"
+version = "0.1.0-rc.8"
 dependencies = [
  "image",
  "lru",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eldraw"
-version = "0.1.0-rc.7"
+version = "0.1.0-rc.8"
 description = "PDF annotation tool for live math teaching"
 authors = ["Adam"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "eldraw",
-  "version": "0.1.0-rc.7",
+  "version": "0.1.0-rc.8",
   "identifier": "com.adamkadaban.eldraw",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Bump to 0.1.0-rc.8.

Includes every feature from this sprint:
- #15 protractor angle-mark stamping (rc.7)
- #19 in-window presenter mode (earlier)
- #20 pdfium thumbnails + LRU cache
- #21 multi-monitor presenter WebviewWindow
- #27 CI caching + release binary strip
- #28 detachable sidebar (both parts)
- #36 LRU page cache + prefetch + raw RGBA render wire format
- #38 detached sidebar as second WebviewWindow
- #39 line tool 15° Shift snap
- #49 graph axes + grid + tick labels
- #57 Ctrl+K command palette
- #59 customizable keyboard shortcuts
- #60 shortcut suppression in text inputs

All green: `cargo fmt`, `cargo clippy -- -D warnings`, `cargo test`, `pnpm lint`, `pnpm test`.