### PR TITLE
feat(shortcuts): swap color and preset number bindings (#90)

### DIFF
--- a/src/lib/app/shortcutRegistry.ts
+++ b/src/lib/app/shortcutRegistry.ts
@@ -202,7 +202,7 @@ function buildCommands(): ShortcutCommand[] {
     list.push({
       id: `preset.${n}` as ShortcutId,
       label: `Apply preset ${n}`,
-      defaultSpec: `Mod+${n}`,
+      defaultSpec: `${n}`,
       run: () => sidebar.applyPresetSlot(n),
       preventDefault: true,
     });
@@ -212,7 +212,7 @@ function buildCommands(): ShortcutCommand[] {
     list.push({
       id: `palette.${n}` as ShortcutId,
       label: `Pick palette color ${n}`,
-      defaultSpec: `${n}`,
+      defaultSpec: `Mod+${n}`,
       run: () => pickPaletteSlot(n),
     });
   }

--- a/src/lib/store/shortcuts.ts
+++ b/src/lib/store/shortcuts.ts
@@ -10,7 +10,7 @@ const STORAGE_KEY = 'eldraw.shortcuts.v1';
  *
  * Legacy (unversioned) payloads are treated as version 0.
  */
-export const SHORTCUTS_SCHEMA_VERSION = 1;
+export const SHORTCUTS_SCHEMA_VERSION = 2;
 
 export type ShortcutBindings = Record<ShortcutId, string>;
 
@@ -28,11 +28,28 @@ type Migration = (bindings: Partial<Record<ShortcutId, string>>) => void;
  * v0 → v1: command palette default moved from Mod+K to Mod+P (#89). Users
  * whose stored binding still matches the old default are bumped; custom
  * bindings are left alone.
+ *
+ * v1 → v2: number-key bindings swapped (#90). `1`..`9` now select preset
+ * slots (was color slots), `Mod+1`..`Mod+9` now select color slots (was
+ * preset slots). Only stored bindings still matching the old defaults are
+ * rewritten; user customizations are preserved.
  */
 const MIGRATIONS: Migration[] = [
   (bindings) => {
     if (bindings['commandPalette.open'] === 'Mod+K') {
       bindings['commandPalette.open'] = 'Mod+P';
+    }
+  },
+  (bindings) => {
+    for (let n = 1; n <= 9; n++) {
+      const presetId = `preset.${n}` as ShortcutId;
+      const paletteId = `palette.${n}` as ShortcutId;
+      if (bindings[presetId] === `Mod+${n}`) {
+        bindings[presetId] = `${n}`;
+      }
+      if (bindings[paletteId] === `${n}`) {
+        bindings[paletteId] = `Mod+${n}`;
+      }
     }
   },
 ];

--- a/tests/shortcut-store.test.ts
+++ b/tests/shortcut-store.test.ts
@@ -208,21 +208,6 @@ describe('shortcuts store', () => {
     }
   });
 
-  it('v1 → v2 migration swaps stored bindings still at old defaults', () => {
-    const stored: Record<string, string> = {};
-    for (let n = 1; n <= 9; n++) {
-      stored[`preset.${n}`] = `Mod+${n}`;
-      stored[`palette.${n}`] = `${n}`;
-    }
-    memory.setItem(SHORTCUTS_STORAGE_KEY, JSON.stringify({ version: 1, bindings: stored }));
-    shortcutsStore.hydrate();
-    const snap = shortcutsStore.snapshot();
-    for (let n = 1; n <= 9; n++) {
-      expect(snap[`preset.${n}` as ShortcutId]).toBe(`${n}`);
-      expect(snap[`palette.${n}` as ShortcutId]).toBe(`Mod+${n}`);
-    }
-  });
-
   it('v1 → v2 migration preserves user overrides that differ from old defaults', () => {
     memory.setItem(
       SHORTCUTS_STORAGE_KEY,

--- a/tests/shortcut-store.test.ts
+++ b/tests/shortcut-store.test.ts
@@ -7,6 +7,7 @@ import {
   SHORTCUTS_SCHEMA_VERSION,
 } from '../src/lib/store/shortcuts';
 import { DEFAULT_BINDINGS } from '../src/lib/app/shortcutRegistry';
+import type { ShortcutId } from '../src/lib/app/shortcutRegistry';
 
 class MemoryStorage {
   private map = new Map<string, string>();
@@ -183,5 +184,63 @@ describe('shortcuts store', () => {
     const snap = shortcutsStore.snapshot();
     expect(snap['commandPalette.open']).toBe('Mod+P');
     expect(snap['tool.eraser']).toBe('Alt+E');
+  });
+
+  it('number-key defaults: 1-9 pick presets, Mod+1-9 pick colors', () => {
+    for (let n = 1; n <= 9; n++) {
+      expect(DEFAULT_BINDINGS[`preset.${n}` as ShortcutId]).toBe(`${n}`);
+      expect(DEFAULT_BINDINGS[`palette.${n}` as ShortcutId]).toBe(`Mod+${n}`);
+    }
+  });
+
+  it('v1 → v2 migration swaps stored bindings still at old defaults', () => {
+    const stored: Record<string, string> = {};
+    for (let n = 1; n <= 9; n++) {
+      stored[`preset.${n}`] = `Mod+${n}`;
+      stored[`palette.${n}`] = `${n}`;
+    }
+    memory.setItem(SHORTCUTS_STORAGE_KEY, JSON.stringify({ version: 1, bindings: stored }));
+    shortcutsStore.hydrate();
+    const snap = shortcutsStore.snapshot();
+    for (let n = 1; n <= 9; n++) {
+      expect(snap[`preset.${n}` as ShortcutId]).toBe(`${n}`);
+      expect(snap[`palette.${n}` as ShortcutId]).toBe(`Mod+${n}`);
+    }
+  });
+
+  it('v1 → v2 migration swaps stored bindings still at old defaults', () => {
+    const stored: Record<string, string> = {};
+    for (let n = 1; n <= 9; n++) {
+      stored[`preset.${n}`] = `Mod+${n}`;
+      stored[`palette.${n}`] = `${n}`;
+    }
+    memory.setItem(SHORTCUTS_STORAGE_KEY, JSON.stringify({ version: 1, bindings: stored }));
+    shortcutsStore.hydrate();
+    const snap = shortcutsStore.snapshot();
+    for (let n = 1; n <= 9; n++) {
+      expect(snap[`preset.${n}` as ShortcutId]).toBe(`${n}`);
+      expect(snap[`palette.${n}` as ShortcutId]).toBe(`Mod+${n}`);
+    }
+  });
+
+  it('v1 → v2 migration preserves user overrides that differ from old defaults', () => {
+    memory.setItem(
+      SHORTCUTS_STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        bindings: {
+          'preset.1': 'Shift+1',
+          'palette.1': 'Alt+1',
+          'preset.2': 'Mod+2',
+          'palette.2': '2',
+        },
+      }),
+    );
+    shortcutsStore.hydrate();
+    const snap = shortcutsStore.snapshot();
+    expect(snap['preset.1']).toBe('Shift+1');
+    expect(snap['palette.1']).toBe('Alt+1');
+    expect(snap['preset.2']).toBe(`2`);
+    expect(snap['palette.2']).toBe(`Mod+2`);
   });
 });


### PR DESCRIPTION
Closes #90. Unmodified `1`–`9` pick presets, `Mod+1`–`Mod+9` pick colors. v1→v2 migration rewrites bindings still at the old defaults while preserving user overrides.