### PR TITLE
feat(ink): per-tool smoothing slider (#86)

### DIFF
--- a/src/lib/canvas/CanvasStack.svelte
+++ b/src/lib/canvas/CanvasStack.svelte
@@ -29,6 +29,9 @@
     laserRadius?: number;
     tempInkStyle?: StrokeStyle;
     tempInkFadeMs?: number;
+    penStreamline?: number;
+    highlighterStreamline?: number;
+    tempInkStreamline?: number;
     rulerSnap?: RulerState | null;
     rulerSnapThresholdPx?: number;
     overlay?: Snippet;
@@ -49,6 +52,9 @@
     laserRadius = 6,
     tempInkStyle = { color: '#000000', width: 2, dash: 'solid', opacity: 1 },
     tempInkFadeMs = 3000,
+    penStreamline,
+    highlighterStreamline,
+    tempInkStreamline,
     rulerSnap = null,
     rulerSnapThresholdPx,
     overlay,
@@ -61,7 +67,7 @@
 
 <div class="stack" style="width: {width}px; height: {height}px;">
   <div class="layer layer-highlight">
-    <HighlightLayer {strokes} {width} {height} {ptToPx} />
+    <HighlightLayer {strokes} {width} {height} {ptToPx} streamline={highlighterStreamline} />
   </div>
 
   <div class="layer layer-objects">
@@ -69,7 +75,7 @@
   </div>
 
   <div class="layer layer-ink">
-    <InkLayer {strokes} {width} {height} {ptToPx} />
+    <InkLayer {strokes} {width} {height} {ptToPx} streamline={penStreamline} />
   </div>
 
   <div class="layer layer-live">
@@ -79,6 +85,8 @@
       {ptToPx}
       {rulerSnap}
       {rulerSnapThresholdPx}
+      {penStreamline}
+      {highlighterStreamline}
       {oncommit}
       {onerase}
       {ongraph}
@@ -97,6 +105,7 @@
       active={activeTool === 'temp-ink'}
       style={tempInkStyle}
       fadeMs={tempInkFadeMs}
+      streamline={tempInkStreamline}
     />
   </div>
 

--- a/src/lib/canvas/HighlightLayer.svelte
+++ b/src/lib/canvas/HighlightLayer.svelte
@@ -8,9 +8,10 @@
     width: number;
     height: number;
     ptToPx: number;
+    streamline?: number;
   }
 
-  let { strokes, width, height, ptToPx }: Props = $props();
+  let { strokes, width, height, ptToPx, streamline }: Props = $props();
 
   let canvas: HTMLCanvasElement;
 
@@ -26,7 +27,7 @@
         ...s,
         style: { ...s.style, opacity: Math.min(s.style.opacity, 0.3) },
       };
-      drawStroke(ctx, faded, { ptToPx });
+      drawStroke(ctx, faded, { ptToPx, streamline });
     }
   }
 
@@ -37,6 +38,7 @@
     void width;
     void height;
     void ptToPx;
+    void streamline;
     redraw();
   });
 </script>

--- a/src/lib/canvas/InkLayer.svelte
+++ b/src/lib/canvas/InkLayer.svelte
@@ -8,9 +8,10 @@
     width: number;
     height: number;
     ptToPx: number;
+    streamline?: number;
   }
 
-  let { strokes, width, height, ptToPx }: Props = $props();
+  let { strokes, width, height, ptToPx, streamline }: Props = $props();
 
   let canvas: HTMLCanvasElement;
 
@@ -21,7 +22,7 @@
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     ctx.globalCompositeOperation = 'source-over';
     for (const s of strokes) {
-      if (s.tool === 'pen') drawStroke(ctx, s, { ptToPx });
+      if (s.tool === 'pen') drawStroke(ctx, s, { ptToPx, streamline });
     }
   }
 
@@ -32,6 +33,7 @@
     void width;
     void height;
     void ptToPx;
+    void streamline;
     redraw();
   });
 </script>

--- a/src/lib/canvas/LiveLayer.svelte
+++ b/src/lib/canvas/LiveLayer.svelte
@@ -14,6 +14,8 @@
     ptToPx: number;
     rulerSnap?: RulerState | null;
     rulerSnapThresholdPx?: number;
+    penStreamline?: number;
+    highlighterStreamline?: number;
     oncommit?: (stroke: StrokeObject) => void;
     onerase?: (at: { x: number; y: number }) => void;
     ongraph?: (bounds: { x: number; y: number; w: number; h: number }) => void;
@@ -25,6 +27,8 @@
     ptToPx,
     rulerSnap = null,
     rulerSnapThresholdPx = 12,
+    penStreamline,
+    highlighterStreamline,
     oncommit,
     onerase,
     ongraph,
