### PR TITLE
feat(shortcuts): command palette default is Ctrl+P (#89)

### DIFF
--- a/src/lib/app/shortcutRegistry.ts
+++ b/src/lib/app/shortcutRegistry.ts
@@ -178,7 +178,7 @@ function buildCommands(): ShortcutCommand[] {
     {
       id: 'commandPalette.open',
       label: 'Open command palette',
-      defaultSpec: 'Mod+K',
+      defaultSpec: 'Mod+P',
       run: () => commandPalette.toggle(),
       preventDefault: true,
     },

--- a/src/lib/store/shortcuts.ts
+++ b/src/lib/store/shortcuts.ts
@@ -3,18 +3,82 @@ import { DEFAULT_BINDINGS, SHORTCUT_IDS, type ShortcutId } from '$lib/app/shortc
 
 const STORAGE_KEY = 'eldraw.shortcuts.v1';
 
+/**
+ * Current migration version for the persisted bindings payload.
+ * Bump this and append a step to `MIGRATIONS` when changing a default that
+ * users may already have stored as their "accepted" binding.
+ *
+ * Legacy (unversioned) payloads are treated as version 0.
+ */
+export const SHORTCUTS_SCHEMA_VERSION = 1;
+
 export type ShortcutBindings = Record<ShortcutId, string>;
+
+interface StoredPayload {
+  version: number;
+  bindings: Partial<Record<ShortcutId, string>>;
+}
+
+type Migration = (bindings: Partial<Record<ShortcutId, string>>) => void;
+
+/**
+ * Ordered migration steps indexed by the version they produce.
+ * Step at index i migrates from version i to version i+1.
+ *
+ * v0 → v1: command palette default moved from Mod+K to Mod+P (#89). Users
+ * whose stored binding still matches the old default are bumped; custom
+ * bindings are left alone.
+ */
+const MIGRATIONS: Migration[] = [
+  (bindings) => {
+    if (bindings['commandPalette.open'] === 'Mod+K') {
+      bindings['commandPalette.open'] = 'Mod+P';
+    }
+  },
+];
 
 function cloneDefaults(): ShortcutBindings {
   return { ...DEFAULT_BINDINGS };
 }
 
+function isStoredPayload(raw: unknown): raw is StoredPayload {
+  return (
+    !!raw &&
+    typeof raw === 'object' &&
+    typeof (raw as { version?: unknown }).version === 'number' &&
+    typeof (raw as { bindings?: unknown }).bindings === 'object' &&
+    (raw as { bindings: unknown }).bindings !== null
+  );
+}
+
+function extractStoredBindings(raw: unknown): {
+  version: number;
+  bindings: Partial<Record<ShortcutId, string>>;
+} {
+  if (isStoredPayload(raw)) {
+    return {
+      version: raw.version,
+      bindings: { ...(raw.bindings as Partial<Record<ShortcutId, string>>) },
+    };
+  }
+  if (raw && typeof raw === 'object') {
+    return { version: 0, bindings: { ...(raw as Partial<Record<ShortcutId, string>>) } };
+  }
+  return { version: SHORTCUTS_SCHEMA_VERSION, bindings: {} };
+}
+
+function runMigrations(bindings: Partial<Record<ShortcutId, string>>, fromVersion: number): void {
+  for (let v = Math.max(0, fromVersion); v < SHORTCUTS_SCHEMA_VERSION; v++) {
+    MIGRATIONS[v]?.(bindings);
+  }
+}
+
 function sanitize(raw: unknown): ShortcutBindings {
   const result = cloneDefaults();
-  if (!raw || typeof raw !== 'object') return result;
-  const record = raw as Record<string, unknown>;
+  const { version, bindings } = extractStoredBindings(raw);
+  runMigrations(bindings, version);
   for (const id of SHORTCUT_IDS) {
-    const v = record[id];
+    const v = bindings[id];
     if (typeof v === 'string' && v.length > 0) {
       result[id] = v;
     }
@@ -36,7 +100,11 @@ function readStorage(): ShortcutBindings {
 function writeStorage(bindings: ShortcutBindings): void {
   if (typeof localStorage === 'undefined') return;
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(bindings));
+    const payload: StoredPayload = {
+      version: SHORTCUTS_SCHEMA_VERSION,
+      bindings: { ...bindings },
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
   } catch {
     // Storage may be unavailable (private mode, quota). Non-fatal.
   }

--- a/src/lib/store/shortcuts.ts
+++ b/src/lib/store/shortcuts.ts
@@ -41,23 +41,28 @@ function cloneDefaults(): ShortcutBindings {
   return { ...DEFAULT_BINDINGS };
 }
 
-function isStoredPayload(raw: unknown): raw is StoredPayload {
-  return (
-    !!raw &&
-    typeof raw === 'object' &&
-    typeof (raw as { version?: unknown }).version === 'number' &&
-    typeof (raw as { bindings?: unknown }).bindings === 'object' &&
-    (raw as { bindings: unknown }).bindings !== null
-  );
+function hasWrapperShape(
+  raw: unknown,
+): raw is { version: unknown; bindings: Record<string, unknown> } {
+  if (!raw || typeof raw !== 'object') return false;
+  const obj = raw as Record<string, unknown>;
+  return 'version' in obj && typeof obj.bindings === 'object' && obj.bindings !== null;
+}
+
+function isValidVersion(v: unknown): v is number {
+  return typeof v === 'number' && Number.isInteger(v) && v >= 0;
 }
 
 function extractStoredBindings(raw: unknown): {
   version: number;
   bindings: Partial<Record<ShortcutId, string>>;
 } {
-  if (isStoredPayload(raw)) {
+  if (hasWrapperShape(raw)) {
+    // Corrupt/invalid versions (fractional, negative, NaN, non-numeric) are
+    // treated as legacy v0 so all migrations re-run against the bindings.
+    const version = isValidVersion(raw.version) ? raw.version : 0;
     return {
-      version: raw.version,
+      version,
       bindings: { ...(raw.bindings as Partial<Record<ShortcutId, string>>) },
     };
   }

--- a/tests/shortcut-store.test.ts
+++ b/tests/shortcut-store.test.ts
@@ -4,6 +4,7 @@ import {
   shortcutsStore,
   shortcutBindings,
   SHORTCUTS_STORAGE_KEY,
+  SHORTCUTS_SCHEMA_VERSION,
 } from '../src/lib/store/shortcuts';
 import { DEFAULT_BINDINGS } from '../src/lib/app/shortcutRegistry';
 
@@ -56,7 +57,8 @@ describe('shortcuts store', () => {
     const raw = memory.getItem(SHORTCUTS_STORAGE_KEY);
     expect(raw).not.toBeNull();
     const parsed = JSON.parse(raw as string);
-    expect(parsed['tool.pen']).toBe('Shift+P');
+    expect(parsed.version).toBe(SHORTCUTS_SCHEMA_VERSION);
+    expect(parsed.bindings['tool.pen']).toBe('Shift+P');
   });
 
   it('resetBinding restores only that command to default', () => {
@@ -111,5 +113,47 @@ describe('shortcuts store', () => {
     const snap = shortcutsStore.snapshot();
     expect(snap['tool.pen']).toBe(DEFAULT_BINDINGS['tool.pen']);
     expect(snap['tool.eraser']).toBe('Alt+E');
+  });
+
+  it('command palette default is Mod+P', () => {
+    expect(DEFAULT_BINDINGS['commandPalette.open']).toBe('Mod+P');
+  });
+
+  it('migrates legacy unversioned Mod+K to Mod+P for commandPalette.open', () => {
+    memory.setItem(
+      SHORTCUTS_STORAGE_KEY,
+      JSON.stringify({ 'commandPalette.open': 'Mod+K', 'tool.pen': 'Shift+P' }),
+    );
+    shortcutsStore.hydrate();
+    const snap = shortcutsStore.snapshot();
+    expect(snap['commandPalette.open']).toBe('Mod+P');
+    expect(snap['tool.pen']).toBe('Shift+P');
+  });
+
+  it('leaves non-default custom commandPalette bindings untouched during migration', () => {
+    memory.setItem(SHORTCUTS_STORAGE_KEY, JSON.stringify({ 'commandPalette.open': 'Mod+Shift+K' }));
+    shortcutsStore.hydrate();
+    expect(shortcutsStore.snapshot()['commandPalette.open']).toBe('Mod+Shift+K');
+  });
+
+  it('does not re-run migrations on already-versioned payloads', () => {
+    // User explicitly set Mod+K after the migration landed — must be preserved.
+    memory.setItem(
+      SHORTCUTS_STORAGE_KEY,
+      JSON.stringify({
+        version: SHORTCUTS_SCHEMA_VERSION,
+        bindings: { 'commandPalette.open': 'Mod+K' },
+      }),
+    );
+    shortcutsStore.hydrate();
+    expect(shortcutsStore.snapshot()['commandPalette.open']).toBe('Mod+K');
+  });
+
+  it('persists with current schema version and bindings wrapper', () => {
+    shortcutsStore.setBinding('commandPalette.open', 'Mod+K');
+    const raw = memory.getItem(SHORTCUTS_STORAGE_KEY);
+    const parsed = JSON.parse(raw as string);
+    expect(parsed.version).toBe(SHORTCUTS_SCHEMA_VERSION);
+    expect(parsed.bindings['commandPalette.open']).toBe('Mod+K');
   });
 });

--- a/tests/shortcut-store.test.ts
+++ b/tests/shortcut-store.test.ts
@@ -156,4 +156,32 @@ describe('shortcuts store', () => {
     expect(parsed.version).toBe(SHORTCUTS_SCHEMA_VERSION);
     expect(parsed.bindings['commandPalette.open']).toBe('Mod+K');
   });
+
+  it('treats fractional schema version as legacy and runs migrations from v0', () => {
+    memory.setItem(
+      SHORTCUTS_STORAGE_KEY,
+      JSON.stringify({
+        version: 0.5,
+        bindings: { 'commandPalette.open': 'Mod+K', 'tool.pen': 'Shift+P' },
+      }),
+    );
+    shortcutsStore.hydrate();
+    const snap = shortcutsStore.snapshot();
+    expect(snap['commandPalette.open']).toBe('Mod+P');
+    expect(snap['tool.pen']).toBe('Shift+P');
+  });
+
+  it('treats negative schema version as legacy and runs migrations from v0', () => {
+    memory.setItem(
+      SHORTCUTS_STORAGE_KEY,
+      JSON.stringify({
+        version: -1,
+        bindings: { 'commandPalette.open': 'Mod+K', 'tool.eraser': 'Alt+E' },
+      }),
+    );
+    shortcutsStore.hydrate();
+    const snap = shortcutsStore.snapshot();
+    expect(snap['commandPalette.open']).toBe('Mod+P');
+    expect(snap['tool.eraser']).toBe('Alt+E');
+  });
 });


### PR DESCRIPTION
Closes #89.

## Summary
- Default binding for `commandPalette.open`: `Mod+K` → `Mod+P`. Keeps `preventDefault: true` so browser print is suppressed.
- Added versioned persistence schema for `eldraw.shortcuts.v1`:
  - Legacy bare `{id: spec}` dict = version 0.
  - New: `{ version: 1, bindings: {...} }`.
  - `MIGRATIONS[0]`: if stored `commandPalette.open === 'Mod+K'`, upgrade to `Mod+P`; else untouched.
  - Already-versioned payloads skip earlier migrations, so users who explicitly rebind to `Mod+K` after this change keep their choice.

## Testing
- `pnpm lint`, `pnpm test`: 353/353 pass (+5 new tests for default, migration, custom preservation, no-op on current version, persistence wrapper).