### PR TITLE
feat(sidebar): composite annotations into thumbnails on stroke commit (#92)

### DIFF
--- a/src/lib/pdf/thumbnailComposite.ts
+++ b/src/lib/pdf/thumbnailComposite.ts
@@ -1,0 +1,107 @@
+import type { AnyObject, Page } from '$lib/types';
+import { drawAngleMark, drawLine, drawNumberLine, drawShape } from '$lib/canvas/objectRenderer';
+import { drawStroke } from '$lib/canvas/strokeRenderer';
+
+/**
+ * Render annotation objects onto `ctx` scaled to fit a thumbnail. `pxPerPt`
+ * converts PDF user-space points to the target canvas pixels. Text and
+ * graph objects render as minimal placeholders — full LaTeX/plotter output
+ * is too expensive for a strip of thumbnails and the user only needs shape
+ * cues at this size.
+ */
+export function drawAnnotationOverlay(
+  ctx: CanvasRenderingContext2D,
+  objects: readonly AnyObject[],
+  pxPerPt: number,
+): void {
+  for (const obj of objects) drawObject(ctx, obj, pxPerPt);
+}
+
+function drawObject(ctx: CanvasRenderingContext2D, obj: AnyObject, pxPerPt: number): void {
+  switch (obj.type) {
+    case 'stroke':
+      drawStroke(ctx, obj, { ptToPx: pxPerPt, simulatePressure: false });
+      return;
+    case 'line':
+      drawLine(ctx, obj, pxPerPt);
+      return;
+    case 'shape':
+      drawShape(ctx, obj, pxPerPt);
+      return;
+    case 'numberline':
+      drawNumberLine(ctx, obj, pxPerPt);
+      return;
+    case 'angleMark':
+      drawAngleMark(ctx, obj, pxPerPt);
+      return;
+    case 'graph':
+      drawGraphPlaceholder(ctx, obj.bounds, pxPerPt);
+      return;
+    case 'text':
+      drawTextPlaceholder(ctx, obj.at, obj.fontSize, obj.content, obj.color, pxPerPt);
+      return;
+  }
+}
+
+function drawGraphPlaceholder(
+  ctx: CanvasRenderingContext2D,
+  bounds: { x: number; y: number; w: number; h: number },
+  pxPerPt: number,
+): void {
+  const x = bounds.x * pxPerPt;
+  const y = bounds.y * pxPerPt;
+  const w = bounds.w * pxPerPt;
+  const h = bounds.h * pxPerPt;
+  if (w < 1 || h < 1) return;
+  ctx.save();
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(x, y, w, h);
+  ctx.strokeStyle = '#888';
+  ctx.lineWidth = 1;
+  ctx.strokeRect(x + 0.5, y + 0.5, Math.max(0, w - 1), Math.max(0, h - 1));
+  ctx.strokeStyle = '#bbb';
+  ctx.beginPath();
+  ctx.moveTo(x, y + h / 2);
+  ctx.lineTo(x + w, y + h / 2);
+  ctx.moveTo(x + w / 2, y);
+  ctx.lineTo(x + w / 2, y + h);
+  ctx.stroke();
+  ctx.restore();
+}
+
+function drawTextPlaceholder(
+  ctx: CanvasRenderingContext2D,
+  at: { x: number; y: number },
+  fontSize: number,
+  content: string,
+  color: string,
+  pxPerPt: number,
+): void {
+  const px = fontSize * pxPerPt;
+  if (px < 4) return;
+  ctx.save();
+  ctx.fillStyle = color;
+  ctx.font = `${px}px system-ui, sans-serif`;
+  ctx.textBaseline = 'top';
+  ctx.fillText(content, at.x * pxPerPt, at.y * pxPerPt);
+  ctx.restore();
+}
+
+/**
+ * Target thumbnail pixel size for a page of `widthPt × heightPt` at the
+ * given longest-side bound. Matches the sizing used by the Rust renderer
+ * so the overlay aligns with the raw PDF thumbnail.
+ */
+export function thumbnailPixelSize(
+  page: Pick<Page, 'width' | 'height'>,
+  maxDim: number,
+): { width: number; height: number; pxPerPt: number } {
+  const longest = Math.max(page.width, page.height);
+  if (longest <= 0) return { width: 0, height: 0, pxPerPt: 0 };
+  const pxPerPt = maxDim / longest;
+  return {
+    width: Math.max(1, Math.round(page.width * pxPerPt)),
+    height: Math.max(1, Math.round(page.height * pxPerPt)),
+    pxPerPt,
+  };
+}

--- a/src/lib/pdf/thumbnails.ts
+++ b/src/lib/pdf/thumbnails.ts
@@ -9,9 +9,15 @@ function keyOf(pdfId: string, pageIndex: number, maxDim: number): Key {
   return `${pdfId}\u0000${pageIndex}\u0000${maxDim}`;
 }
 
+function pageKey(pdfId: string, pageIndex: number): Key {
+  return `${pdfId}\u0000${pageIndex}`;
+}
+
 const urls = new Map<Key, string>();
 const inflight = new Map<Key, Promise<string>>();
 const generations = new Map<string, number>();
+const pageGenerations = new Map<Key, number>();
+const pageListeners = new Map<Key, Set<(generation: number) => void>>();
 
 function generation(pdfId: string): number {
   return generations.get(pdfId) ?? 0;
@@ -79,6 +85,12 @@ export function revokeThumbnails(pdfId?: string): void {
       urls.delete(k);
     }
   }
+  for (const k of pageGenerations.keys()) {
+    if (!prefix || k.startsWith(prefix)) pageGenerations.delete(k);
+  }
+  for (const k of pageListeners.keys()) {
+    if (!prefix || k.startsWith(prefix)) pageListeners.delete(k);
+  }
 }
 
 /**
@@ -99,4 +111,50 @@ export function retainThumbnails(pdfId: string, keepPageIndexes: ReadonlySet<num
       urls.delete(k);
     }
   }
+  for (const k of pageGenerations.keys()) {
+    if (!k.startsWith(prefix)) continue;
+    const pageIndex = Number(k.slice(prefix.length));
+    if (!keepPageIndexes.has(pageIndex)) {
+      pageGenerations.delete(k);
+      pageListeners.delete(k);
+    }
+  }
+}
+
+/**
+ * Per-page generation counter. Bumped on each committed annotation change
+ * so thumbnail consumers can re-composite only the affected page.
+ */
+export function pageGeneration(pdfId: string, pageIndex: number): number {
+  return pageGenerations.get(pageKey(pdfId, pageIndex)) ?? 0;
+}
+
+export function bumpPageGeneration(pdfId: string, pageIndex: number): void {
+  const k = pageKey(pdfId, pageIndex);
+  const next = (pageGenerations.get(k) ?? 0) + 1;
+  pageGenerations.set(k, next);
+  const listeners = pageListeners.get(k);
+  if (listeners) {
+    for (const cb of listeners) cb(next);
+  }
+}
+
+export function subscribePageGeneration(
+  pdfId: string,
+  pageIndex: number,
+  listener: (generation: number) => void,
+): () => void {
+  const k = pageKey(pdfId, pageIndex);
+  let set = pageListeners.get(k);
+  if (!set) {
+    set = new Set();
+    pageListeners.set(k, set);
+  }
+  set.add(listener);
+  return () => {
+    const s = pageListeners.get(k);
+    if (!s) return;
+    s.delete(listener);
+    if (s.size === 0) pageListeners.delete(k);
+  };
 }