@@ -106,10 +110,10 @@
     clear();
     if (currentTool === 'highlighter') {
       c.globalCompositeOperation = 'multiply';
-      drawLiveStroke(c, points, currentStyle, 'highlighter', ptToPx);
+      drawLiveStroke(c, points, currentStyle, 'highlighter', ptToPx, highlighterStreamline);
     } else if (currentTool === 'pen') {
       c.globalCompositeOperation = 'source-over';
-      drawLiveStroke(c, points, currentStyle, 'pen', ptToPx);
+      drawLiveStroke(c, points, currentStyle, 'pen', ptToPx, penStreamline);
     } else if (currentTool === 'graph' && graphStart && graphEnd) {
       drawGraphRect(c);
     }

--- a/src/lib/canvas/TempInkLayer.svelte
+++ b/src/lib/canvas/TempInkLayer.svelte
@@ -16,9 +16,10 @@
     active: boolean;
     style: StrokeStyle;
     fadeMs: number;
+    streamline?: number;
   }
 
-  let { width, height, ptToPx, active, style, fadeMs }: Props = $props();
+  let { width, height, ptToPx, active, style, fadeMs, streamline }: Props = $props();
 
   let canvas: HTMLCanvasElement;
   let strokes: TempInkStroke[] = [];
@@ -50,14 +51,14 @@
       const a = fadeOpacity(s, now);
       if (a <= 0) continue;
       c.globalAlpha = a * s.style.opacity;
-      drawLiveStroke(c, s.points, { ...s.style, opacity: 1 }, 'pen', ptToPx);
+      drawLiveStroke(c, s.points, { ...s.style, opacity: 1 }, 'pen', ptToPx, streamline);
     }
     c.restore();
 
     if (livePoints.length > 0) {
       c.save();
       c.globalAlpha = liveStyle.opacity;
-      drawLiveStroke(c, livePoints, { ...liveStyle, opacity: 1 }, 'pen', ptToPx);
+      drawLiveStroke(c, livePoints, { ...liveStyle, opacity: 1 }, 'pen', ptToPx, streamline);
       c.restore();
     }
 

--- a/src/lib/canvas/strokeRenderer.ts
+++ b/src/lib/canvas/strokeRenderer.ts
@@ -4,6 +4,8 @@ import type { Point, StrokeObject } from '$lib/types';
 export interface StrokeRenderOptions {
   ptToPx: number;
   simulatePressure?: boolean;
+  /** perfect-freehand `streamline` in [0, 1). Defaults to 0.5. */
+  streamline?: number;
 }
 
 function toSvgPath(points: number[][]): string {
@@ -58,7 +60,7 @@ export function drawStroke(
           size: widthPx * 2,
           thinning: 0.6,
           smoothing: 0.5,
-          streamline: 0.5,
+          streamline: opts.streamline ?? 0.5,
           simulatePressure: opts.simulatePressure ?? false,
           last: true,
         })
