### PR TITLE
fix(view): zen mode hides all chrome (#87)

### DIFF
--- a/src/lib/store/zen.ts
+++ b/src/lib/store/zen.ts
@@ -36,3 +36,28 @@ function createZen() {
 export const zen = createZen();
 
 export const zenStore: Readable<ZenState> = { subscribe: zen.subscribe };
+
+export interface ChromeVisibility {
+  topbar: boolean;
+  sidebar: boolean;
+  thumbnails: boolean;
+}
+
+/**
+ * Decide which chrome sections render for the current view flags.
+ * Zen mode hides everything except the canvas; presenter behaves the same.
+ * A detached sidebar lives in its own window, so it never renders inline.
+ */
+export function chromeVisibility(flags: {
+  zen: boolean;
+  presenter: boolean;
+  sidebarDetached: boolean;
+  hasPages: boolean;
+}): ChromeVisibility {
+  const chromeHidden = flags.zen || flags.presenter;
+  return {
+    topbar: !chromeHidden,
+    sidebar: !chromeHidden && !flags.sidebarDetached,
+    thumbnails: !chromeHidden && flags.hasPages,
+  };
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -20,7 +20,7 @@
   import { startAutosave } from '$lib/store/autosave';
   import { viewport, viewportStore, MIN_SCALE, MAX_SCALE } from '$lib/store/viewport';
   import { presenter, presenterStore } from '$lib/store/presenter';
-  import { zenStore } from '$lib/store/zen';
+  import { zenStore, chromeVisibility } from '$lib/store/zen';
   import { overlays } from '$lib/store/overlays';
   import { startToolBridge } from '$lib/app/toolBridge';
   import { startPresenterBridge } from '$lib/app/presenterBridge';
@@ -84,9 +84,15 @@
   });
   const zenState = $derived($zenStore);
   const isZen = $derived(zenState.active);
-  const chromeHidden = $derived(isPresenter || isZen);
   const sidebarDetached = $derived(sidebarState.detached);
-  const sidebarHidden = $derived(chromeHidden || sidebarDetached);
+  const chrome = $derived(
+    chromeVisibility({
+      zen: isZen,
+      presenter: isPresenter,
+      sidebarDetached,
+      hasPages: (doc?.pages.length ?? 0) > 0,
+    }),
+  );
 
   $effect(() => {
     if (sidebarDetached && !stopSidebarBridge) {
@@ -438,21 +444,21 @@
 
 <main
   class="app"
-  class:pinned={sidebarState.pinned && !sidebarDetached}
+  class:pinned={sidebarState.pinned && chrome.sidebar}
   class:presenter={isPresenter}
   class:zen={isZen}
   class:sidebar-detached={sidebarDetached}
-  class:has-thumbs={!chromeHidden && pages.length > 0}
+  class:has-thumbs={chrome.thumbnails}
   use:shortcuts
   tabindex="-1"
   role="application"
 >
-  {#if !sidebarHidden}
+  {#if chrome.sidebar}
     <Sidebar onDetachChange={onSidebarDetachChange} />
   {/if}
 
   <section class="main">
-    {#if !chromeHidden}
+    {#if chrome.topbar}
       <header class="topbar">
         <button type="button" class="topbar-btn" onclick={openFromDialog}>Open PDF…</button>
         <div class="pager">
@@ -610,7 +616,7 @@
     </div>
   </section>
 
-  {#if !chromeHidden && pages.length > 0}
+  {#if chrome.thumbnails}
     <ThumbnailStrip
       {pages}
       currentIndex={pageIndex}
@@ -674,15 +680,17 @@
   .app.pinned.has-thumbs {
     grid-template-columns: 220px 1fr 160px;
   }
-  .app.presenter {
-    grid-template-columns: 1fr;
-    background: #000;
-  }
-  .app.presenter .canvas-area {
-    background: #000;
-  }
+  .app.presenter,
   .app.zen {
     grid-template-columns: 1fr;
+    grid-template-rows: 1fr;
+  }
+  .app.presenter {
+    background: #000;
+  }
+  .app.presenter .canvas-area,
+  .app.zen .canvas-area {
+    background: #000;
   }
   .zen-hint {
     position: fixed;

--- a/tests/zen-store.test.ts
+++ b/tests/zen-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, beforeEach } from 'vitest';
 import { get } from 'svelte/store';
-import { zen } from '../src/lib/store/zen';
+import { zen, chromeVisibility } from '../src/lib/store/zen';
 
 describe('zen store', () => {
   beforeEach(() => zen.reset());
@@ -36,5 +36,52 @@ describe('zen store', () => {
     zen.enter();
     zen.reset();
     expect(zen.isActive()).toBe(false);
+  });
+
+  it('toggle emits to subscribers on each state change', () => {
+    const observed: boolean[] = [];
+    const unsubscribe = zen.subscribe((s) => observed.push(s.active));
+    zen.toggle();
+    zen.toggle();
+    unsubscribe();
+    expect(observed).toEqual([false, true, false]);
+  });
+});
+
+describe('chromeVisibility', () => {
+  it('shows all chrome in default editing view', () => {
+    expect(
+      chromeVisibility({ zen: false, presenter: false, sidebarDetached: false, hasPages: true }),
+    ).toEqual({ topbar: true, sidebar: true, thumbnails: true });
+  });
+
+  it('hides everything when zen is active, even with pinned sidebar and pages', () => {
+    expect(
+      chromeVisibility({ zen: true, presenter: false, sidebarDetached: false, hasPages: true }),
+    ).toEqual({ topbar: false, sidebar: false, thumbnails: false });
+  });
+
+  it('hides everything when presenter is active', () => {
+    expect(
+      chromeVisibility({ zen: false, presenter: true, sidebarDetached: false, hasPages: true }),
+    ).toEqual({ topbar: false, sidebar: false, thumbnails: false });
+  });
+
+  it('hides inline sidebar when detached but keeps topbar and thumbs', () => {
+    expect(
+      chromeVisibility({ zen: false, presenter: false, sidebarDetached: true, hasPages: true }),
+    ).toEqual({ topbar: true, sidebar: false, thumbnails: true });
+  });
+
+  it('hides thumbnails when no pages are loaded', () => {
+    expect(
+      chromeVisibility({ zen: false, presenter: false, sidebarDetached: false, hasPages: false }),
+    ).toEqual({ topbar: true, sidebar: true, thumbnails: false });
+  });
+
+  it('zen overrides sidebarDetached flag (everything hidden)', () => {
+    expect(
+      chromeVisibility({ zen: true, presenter: false, sidebarDetached: true, hasPages: true }),
+    ).toEqual({ topbar: false, sidebar: false, thumbnails: false });
   });
 });


### PR DESCRIPTION
Closes #87.

## Summary
- Route all chrome visibility through a single `chromeVisibility` helper used by both `{#if}` gates and the app's CSS grid class bindings.
- Hardened `.app.zen` / `.app.presenter` CSS to deterministically collapse to `1fr × 1fr` regardless of other classes.
- Previously: the sidebar didn't render in zen, but the grid still reserved its 220px column — leaving zen mode short of true fullscreen.

## Testing
- `pnpm lint`, `pnpm test`: 355/355 pass (+6 `chromeVisibility` cases, +1 toggle emit).