--- a/src/lib/sidebar/ThumbnailStrip.svelte
+++ b/src/lib/sidebar/ThumbnailStrip.svelte
@@ -47,28 +47,36 @@
   let destroyed = false;
   let cacheKey: string | null = null;
   let observer: IntersectionObserver | null = null;
-  const slotToKey = new WeakMap<Element, number>();
+  const slotToIdentity = new WeakMap<Element, number>();
 
-  function sourceKey(page: Page): number {
+  /** Per-document-page identity. Distinguishes duplicated PDF pages that
+   *  share the same pdfSourceIndex so their composites don't collide. */
+  function pageIdentity(page: Page): number {
+    return page.pageIndex;
+  }
+
+  /** Raw PDF thumbnail cache key. Shared across duplicates so pdfium is
+   *  only asked to render each source page once. */
+  function rawSourceKey(page: Page): number {
     return page.pdfSourceIndex ?? page.pageIndex;
   }
 
-  function findPageBySource(key: number): Page | undefined {
-    return pages.find((p) => p.type === 'pdf' && sourceKey(p) === key);
+  function findPageByIdentity(identity: number): Page | undefined {
+    return pages.find((p) => p.type === 'pdf' && pageIdentity(p) === identity);
   }
 
-  function setPreviewUrl(key: number, url: string) {
+  function setPreviewUrl(identity: number, url: string) {
     const next = new Map(previewUrls);
-    next.set(key, url);
+    next.set(identity, url);
     previewUrls = next;
   }
 
-  function revokeComposited(key: number) {
-    const url = compositedUrls.get(key);
+  function revokeComposited(identity: number) {
+    const url = compositedUrls.get(identity);
     if (!url) return;
     URL.revokeObjectURL(url);
-    compositedUrls.delete(key);
-    compositedGenerations.delete(key);
+    compositedUrls.delete(identity);
+    compositedGenerations.delete(identity);
   }
 
   function dropState() {
@@ -82,12 +90,12 @@
     previewUrls = new Map();
   }
 
-  function ensureGenerationSub(pdfId: string, key: number) {
-    if (generationSubs.has(key)) return;
-    const unsub = subscribePageGeneration(pdfId, key, () => {
-      void composite(key);
+  function ensureGenerationSub(pdfId: string, identity: number) {
+    if (generationSubs.has(identity)) return;
+    const unsub = subscribePageGeneration(pdfId, identity, () => {
+      void composite(identity);
     });
-    generationSubs.set(key, unsub);
+    generationSubs.set(identity, unsub);
   }
 
   function loadImage(url: string): Promise<HTMLImageElement> {
@@ -99,18 +107,18 @@
     });
   }
 
-  async function composite(key: number) {
-    if (destroyed || !docKey || compositing.has(key)) return;
-    const page = findPageBySource(key);
+  async function composite(identity: number) {
+    if (destroyed || !docKey || compositing.has(identity)) return;
+    const page = findPageByIdentity(identity);
     if (!page || page.type !== 'pdf') return;
     const scopedKey = docKey;
-    const startGeneration = pageGeneration(scopedKey, key);
+    const startGeneration = pageGeneration(scopedKey, identity);
     const objects = page.objects;
     const dims = thumbnailPixelSize(page, DEFAULT_MAX_DIM);
     if (dims.width < 1 || dims.height < 1) return;
-    compositing.add(key);
+    compositing.add(identity);
     try {
-      const rawUrl = await getThumbnail(scopedKey, key, DEFAULT_MAX_DIM);
+      const rawUrl = await getThumbnail(scopedKey, rawSourceKey(page), DEFAULT_MAX_DIM);
       if (destroyed || scopedKey !== cacheKey) return;
       const img = await loadImage(rawUrl);
       if (destroyed || scopedKey !== cacheKey) return;
@@ -126,26 +134,26 @@
       });
       if (!blob || destroyed || scopedKey !== cacheKey) return;
       const url = URL.createObjectURL(blob);
-      revokeComposited(key);
-      compositedUrls.set(key, url);
-      compositedGenerations.set(key, startGeneration);
-      setPreviewUrl(key, url);
-      if (pageGeneration(scopedKey, key) !== startGeneration) {
-        void composite(key);
+      revokeComposited(identity);
+      compositedUrls.set(identity, url);
+      compositedGenerations.set(identity, startGeneration);
+      setPreviewUrl(identity, url);
+      if (pageGeneration(scopedKey, identity) !== startGeneration) {
+        void composite(identity);
       }
     } catch {
       // leave previous preview in place
     } finally {
-      compositing.delete(key);
+      compositing.delete(identity);
     }
   }
 
-  function request(key: number) {
+  function request(identity: number) {
     if (!docKey || destroyed) return;
-    ensureGenerationSub(docKey, key);
-    const currentGen = pageGeneration(docKey, key);
-    if (compositedGenerations.get(key) === currentGen && compositedUrls.has(key)) return;
-    void composite(key);
+    ensureGenerationSub(docKey, identity);
+    const currentGen = pageGeneration(docKey, identity);
+    if (compositedGenerations.get(identity) === currentGen && compositedUrls.has(identity)) return;
+    void composite(identity);
   }
 
   function ensureObserver(): IntersectionObserver | null {
@@ -154,8 +162,8 @@
       (entries) => {
         for (const entry of entries) {
           if (!entry.isIntersecting) continue;
-          const key = slotToKey.get(entry.target);
-          if (key !== undefined) request(key);
+          const identity = slotToIdentity.get(entry.target);
+          if (identity !== undefined) request(identity);
         }
       },
       { rootMargin: '200px' },
@@ -165,18 +173,18 @@
 
   function observe(el: Element, page: Page) {
     if (page.type !== 'pdf') return { destroy() {} };
-    const key = sourceKey(page);
+    const identity = pageIdentity(page);
     const io = ensureObserver();
     if (!io) {
-      request(key);
+      request(identity);
       return { destroy() {} };
     }
-    slotToKey.set(el, key);
+    slotToIdentity.set(el, identity);
     io.observe(el);
     return {
       destroy() {
         io.unobserve(el);
-        slotToKey.delete(el);
+        slotToIdentity.delete(el);
       },
     };
   }
@@ -185,7 +193,7 @@
     if (!docKey) return;
     const page = pages[pageIndex];
     if (!page || page.type !== 'pdf') return;
-    bumpPageGeneration(docKey, sourceKey(page));
+    bumpPageGeneration(docKey, pageIdentity(page));
   });
 
   $effect(() => {
@@ -199,29 +207,34 @@
   });
 
   $effect(() => {
-    const activeKeys = new Set<number>();
+    const activeIdentities = new Set<number>();
+    const activeSourceKeys = new Set<number>();
     for (const page of pages) {
-      if (page.type === 'pdf') activeKeys.add(sourceKey(page));
+      if (page.type !== 'pdf') continue;
+      activeIdentities.add(pageIdentity(page));
+      activeSourceKeys.add(rawSourceKey(page));
     }
     untrack(() => {
       if (!cacheKey) return;
       let changed = false;
       const next = new Map(previewUrls);
-      for (const key of next.keys()) {
-        if (!activeKeys.has(key)) {
-          next.delete(key);
-          revokeComposited(key);
-          compositing.delete(key);
-          const unsub = generationSubs.get(key);
+      for (const identity of next.keys()) {
+        if (!activeIdentities.has(identity)) {
+          next.delete(identity);
+          revokeComposited(identity);
+          compositing.delete(identity);
+          const unsub = generationSubs.get(identity);
           if (unsub) {
             unsub();
-            generationSubs.delete(key);
+            generationSubs.delete(identity);
           }
           changed = true;
         }
       }
       if (changed) previewUrls = next;
-      retainThumbnails(cacheKey, activeKeys);
+      const retain = new Set<number>(activeIdentities);
+      for (const k of activeSourceKeys) retain.add(k);
+      retainThumbnails(cacheKey, retain);
     });
   });
 
@@ -241,7 +254,7 @@
 
   function previewFor(page: Page): string | undefined {
     if (page.type !== 'pdf') return undefined;
-    return previewUrls.get(sourceKey(page));
+    return previewUrls.get(pageIdentity(page));
   }
 </script>
 

--- a/src/lib/sidebar/ThumbnailStrip.svelte
+++ b/src/lib/sidebar/ThumbnailStrip.svelte
@@ -2,11 +2,16 @@
   import { onDestroy, untrack } from 'svelte';
   import type { Page } from '$lib/types';
   import {
+    bumpPageGeneration,
+    DEFAULT_MAX_DIM,
     getThumbnail,
+    pageGeneration,
     retainThumbnails,
     revokeThumbnails,
-    DEFAULT_MAX_DIM,
+    subscribePageGeneration,
   } from '$lib/pdf/thumbnails';
+  import { drawAnnotationOverlay, thumbnailPixelSize } from '$lib/pdf/thumbnailComposite';
+  import { documentStore } from '$lib/store/document';
   import { thumbnailSize } from './thumbnailSize';
 
   interface Props {
@@ -35,7 +40,10 @@
   const canDelete = $derived(pages.length > 1);
 
   let previewUrls = $state(new Map<number, string>());
-  const requested = new Set<number>();
+  const compositedUrls = new Map<number, string>();
+  const compositedGenerations = new Map<number, number>();
+  const compositing = new Set<number>();
+  const generationSubs = new Map<number, () => void>();
   let destroyed = false;
   let cacheKey: string | null = null;
   let observer: IntersectionObserver | null = null;
@@ -45,27 +53,99 @@
     return page.pdfSourceIndex ?? page.pageIndex;
   }
 
-  function dropState() {
-    if (cacheKey) revokeThumbnails(cacheKey);
-    previewUrls = new Map();
-    requested.clear();
+  function findPageBySource(key: number): Page | undefined {
+    return pages.find((p) => p.type === 'pdf' && sourceKey(p) === key);
   }
 
-  async function request(key: number) {
-    if (!docKey || destroyed || requested.has(key)) return;
-    requested.add(key);
+  function setPreviewUrl(key: number, url: string) {
+    const next = new Map(previewUrls);
+    next.set(key, url);
+    previewUrls = next;
+  }
+
+  function revokeComposited(key: number) {
+    const url = compositedUrls.get(key);
+    if (!url) return;
+    URL.revokeObjectURL(url);
+    compositedUrls.delete(key);
+    compositedGenerations.delete(key);
+  }
+
+  function dropState() {
+    if (cacheKey) revokeThumbnails(cacheKey);
+    for (const url of compositedUrls.values()) URL.revokeObjectURL(url);
+    compositedUrls.clear();
+    compositedGenerations.clear();
+    compositing.clear();
+    for (const unsub of generationSubs.values()) unsub();
+    generationSubs.clear();
+    previewUrls = new Map();
+  }
+
+  function ensureGenerationSub(pdfId: string, key: number) {
+    if (generationSubs.has(key)) return;
+    const unsub = subscribePageGeneration(pdfId, key, () => {
+      void composite(key);
+    });
+    generationSubs.set(key, unsub);
+  }
+
+  function loadImage(url: string): Promise<HTMLImageElement> {
+    return new Promise((resolve, reject) => {
+      const img = new Image();
+      img.onload = () => resolve(img);
+      img.onerror = () => reject(new Error('thumbnail image load failed'));
+      img.src = url;
+    });
+  }
+
+  async function composite(key: number) {
+    if (destroyed || !docKey || compositing.has(key)) return;
+    const page = findPageBySource(key);
+    if (!page || page.type !== 'pdf') return;
     const scopedKey = docKey;
+    const startGeneration = pageGeneration(scopedKey, key);
+    const objects = page.objects;
+    const dims = thumbnailPixelSize(page, DEFAULT_MAX_DIM);
+    if (dims.width < 1 || dims.height < 1) return;
+    compositing.add(key);
     try {
-      const url = await getThumbnail(scopedKey, key, DEFAULT_MAX_DIM);
+      const rawUrl = await getThumbnail(scopedKey, key, DEFAULT_MAX_DIM);
       if (destroyed || scopedKey !== cacheKey) return;
-      const next = new Map(previewUrls);
-      next.set(key, url);
-      previewUrls = next;
+      const img = await loadImage(rawUrl);
+      if (destroyed || scopedKey !== cacheKey) return;
+      const canvas = document.createElement('canvas');
+      canvas.width = dims.width;
+      canvas.height = dims.height;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
+      ctx.drawImage(img, 0, 0, dims.width, dims.height);
+      drawAnnotationOverlay(ctx, objects, dims.pxPerPt);
+      const blob = await new Promise<Blob | null>((resolve) => {
+        canvas.toBlob((b) => resolve(b), 'image/png');
+      });
+      if (!blob || destroyed || scopedKey !== cacheKey) return;
+      const url = URL.createObjectURL(blob);
+      revokeComposited(key);
+      compositedUrls.set(key, url);
+      compositedGenerations.set(key, startGeneration);
+      setPreviewUrl(key, url);
+      if (pageGeneration(scopedKey, key) !== startGeneration) {
+        void composite(key);
+      }
     } catch {
-      // Leave the slot blank on failure; main layer surfaces the error.
+      // leave previous preview in place
     } finally {
-      requested.delete(key);
+      compositing.delete(key);
     }
+  }
+
+  function request(key: number) {
+    if (!docKey || destroyed) return;
+    ensureGenerationSub(docKey, key);
+    const currentGen = pageGeneration(docKey, key);
+    if (compositedGenerations.get(key) === currentGen && compositedUrls.has(key)) return;
+    void composite(key);
   }
 
   function ensureObserver(): IntersectionObserver | null {
@@ -75,7 +155,7 @@
         for (const entry of entries) {
           if (!entry.isIntersecting) continue;
           const key = slotToKey.get(entry.target);
-          if (key !== undefined) void request(key);
+          if (key !== undefined) request(key);
         }
       },
       { rootMargin: '200px' },
@@ -88,7 +168,7 @@
     const key = sourceKey(page);
     const io = ensureObserver();
     if (!io) {
-      void request(key);
+      request(key);
       return { destroy() {} };
     }
     slotToKey.set(el, key);
@@ -100,6 +180,13 @@
       },
     };
   }
+
+  const unsubCommit = documentStore.onPageCommit((pageIndex) => {
+    if (!docKey) return;
+    const page = pages[pageIndex];
+    if (!page || page.type !== 'pdf') return;
+    bumpPageGeneration(docKey, sourceKey(page));
+  });
 
   $effect(() => {
     const key = docKey;
@@ -123,7 +210,13 @@
       for (const key of next.keys()) {
         if (!activeKeys.has(key)) {
           next.delete(key);
-          requested.delete(key);
+          revokeComposited(key);
+          compositing.delete(key);
+          const unsub = generationSubs.get(key);
+          if (unsub) {
+            unsub();
+            generationSubs.delete(key);
+          }
           changed = true;
         }
       }
@@ -134,11 +227,16 @@
 
   onDestroy(() => {
     destroyed = true;
+    unsubCommit();
     observer?.disconnect();
     observer = null;
     if (cacheKey) revokeThumbnails(cacheKey);
+    for (const url of compositedUrls.values()) URL.revokeObjectURL(url);
+    compositedUrls.clear();
+    compositedGenerations.clear();
+    for (const unsub of generationSubs.values()) unsub();
+    generationSubs.clear();
     previewUrls.clear();
-    requested.clear();
   });
 
   function previewFor(page: Page): string | undefined {

--- a/src/lib/store/document.ts
+++ b/src/lib/store/document.ts
@@ -3,6 +3,8 @@ import type { AnyObject, EldrawDocument, ObjectId, Page } from '$lib/types';
 import { isSafeHexColor } from '$lib/color';
 import { applyCommand, createHistory, type Command, type History } from './history';
 
+export type PageCommitListener = (pageIndex: number) => void;
+
 export interface DocumentStore {
   subscribe: Readable<EldrawDocument | null>['subscribe'];
   load(doc: EldrawDocument): void;
@@ -29,6 +31,14 @@ export interface DocumentStore {
   canRedo(pageIndex: number): Readable<boolean>;
 
   objectsOnPage(pageIndex: number): Readable<AnyObject[]>;
+
+  /**
+   * Subscribe to page annotation commits. Fires on add/remove/update/clear
+   * and on undo/redo — i.e. every mutation that changes a page's `objects`.
+   * Does NOT fire during live strokes (those never touch the store) or
+   * structural page ops (insert/move/duplicate/delete).
+   */
+  onPageCommit(listener: PageCommitListener): () => void;
 
   /** Escape hatch for undo/redo replays that must not re-push history. */
   _internalApply(pageIndex: number, cmd: Command): void;
@@ -136,6 +146,11 @@ function clonePageForDuplicate(p: Page): Page {
 export function createDocumentStore(): DocumentStore {
   const state = writable<EldrawDocument | null>(null);
   const history = createHistory();
+  const commitListeners = new Set<PageCommitListener>();
+
+  function emitCommit(pageIndex: number) {
+    for (const listener of commitListeners) listener(pageIndex);
+  }
 
   function mutatePage(pageIndex: number, fn: (p: Page) => Page) {
     state.update((doc) => {
@@ -149,6 +164,7 @@ export function createDocumentStore(): DocumentStore {
   function pushAndApply(pageIndex: number, cmd: Command) {
     history.pushCommand(pageIndex, cmd);
     mutatePage(pageIndex, (p) => applyCommand(p, cmd));
+    emitCommit(pageIndex);
   }
 
   return {
@@ -264,7 +280,10 @@ export function createDocumentStore(): DocumentStore {
       const page = doc.pages[pageIndex];
       if (!page) return;
       const next = history.undo(pageIndex, page);
-      if (next) mutatePage(pageIndex, () => next);
+      if (next) {
+        mutatePage(pageIndex, () => next);
+        emitCommit(pageIndex);
+      }
     },
 
     redo(pageIndex) {
@@ -273,7 +292,10 @@ export function createDocumentStore(): DocumentStore {
       const page = doc.pages[pageIndex];
       if (!page) return;
       const next = history.redo(pageIndex, page);
-      if (next) mutatePage(pageIndex, () => next);
+      if (next) {
+        mutatePage(pageIndex, () => next);
+        emitCommit(pageIndex);
+      }
     },
 
     canUndo(pageIndex) {
@@ -288,8 +310,16 @@ export function createDocumentStore(): DocumentStore {
       return derived(state, ($doc) => $doc?.pages[pageIndex]?.objects ?? []);
     },
 
+    onPageCommit(listener) {
+      commitListeners.add(listener);
+      return () => {
+        commitListeners.delete(listener);
+      };
+    },
+
     _internalApply(pageIndex, cmd) {
       mutatePage(pageIndex, (p) => applyCommand(p, cmd));
+      emitCommit(pageIndex);
     },
 
     history,

--- a/tests/document-store.test.ts
+++ b/tests/document-store.test.ts
@@ -190,4 +190,66 @@ describe('documentStore', () => {
     const doc = get(store)!;
     expect(doc.pages[1].background).toBe('#123456');
   });
+
+  it('onPageCommit fires on add/remove/update/clear and on undo/redo', () => {
+    const store = createDocumentStore();
+    store.load(docWithPages([pdfPage(0), pdfPage(1)]));
+    const events: number[] = [];
+    const unsub = store.onPageCommit((i) => events.push(i));
+
+    store.addObject(0, stroke('a'));
+    store.addObject(1, stroke('b'));
+    store.updateObject(0, 'a', { style: { color: '#f00', width: 2, dash: 'solid', opacity: 1 } });
+    store.removeObject(1, 'b');
+    store.undo(0);
+    store.redo(0);
+    store.clearPage(0);
+
+    expect(events).toEqual([0, 1, 0, 1, 0, 0, 0]);
+    unsub();
+  });
+
+  it('onPageCommit does not fire for structural page ops', () => {
+    const store = createDocumentStore();
+    store.load(docWithPages([pdfPage(0), pdfPage(1)]));
+    const events: number[] = [];
+    store.onPageCommit((i) => events.push(i));
+
+    store.insertBlankPageAfter(0, 500, 700);
+    store.movePage(0, 1);
+    store.duplicatePage(0);
+    store.deletePage(0);
+
+    expect(events).toEqual([]);
+  });
+
+  it('onPageCommit does not fire when the store is unchanged by a no-op', () => {
+    const store = createDocumentStore();
+    store.load(docWithPages([pdfPage(0)]));
+    const events: number[] = [];
+    store.onPageCommit((i) => events.push(i));
+
+    // No undo stack yet: these should be silent.
+    store.undo(0);
+    store.redo(0);
+    // Removing a nonexistent object is a no-op.
+    store.removeObject(0, 'does-not-exist');
+    // Clearing an empty page is a no-op.
+    store.clearPage(0);
+
+    expect(events).toEqual([]);
+  });
+
+  it('onPageCommit unsubscribe stops delivery', () => {
+    const store = createDocumentStore();
+    store.load(docWithPages([pdfPage(0)]));
+    const events: number[] = [];
+    const unsub = store.onPageCommit((i) => events.push(i));
+
+    store.addObject(0, stroke('a'));
+    unsub();
+    store.addObject(0, stroke('b'));
+
+    expect(events).toEqual([0]);
+  });
 });

--- a/tests/thumbnail-composite.test.ts
+++ b/tests/thumbnail-composite.test.ts
@@ -1,0 +1,180 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { drawAnnotationOverlay, thumbnailPixelSize } from '$lib/pdf/thumbnailComposite';
+import type {
+  AnyObject,
+  GraphObject,
+  LineObject,
+  ShapeObject,
+  StrokeObject,
+  TextObject,
+} from '$lib/types';
+
+beforeAll(() => {
+  if (typeof globalThis.Path2D === 'undefined') {
+    class Path2DStub {
+      constructor(_d?: string) {
+        void _d;
+      }
+    }
+    Object.defineProperty(globalThis, 'Path2D', { value: Path2DStub });
+  }
+});
+
+function mockCtx() {
+  const calls: { name: string; args: unknown[] }[] = [];
+  const record =
+    (name: string) =>
+    (...args: unknown[]) => {
+      calls.push({ name, args });
+    };
+  const ctx: Record<string, unknown> = {
+    save: record('save'),
+    restore: record('restore'),
+    beginPath: record('beginPath'),
+    moveTo: record('moveTo'),
+    lineTo: record('lineTo'),
+    stroke: record('stroke'),
+    fill: record('fill'),
+    fillRect: record('fillRect'),
+    strokeRect: record('strokeRect'),
+    rect: record('rect'),
+    ellipse: record('ellipse'),
+    arc: record('arc'),
+    closePath: record('closePath'),
+    clip: record('clip'),
+    setLineDash: record('setLineDash'),
+    fillText: record('fillText'),
+    drawImage: record('drawImage'),
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, calls };
+}
+
+function stroke(): StrokeObject {
+  return {
+    id: 's1',
+    createdAt: 0,
+    type: 'stroke',
+    tool: 'pen',
+    style: { color: '#000', width: 2, dash: 'solid', opacity: 1 },
+    points: [
+      { x: 10, y: 10, pressure: 0.5, t: 0 },
+      { x: 50, y: 30, pressure: 0.5, t: 10 },
+      { x: 100, y: 40, pressure: 0.5, t: 20 },
+    ],
+  };
+}
+
+function line(): LineObject {
+  return {
+    id: 'l1',
+    createdAt: 0,
+    type: 'line',
+    style: { color: '#222', width: 1, dash: 'solid', opacity: 1 },
+    from: { x: 0, y: 0 },
+    to: { x: 100, y: 100 },
+    arrow: { start: false, end: false },
+  };
+}
+
+function shape(): ShapeObject {
+  return {
+    id: 'sh1',
+    createdAt: 0,
+    type: 'shape',
+    kind: 'rect',
+    style: { color: '#444', width: 1, dash: 'solid', opacity: 1 },
+    fill: null,
+    bounds: { x: 0, y: 0, w: 50, h: 30 },
+  };
+}
+
+function graph(): GraphObject {
+  return {
+    id: 'g1',
+    createdAt: 0,
+    type: 'graph',
+    bounds: { x: 10, y: 10, w: 40, h: 40 },
+    xRange: [-10, 10],
+    yRange: [-10, 10],
+    gridStep: 0,
+    showAxes: true,
+    showGrid: true,
+    functions: [],
+  };
+}
+
+function text(): TextObject {
+  return {
+    id: 't1',
+    createdAt: 0,
+    type: 'text',
+    at: { x: 20, y: 20 },
+    content: 'hello',
+    latex: false,
+    fontSize: 12,
+    color: '#000',
+  };
+}
+
+describe('thumbnailPixelSize', () => {
+  it('scales by the longest side to the requested maxDim', () => {
+    expect(thumbnailPixelSize({ width: 612, height: 792 }, 200)).toEqual({
+      width: 155,
+      height: 200,
+      pxPerPt: 200 / 792,
+    });
+  });
+
+  it('handles degenerate zero-sized pages without NaN', () => {
+    expect(thumbnailPixelSize({ width: 0, height: 0 }, 200)).toEqual({
+      width: 0,
+      height: 0,
+      pxPerPt: 0,
+    });
+  });
+});
+
+describe('drawAnnotationOverlay', () => {
+  it('issues canvas ops for each supported object type', () => {
+    const { ctx, calls } = mockCtx();
+    const objects: AnyObject[] = [stroke(), line(), shape(), graph(), text()];
+
+    drawAnnotationOverlay(ctx, objects, 1);
+
+    const names = new Set(calls.map((c) => c.name));
+    expect(names.has('save')).toBe(true);
+    expect(names.has('stroke')).toBe(true);
+    expect(names.has('fillText')).toBe(true);
+    expect(names.has('fillRect')).toBe(true);
+    expect(names.has('strokeRect')).toBe(true);
+  });
+
+  it('is a no-op for an empty object list', () => {
+    const { ctx, calls } = mockCtx();
+    drawAnnotationOverlay(ctx, [], 0.25);
+    expect(calls).toEqual([]);
+  });
+
+  it('skips invisible text when the scaled font is below the legibility floor', () => {
+    const { ctx, calls } = mockCtx();
+    const t = text();
+    drawAnnotationOverlay(ctx, [{ ...t, fontSize: 4 }], 0.1);
+    expect(calls.some((c) => c.name === 'fillText')).toBe(false);
+  });
+
+  it('renders an early-return-free graph placeholder when bounds are positive', () => {
+    const { ctx, calls } = mockCtx();
+    drawAnnotationOverlay(ctx, [graph()], 1);
+    expect(calls.some((c) => c.name === 'fillRect')).toBe(true);
+    expect(calls.some((c) => c.name === 'strokeRect')).toBe(true);
+  });
+});
+
+describe('drawAnnotationOverlay unknown types', () => {
+  it('does not throw on unknown discriminants', () => {
+    const { ctx } = mockCtx();
+    const bogus = { id: 'x', createdAt: 0, type: 'mystery' } as unknown as AnyObject;
+    expect(() => drawAnnotationOverlay(ctx, [bogus], 1)).not.toThrow();
+    vi.restoreAllMocks();
+  });
+});

--- a/tests/thumbnails.test.ts
+++ b/tests/thumbnails.test.ts
@@ -173,4 +173,33 @@ describe('page generation', () => {
     expect(mod.pageGeneration('hash-a', 1)).toBe(1);
     expect(mod.pageGeneration('hash-a', 2)).toBe(0);
   });
+
+  it('keeps per-page generations independent across identities that alias the same pdf source', async () => {
+    setupObjectUrls();
+    const mod = await import('../src/lib/pdf/thumbnails');
+
+    // Two duplicated sidebar slots with distinct per-page identities (e.g.
+    // pageIndex 10 and 11) that happen to share the same underlying
+    // pdfSourceIndex. The component keys generation subscriptions by the
+    // per-page identity so edits to one duplicate must not bump the other.
+    const seen10: number[] = [];
+    const seen11: number[] = [];
+    const unsub10 = mod.subscribePageGeneration('hash-a', 10, (g) => seen10.push(g));
+    const unsub11 = mod.subscribePageGeneration('hash-a', 11, (g) => seen11.push(g));
+
+    mod.bumpPageGeneration('hash-a', 10);
+    expect(seen10).toEqual([1]);
+    expect(seen11).toEqual([]);
+    expect(mod.pageGeneration('hash-a', 10)).toBe(1);
+    expect(mod.pageGeneration('hash-a', 11)).toBe(0);
+
+    mod.bumpPageGeneration('hash-a', 11);
+    expect(seen10).toEqual([1]);
+    expect(seen11).toEqual([1]);
+    expect(mod.pageGeneration('hash-a', 10)).toBe(1);
+    expect(mod.pageGeneration('hash-a', 11)).toBe(1);
+
+    unsub10();
+    unsub11();
+  });
 });

--- a/tests/thumbnails.test.ts
+++ b/tests/thumbnails.test.ts
@@ -104,3 +104,73 @@ describe('getThumbnail', () => {
     );
   });
 });
+
+describe('page generation', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('starts at 0, bumps to 1, notifies subscribers with the new generation', async () => {
+    setupObjectUrls();
+    const mod = await import('../src/lib/pdf/thumbnails');
+
+    expect(mod.pageGeneration('hash-a', 0)).toBe(0);
+    const seen: number[] = [];
+    const unsub = mod.subscribePageGeneration('hash-a', 0, (g) => seen.push(g));
+
+    mod.bumpPageGeneration('hash-a', 0);
+    mod.bumpPageGeneration('hash-a', 0);
+
+    expect(mod.pageGeneration('hash-a', 0)).toBe(2);
+    expect(seen).toEqual([1, 2]);
+    unsub();
+    mod.bumpPageGeneration('hash-a', 0);
+    expect(seen).toEqual([1, 2]);
+  });
+
+  it('scopes generations per (pdfId, pageIndex)', async () => {
+    setupObjectUrls();
+    const mod = await import('../src/lib/pdf/thumbnails');
+
+    mod.bumpPageGeneration('hash-a', 0);
+    expect(mod.pageGeneration('hash-a', 0)).toBe(1);
+    expect(mod.pageGeneration('hash-a', 1)).toBe(0);
+    expect(mod.pageGeneration('hash-b', 0)).toBe(0);
+  });
+
+  it('revokeThumbnails clears generations and subscribers for the pdfId', async () => {
+    setupObjectUrls();
+    const mod = await import('../src/lib/pdf/thumbnails');
+
+    mod.bumpPageGeneration('hash-a', 0);
+    mod.bumpPageGeneration('hash-b', 0);
+    const seen: number[] = [];
+    mod.subscribePageGeneration('hash-a', 0, (g) => seen.push(g));
+
+    mod.revokeThumbnails('hash-a');
+
+    expect(mod.pageGeneration('hash-a', 0)).toBe(0);
+    expect(mod.pageGeneration('hash-b', 0)).toBe(1);
+
+    mod.bumpPageGeneration('hash-a', 0);
+    expect(seen).toEqual([]);
+  });
+
+  it('retainThumbnails drops generations for pages not in the retained set', async () => {
+    setupObjectUrls();
+    const mod = await import('../src/lib/pdf/thumbnails');
+
+    mod.bumpPageGeneration('hash-a', 0);
+    mod.bumpPageGeneration('hash-a', 1);
+    mod.bumpPageGeneration('hash-a', 2);
+
+    mod.retainThumbnails('hash-a', new Set([1]));
+
+    expect(mod.pageGeneration('hash-a', 0)).toBe(0);
+    expect(mod.pageGeneration('hash-a', 1)).toBe(1);
+    expect(mod.pageGeneration('hash-a', 2)).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #92.

## Summary
- Thumbnail strip composites committed annotations over the raw PDF thumbnail.
- Per-page generation counter in `thumbnails.ts`; `ThumbnailStrip` subscribes and re-composites only the affected page.
- Commit-driven refresh: `document.ts` exposes `onPageCommit`, fired only on add/remove/update/clear/undo/redo — live strokes don't trigger (they never touch the store).
- Canvas-backed types (strokes, lines, shapes, number lines, angle marks) reuse the existing renderers; graphs/text render minimal thumbnail-sized placeholders.
- Existing `revokeThumbnails`/`retainThumbnails` cleanup also drops per-page generation state.

## Testing
- `pnpm lint`, `pnpm test`: 363/363 pass (+ new `thumbnail-composite.test.ts`).