@@ -102,6 +104,7 @@ export function drawLiveStroke(
   style: StrokeObject['style'],
   tool: 'pen' | 'highlighter',
   ptToPx: number,
+  streamline?: number,
 ): void {
   if (points.length === 0) return;
   const temp: StrokeObject = {
@@ -112,5 +115,5 @@ export function drawLiveStroke(
     style,
     points,
   };
-  drawStroke(ctx, temp, { ptToPx, simulatePressure: false });
+  drawStroke(ctx, temp, { ptToPx, simulatePressure: false, streamline });
 }

--- a/src/lib/sidebar/Sidebar.svelte
+++ b/src/lib/sidebar/Sidebar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-  import { currentStyle, sidebar, styleKeyFor } from '$lib/store/sidebar';
+  import { currentStyle, sidebar, styleKeyFor, type SmoothingTool } from '$lib/store/sidebar';
   import type { DashStyle, StrokeStyle, ToolKind } from '$lib/types';
+  import type { SidebarState } from '$lib/store/sidebar';
   import ColorPalette from './ColorPalette.svelte';
   import WidthPicker from './WidthPicker.svelte';
   import DashStyleToggle from './DashStyleToggle.svelte';
@@ -55,6 +56,10 @@
 
   const sidebarState = $derived($sidebar);
   const style = $derived($currentStyle);
+  const activeSmoothingTool = $derived(smoothingToolFor(sidebarState.activeTool));
+  const smoothing = $derived(
+    activeSmoothingTool ? smoothingValue(sidebarState, activeSmoothingTool) : 0,
+  );
 
   function pickTool(tool: ToolKind, disabled: boolean | undefined) {
     if (disabled) return;
@@ -72,6 +77,24 @@
   function onTempInkFade(e: Event) {
     const v = Number((e.target as HTMLInputElement).value);
     if (Number.isFinite(v)) sidebar.setTempInkFadeMs(v);
+  }
+
+  function smoothingToolFor(tool: ToolKind): SmoothingTool | null {
+    if (tool === 'pen' || tool === 'highlighter' || tool === 'temp-ink') return tool;
+    return null;
+  }
+
+  function smoothingValue(state: SidebarState, tool: SmoothingTool): number {
+    if (tool === 'pen') return state.smoothingPen;
+    if (tool === 'highlighter') return state.smoothingHighlighter;
+    return state.smoothingTempInk;
+  }
+
+  function onSmoothing(e: Event) {
+    const tool = smoothingToolFor(sidebarState.activeTool);
+    if (!tool) return;
+    const v = Number((e.target as HTMLInputElement).value);
+    if (Number.isFinite(v)) sidebar.setSmoothing(tool, v);
   }
 
   function onColor(color: string) {
@@ -299,6 +322,24 @@
     <DashStyleToggle value={style.dash} onChange={onDash} />
   </section>
 
+  {#if activeSmoothingTool}
+    <section class="section smoothing" aria-label="Smoothing">
+      <h3 class="section-title">Smoothing</h3>
+      <div class="row">
+        <input
+          type="range"
+          min="0"
+          max="100"
+          step="1"
+          value={smoothing}
+          oninput={onSmoothing}
+          aria-label="Smoothing amount"
+        />
+        <span class="value">{smoothing}%</span>
+      </div>
+    </section>
+  {/if}
+
   <section class="section" aria-label="Presets">
     <ToolPresets
       presets={sidebarState.presets}
@@ -477,6 +518,20 @@
   .value {
     font-size: 11px;
     color: #aaa;
+  }
+  .smoothing .row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .smoothing input[type='range'] {
+    flex: 1;
+    min-width: 0;
+  }
+  .smoothing .value {
+    min-width: 36px;
+    text-align: right;
+    font-variant-numeric: tabular-nums;
   }
   input[type='number'] {
     background: #1b1b1b;

--- a/src/lib/store/sidebar.ts
+++ b/src/lib/store/sidebar.ts
@@ -4,7 +4,24 @@ import { clampFadeMs, DEFAULT_TEMP_INK_FADE_MS } from '$lib/tools/tempInk';
 
 export type StyledTool = 'pen' | 'highlighter' | 'line';
 
+export type SmoothingTool = 'pen' | 'highlighter' | 'temp-ink';
+
 export const MAX_PRESETS = 9;
+
+export const MAX_STREAMLINE = 0.99;
+export const DEFAULT_SMOOTHING_PEN = 50;
+export const DEFAULT_SMOOTHING_HIGHLIGHTER = 50;
+export const DEFAULT_SMOOTHING_TEMP_INK = 30;
+
+/**
+ * Map a 0..100 smoothing slider value to perfect-freehand's `streamline`
+ * parameter in [0, 0.99]. 0 disables smoothing; 100 is the practical max
+ * (perfect-freehand saturates at 1.0 which stalls the stroke).
+ */
+export function streamlineFromSmoothing(value: number): number {
+  const clamped = Math.max(0, Math.min(100, Number.isFinite(value) ? value : 0));
+  return (clamped / 100) * MAX_STREAMLINE;
+}
 
 export interface LaserStyle {
   color: string;
@@ -46,6 +63,9 @@ export interface SidebarState {
   activeColor: string;
   laser: LaserStyle;
   tempInkFadeMs: number;
+  smoothingPen: number;
+  smoothingHighlighter: number;
+  smoothingTempInk: number;
   presets: ToolPreset[];
   floatingPos: { x: number; y: number } | null;
 }
@@ -67,6 +87,9 @@ function initialState(): SidebarState {
     activeColor: '#000000',
     laser: { ...DEFAULT_LASER_STYLE },
     tempInkFadeMs: DEFAULT_TEMP_INK_FADE_MS,
+    smoothingPen: DEFAULT_SMOOTHING_PEN,
+    smoothingHighlighter: DEFAULT_SMOOTHING_HIGHLIGHTER,
+    smoothingTempInk: DEFAULT_SMOOTHING_TEMP_INK,
     presets: [],
     floatingPos: null,
   };
@@ -229,6 +252,13 @@ function createSidebarStore() {
         if (snapshot.activeColor !== undefined) next.activeColor = snapshot.activeColor;
         if (snapshot.laser !== undefined) next.laser = snapshot.laser;
         if (snapshot.tempInkFadeMs !== undefined) next.tempInkFadeMs = snapshot.tempInkFadeMs;
+        if (snapshot.smoothingPen !== undefined) next.smoothingPen = snapshot.smoothingPen;
+        if (snapshot.smoothingHighlighter !== undefined) {
+          next.smoothingHighlighter = snapshot.smoothingHighlighter;
+        }
+        if (snapshot.smoothingTempInk !== undefined) {
+          next.smoothingTempInk = snapshot.smoothingTempInk;
+        }
         if (snapshot.presets !== undefined) next.presets = snapshot.presets;
         return next;
       });
@@ -261,6 +291,15 @@ function createSidebarStore() {
 
     setTempInkFadeMs(ms: number) {
       update((s) => ({ ...s, tempInkFadeMs: clampFadeMs(ms) }));
+    },
+
+    setSmoothing(tool: SmoothingTool, value: number) {
+      const clamped = clamp(value, 0, 100);
+      update((s) => {
+        if (tool === 'pen') return { ...s, smoothingPen: clamped };
+        if (tool === 'highlighter') return { ...s, smoothingHighlighter: clamped };
+        return { ...s, smoothingTempInk: clamped };
+      });
     },
 
     capturePreset(): ToolPreset | null {
@@ -438,6 +477,9 @@ export type SyncableSidebarState = Pick<
   | 'activeColor'
   | 'laser'
   | 'tempInkFadeMs'
+  | 'smoothingPen'
+  | 'smoothingHighlighter'
+  | 'smoothingTempInk'
   | 'presets'
 >;
 
@@ -450,6 +492,9 @@ export function pickSyncable(state: SidebarState): SyncableSidebarState {
     activeColor: state.activeColor,
     laser: state.laser,
     tempInkFadeMs: state.tempInkFadeMs,
+    smoothingPen: state.smoothingPen,
+    smoothingHighlighter: state.smoothingHighlighter,
+    smoothingTempInk: state.smoothingTempInk,
     presets: state.presets,
   };
 }

--- a/src/lib/store/sidebar.ts
+++ b/src/lib/store/sidebar.ts
@@ -252,12 +252,17 @@ function createSidebarStore() {
         if (snapshot.activeColor !== undefined) next.activeColor = snapshot.activeColor;
         if (snapshot.laser !== undefined) next.laser = snapshot.laser;
         if (snapshot.tempInkFadeMs !== undefined) next.tempInkFadeMs = snapshot.tempInkFadeMs;
-        if (snapshot.smoothingPen !== undefined) next.smoothingPen = snapshot.smoothingPen;
-        if (snapshot.smoothingHighlighter !== undefined) {
-          next.smoothingHighlighter = snapshot.smoothingHighlighter;
+        if (snapshot.smoothingPen !== undefined && Number.isFinite(snapshot.smoothingPen)) {
+          next.smoothingPen = clamp(snapshot.smoothingPen, 0, 100);
         }
-        if (snapshot.smoothingTempInk !== undefined) {
-          next.smoothingTempInk = snapshot.smoothingTempInk;
+        if (
+          snapshot.smoothingHighlighter !== undefined &&
+          Number.isFinite(snapshot.smoothingHighlighter)
+        ) {
+          next.smoothingHighlighter = clamp(snapshot.smoothingHighlighter, 0, 100);
+        }
+        if (snapshot.smoothingTempInk !== undefined && Number.isFinite(snapshot.smoothingTempInk)) {
+          next.smoothingTempInk = clamp(snapshot.smoothingTempInk, 0, 100);
         }
         if (snapshot.presets !== undefined) next.presets = snapshot.presets;
         return next;
@@ -347,6 +352,7 @@ export const sidebar = createSidebarStore();
 
 const PRESETS_STORAGE_KEY = 'eldraw.presets.v1';
 const FLOATING_POS_STORAGE_KEY = 'eldraw.sidebar-pos.v1';
+const SMOOTHING_STORAGE_KEY = 'eldraw.smoothing.v1';
 
 const VALID_TOOLS: ReadonlySet<ToolKind> = new Set<ToolKind>([
   'pen',
@@ -427,6 +433,37 @@ function loadPersistedFloatingPos(): { x: number; y: number } | null {
   }
 }
 
+interface PersistedSmoothing {
+  pen: number;
+  highlighter: number;
+  tempInk: number;
+}
+
+function loadPersistedSmoothing(): PersistedSmoothing | null {
+  if (typeof localStorage === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(SMOOTHING_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return null;
+    const p = parsed as Record<string, unknown>;
+    const pen = typeof p.pen === 'number' ? p.pen : null;
+    const highlighter = typeof p.highlighter === 'number' ? p.highlighter : null;
+    const tempInk = typeof p.tempInk === 'number' ? p.tempInk : null;
+    if (pen === null || highlighter === null || tempInk === null) return null;
+    if (!Number.isFinite(pen) || !Number.isFinite(highlighter) || !Number.isFinite(tempInk)) {
+      return null;
+    }
+    return {
+      pen: clamp(pen, 0, 100),
+      highlighter: clamp(highlighter, 0, 100),
+      tempInk: clamp(tempInk, 0, 100),
+    };
+  } catch {
+    return null;
+  }
+}
+
 let hydrated = false;
 let hydrationUnsubscribe: (() => void) | null = null;
 
@@ -440,6 +477,13 @@ export function hydrateSidebarFromStorage(): () => void {
   const floatingPos = loadPersistedFloatingPos();
   if (floatingPos) sidebar.setFloatingPos(floatingPos);
 
+  const smoothing = loadPersistedSmoothing();
+  if (smoothing) {
+    sidebar.setSmoothing('pen', smoothing.pen);
+    sidebar.setSmoothing('highlighter', smoothing.highlighter);
+    sidebar.setSmoothing('temp-ink', smoothing.tempInk);
+  }
+
   if (typeof localStorage === 'undefined') {
     hydrationUnsubscribe = () => undefined;
     return hydrationUnsubscribe;
@@ -448,6 +492,14 @@ export function hydrateSidebarFromStorage(): () => void {
   const unsubscribe = sidebar.subscribe((s) => {
     try {
       localStorage.setItem(PRESETS_STORAGE_KEY, JSON.stringify(s.presets));
+      localStorage.setItem(
+        SMOOTHING_STORAGE_KEY,
+        JSON.stringify({
+          pen: s.smoothingPen,
+          highlighter: s.smoothingHighlighter,
+          tempInk: s.smoothingTempInk,
+        }),
+      );
     } catch {
       // storage full or unavailable; ignore
     }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,7 +15,7 @@
   import { openAndLoadPdf } from '$lib/ipc/pdf';
   import { loadSidecar } from '$lib/ipc';
   import { pdf, clearError } from '$lib/store/pdf';
-  import { sidebar, hydrateSidebarFromStorage } from '$lib/store/sidebar';
+  import { sidebar, hydrateSidebarFromStorage, streamlineFromSmoothing } from '$lib/store/sidebar';
   import { currentDocument, documentStore, pdfPageIndexAt } from '$lib/store/document';
   import { startAutosave } from '$lib/store/autosave';
   import { viewport, viewportStore, MIN_SCALE, MAX_SCALE } from '$lib/store/viewport';
@@ -533,6 +533,9 @@
               laserRadius={sidebarState.laser.radius}
               tempInkStyle={sidebarState.toolStyles.pen}
               tempInkFadeMs={sidebarState.tempInkFadeMs}
+              penStreamline={streamlineFromSmoothing(sidebarState.smoothingPen)}
+              highlighterStreamline={streamlineFromSmoothing(sidebarState.smoothingHighlighter)}
+              tempInkStreamline={streamlineFromSmoothing(sidebarState.smoothingTempInk)}
               rulerSnap={rulerSnapState}
               oncommit={onCommitStroke}
               onerase={onEraseAt}

--- a/tests/sidebar-bridge.test.ts
+++ b/tests/sidebar-bridge.test.ts
@@ -101,6 +101,9 @@ describe('sidebar detached window bridge', () => {
       activeColor: '#abcdef',
       laser: get(sidebar).laser,
       tempInkFadeMs: get(sidebar).tempInkFadeMs,
+      smoothingPen: get(sidebar).smoothingPen,
+      smoothingHighlighter: get(sidebar).smoothingHighlighter,
+      smoothingTempInk: get(sidebar).smoothingTempInk,
       presets: [],
     });
     await flush();

--- a/tests/sidebar-smoothing-persist.test.ts
+++ b/tests/sidebar-smoothing-persist.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+function makeLocalStorageStub() {
+  const store = new Map<string, string>();
+  return {
+    store,
+    impl: {
+      getItem: (k: string) => (store.has(k) ? (store.get(k) ?? null) : null),
+      setItem: (k: string, v: string) => {
+        store.set(k, v);
+      },
+      removeItem: (k: string) => {
+        store.delete(k);
+      },
+      clear: () => store.clear(),
+      key: (i: number) => Array.from(store.keys())[i] ?? null,
+      get length() {
+        return store.size;
+      },
+    } as Storage,
+  };
+}
+
+describe('sidebar smoothing persistence', () => {
+  let stub: ReturnType<typeof makeLocalStorageStub>;
+
+  beforeEach(() => {
+    stub = makeLocalStorageStub();
+    vi.stubGlobal('localStorage', stub.impl);
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('writes smoothing values to localStorage on change', async () => {
+    const mod = await import('$lib/store/sidebar');
+    const stop = mod.hydrateSidebarFromStorage();
+
+    mod.sidebar.setSmoothing('pen', 73);
+    mod.sidebar.setSmoothing('highlighter', 22);
+    mod.sidebar.setSmoothing('temp-ink', 4);
+
+    const raw = stub.store.get('eldraw.smoothing.v1');
+    expect(raw).toBeDefined();
+    expect(JSON.parse(raw as string)).toEqual({ pen: 73, highlighter: 22, tempInk: 4 });
+
+    stop();
+  });
+
+  it('restores smoothing values from localStorage on hydrate', async () => {
+    stub.store.set('eldraw.smoothing.v1', JSON.stringify({ pen: 81, highlighter: 17, tempInk: 9 }));
+    const mod = await import('$lib/store/sidebar');
+    const stop = mod.hydrateSidebarFromStorage();
+
+    const s = mod.sidebar.snapshot();
+    expect(s.smoothingPen).toBe(81);
+    expect(s.smoothingHighlighter).toBe(17);
+    expect(s.smoothingTempInk).toBe(9);
+
+    stop();
+  });
+
+  it('clamps persisted out-of-range values on load', async () => {
+    stub.store.set(
+      'eldraw.smoothing.v1',
+      JSON.stringify({ pen: -50, highlighter: 500, tempInk: 42 }),
+    );
+    const mod = await import('$lib/store/sidebar');
+    const stop = mod.hydrateSidebarFromStorage();
+
+    const s = mod.sidebar.snapshot();
+    expect(s.smoothingPen).toBe(0);
+    expect(s.smoothingHighlighter).toBe(100);
+    expect(s.smoothingTempInk).toBe(42);
+
+    stop();
+  });
+
+  it('ignores malformed persisted smoothing payload', async () => {
+    stub.store.set('eldraw.smoothing.v1', '{"pen":"nope"}');
+    const mod = await import('$lib/store/sidebar');
+    const stop = mod.hydrateSidebarFromStorage();
+
+    const s = mod.sidebar.snapshot();
+    expect(s.smoothingPen).toBe(mod.DEFAULT_SMOOTHING_PEN);
+    expect(s.smoothingHighlighter).toBe(mod.DEFAULT_SMOOTHING_HIGHLIGHTER);
+    expect(s.smoothingTempInk).toBe(mod.DEFAULT_SMOOTHING_TEMP_INK);
+
+    stop();
+  });
+});

--- a/tests/sidebar-store.test.ts
+++ b/tests/sidebar-store.test.ts
@@ -217,4 +217,23 @@ describe('sidebar store', () => {
     expect(after.smoothingHighlighter).toBe(DEFAULT_SMOOTHING_HIGHLIGHTER);
     expect(after.smoothingTempInk).toBe(DEFAULT_SMOOTHING_TEMP_INK);
   });
+
+  it('applyRemote clamps smoothing values and rejects non-finite', () => {
+    sidebar.applyRemote({ smoothingPen: -50, smoothingHighlighter: 500, smoothingTempInk: 42 });
+    let s = sidebar.snapshot();
+    expect(s.smoothingPen).toBe(0);
+    expect(s.smoothingHighlighter).toBe(100);
+    expect(s.smoothingTempInk).toBe(42);
+
+    sidebar.reset();
+    sidebar.applyRemote({
+      smoothingPen: Number.NaN,
+      smoothingHighlighter: Number.POSITIVE_INFINITY,
+      smoothingTempInk: Number.NEGATIVE_INFINITY,
+    });
+    s = sidebar.snapshot();
+    expect(s.smoothingPen).toBe(DEFAULT_SMOOTHING_PEN);
+    expect(s.smoothingHighlighter).toBe(DEFAULT_SMOOTHING_HIGHLIGHTER);
+    expect(s.smoothingTempInk).toBe(DEFAULT_SMOOTHING_TEMP_INK);
+  });
 });

--- a/tests/sidebar-store.test.ts
+++ b/tests/sidebar-store.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { get } from 'svelte/store';
-import { currentStyle, PRESET_COLORS, sidebar } from '$lib/store/sidebar';
+import {
+  currentStyle,
+  PRESET_COLORS,
+  sidebar,
+  streamlineFromSmoothing,
+  pickSyncable,
+  DEFAULT_SMOOTHING_PEN,
+  DEFAULT_SMOOTHING_HIGHLIGHTER,
+  DEFAULT_SMOOTHING_TEMP_INK,
+} from '$lib/store/sidebar';
 
 describe('sidebar store', () => {
   beforeEach(() => sidebar.reset());
@@ -149,5 +158,63 @@ describe('sidebar store', () => {
     sidebar.setFloatingPos({ x: 1, y: 2 });
     sidebar.setFloatingPos(null);
     expect(sidebar.snapshot().floatingPos).toBeNull();
+  });
+
+  it('smoothing defaults: 50/50/30', () => {
+    const s = sidebar.snapshot();
+    expect(s.smoothingPen).toBe(DEFAULT_SMOOTHING_PEN);
+    expect(s.smoothingHighlighter).toBe(DEFAULT_SMOOTHING_HIGHLIGHTER);
+    expect(s.smoothingTempInk).toBe(DEFAULT_SMOOTHING_TEMP_INK);
+    expect(DEFAULT_SMOOTHING_PEN).toBe(50);
+    expect(DEFAULT_SMOOTHING_HIGHLIGHTER).toBe(50);
+    expect(DEFAULT_SMOOTHING_TEMP_INK).toBe(30);
+  });
+
+  it('setSmoothing persists per-tool and clamps to 0..100', () => {
+    sidebar.setSmoothing('pen', 80);
+    sidebar.setSmoothing('highlighter', 10);
+    sidebar.setSmoothing('temp-ink', 65);
+    let s = sidebar.snapshot();
+    expect(s.smoothingPen).toBe(80);
+    expect(s.smoothingHighlighter).toBe(10);
+    expect(s.smoothingTempInk).toBe(65);
+
+    sidebar.setSmoothing('pen', -20);
+    sidebar.setSmoothing('highlighter', 150);
+    sidebar.setSmoothing('temp-ink', Number.NaN);
+    s = sidebar.snapshot();
+    expect(s.smoothingPen).toBe(0);
+    expect(s.smoothingHighlighter).toBe(100);
+    expect(s.smoothingTempInk).toBe(0);
+  });
+
+  it('streamlineFromSmoothing maps 0 -> 0 and 100 -> 0.99', () => {
+    expect(streamlineFromSmoothing(0)).toBe(0);
+    expect(streamlineFromSmoothing(100)).toBeCloseTo(0.99, 10);
+    expect(streamlineFromSmoothing(50)).toBeCloseTo(0.495, 10);
+    expect(streamlineFromSmoothing(-5)).toBe(0);
+    expect(streamlineFromSmoothing(250)).toBeCloseTo(0.99, 10);
+    expect(streamlineFromSmoothing(Number.NaN)).toBe(0);
+  });
+
+  it('pickSyncable includes per-tool smoothing for cross-window sync', () => {
+    sidebar.setSmoothing('pen', 77);
+    sidebar.setSmoothing('highlighter', 22);
+    sidebar.setSmoothing('temp-ink', 4);
+    const sync = pickSyncable(sidebar.snapshot());
+    expect(sync.smoothingPen).toBe(77);
+    expect(sync.smoothingHighlighter).toBe(22);
+    expect(sync.smoothingTempInk).toBe(4);
+  });
+
+  it('applyRemote round-trips smoothing values', () => {
+    sidebar.setSmoothing('pen', 11);
+    const snap = pickSyncable(sidebar.snapshot());
+    sidebar.reset();
+    sidebar.applyRemote(snap);
+    const after = sidebar.snapshot();
+    expect(after.smoothingPen).toBe(11);
+    expect(after.smoothingHighlighter).toBe(DEFAULT_SMOOTHING_HIGHLIGHTER);
+    expect(after.smoothingTempInk).toBe(DEFAULT_SMOOTHING_TEMP_INK);
   });
 });

--- a/tests/stroke-renderer-smoothing.test.ts
+++ b/tests/stroke-renderer-smoothing.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { StrokeObject } from '$lib/types';
+import { streamlineFromSmoothing } from '$lib/store/sidebar';
+
+type StrokeOptions = { streamline?: number };
+const getStroke = vi.fn<(points: number[][], opts: StrokeOptions) => number[][]>(() => [
+  [0, 0],
+  [1, 1],
+]);
+
+vi.mock('perfect-freehand', () => ({
+  getStroke: (points: number[][], opts: StrokeOptions) => getStroke(points, opts),
+}));
+
+class FakePath2D {}
+(globalThis as unknown as { Path2D: typeof FakePath2D }).Path2D = FakePath2D;
+
+function makeCtx(): CanvasRenderingContext2D {
+  const noop = () => undefined;
+  return {
+    save: noop,
+    restore: noop,
+    fill: noop,
+    stroke: noop,
+    beginPath: noop,
+    moveTo: noop,
+    lineTo: noop,
+    arc: noop,
+    setLineDash: noop,
+    globalAlpha: 1,
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 0,
+    lineCap: 'round',
+    lineJoin: 'round',
+    globalCompositeOperation: 'source-over',
+  } as unknown as CanvasRenderingContext2D;
+}
+
+function stroke(): StrokeObject {
+  return {
+    id: 's',
+    createdAt: 0,
+    type: 'stroke',
+    tool: 'pen',
+    style: { color: '#000', width: 2, dash: 'solid', opacity: 1 },
+    points: [
+      { x: 0, y: 0, pressure: 0.5, t: 0 },
+      { x: 10, y: 10, pressure: 0.5, t: 16 },
+    ],
+  };
+}
+
+describe('strokeRenderer streamline wiring', () => {
+  beforeEach(() => getStroke.mockClear());
+
+  it('defaults streamline to 0.5 when not provided', async () => {
+    const { drawStroke } = await import('$lib/canvas/strokeRenderer');
+    drawStroke(makeCtx(), stroke(), { ptToPx: 1 });
+    expect(getStroke).toHaveBeenCalledTimes(1);
+    expect(getStroke.mock.calls[0][1]).toMatchObject({ streamline: 0.5 });
+  });
+
+  it('forwards explicit streamline option to perfect-freehand', async () => {
+    const { drawStroke } = await import('$lib/canvas/strokeRenderer');
+    drawStroke(makeCtx(), stroke(), { ptToPx: 1, streamline: 0.25 });
+    expect(getStroke.mock.calls[0][1]).toMatchObject({ streamline: 0.25 });
+  });
+
+  it('drawLiveStroke threads streamline through', async () => {
+    const { drawLiveStroke } = await import('$lib/canvas/strokeRenderer');
+    drawLiveStroke(
+      makeCtx(),
+      stroke().points,
+      stroke().style,
+      'pen',
+      1,
+      streamlineFromSmoothing(100),
+    );
+    expect(getStroke.mock.calls[0][1]).toMatchObject({ streamline: 0.99 });
+  });
+
+  it('slider 0 maps to streamline 0 at the renderer', async () => {
+    const { drawLiveStroke } = await import('$lib/canvas/strokeRenderer');
+    drawLiveStroke(
+      makeCtx(),
+      stroke().points,
+      stroke().style,
+      'pen',
+      1,
+      streamlineFromSmoothing(0),
+    );
+    expect(getStroke.mock.calls[0][1]).toMatchObject({ streamline: 0 });
+  });
+
+  it('slider 50 maps to streamline 0.495 at the renderer', async () => {
+    const { drawLiveStroke } = await import('$lib/canvas/strokeRenderer');
+    drawLiveStroke(
+      makeCtx(),
+      stroke().points,
+      stroke().style,
+      'pen',
+      1,
+      streamlineFromSmoothing(50),
+    );
+    expect(getStroke.mock.calls[0][1]).toMatchObject({ streamline: 0.495 });
+  });
+});

--- a/tests/stroke-renderer-smoothing.test.ts
+++ b/tests/stroke-renderer-smoothing.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { StrokeObject } from '$lib/types';
 import { streamlineFromSmoothing } from '$lib/store/sidebar';
 
@@ -13,7 +13,6 @@ vi.mock('perfect-freehand', () => ({
 }));
 
 class FakePath2D {}
-(globalThis as unknown as { Path2D: typeof FakePath2D }).Path2D = FakePath2D;
 
 function makeCtx(): CanvasRenderingContext2D {
   const noop = () => undefined;
@@ -52,7 +51,11 @@ function stroke(): StrokeObject {
 }
 
 describe('strokeRenderer streamline wiring', () => {
-  beforeEach(() => getStroke.mockClear());
+  beforeEach(() => {
+    getStroke.mockClear();
+    vi.stubGlobal('Path2D', FakePath2D);
+  });
+  afterEach(() => vi.unstubAllGlobals());
 
   it('defaults streamline to 0.5 when not provided', async () => {
     const { drawStroke } = await import('$lib/canvas/strokeRenderer');
@@ -103,6 +106,6 @@ describe('strokeRenderer streamline wiring', () => {
       1,
       streamlineFromSmoothing(50),
     );
-    expect(getStroke.mock.calls[0][1]).toMatchObject({ streamline: 0.495 });
+    expect(getStroke.mock.calls[0][1].streamline).toBeCloseTo(0.495);
   });
 });


### PR DESCRIPTION
Closes #86.

## Summary
- Per-tool smoothing slider (0–100) in the sidebar, visible only for pen / highlighter / temp-ink.
- Maps to perfect-freehand's `streamline`: `streamline = value/100 * 0.99`.
- Defaults: pen 50, highlighter 50, temp-ink 30.
- Persisted in sidebar store, synced across detached window via the existing sync bridge.

## Testing
- `pnpm lint`, `pnpm test`: 358/358 pass (+ new `stroke-renderer-smoothing.test.ts`).