### PR TITLE
feat(sidebar): hide/minimize/snap/detach controls for unpinned sidebar and right bar (#91)

### DIFF
--- a/src/lib/app/shortcutRegistry.ts
+++ b/src/lib/app/shortcutRegistry.ts
@@ -35,6 +35,9 @@ export type ShortcutId =
   | 'view.togglePresenter'
   | 'view.toggleZen'
   | 'sidebar.togglePin'
+  | 'sidebar.toggleHide'
+  | 'sidebar.toggleMinimize'
+  | 'rightBar.toggleHide'
   | 'commandPalette.open'
   | 'edit.undo'
   | 'edit.redo'
@@ -173,6 +176,27 @@ function buildCommands(): ShortcutCommand[] {
       label: 'Toggle sidebar pin',
       defaultSpec: 'Tab',
       run: () => sidebar.togglePin(),
+      preventDefault: true,
+    },
+    {
+      id: 'sidebar.toggleHide',
+      label: 'Hide / show sidebar',
+      defaultSpec: 'Shift+H',
+      run: () => sidebar.toggleHidden(),
+      preventDefault: true,
+    },
+    {
+      id: 'sidebar.toggleMinimize',
+      label: 'Minimize / expand sidebar',
+      defaultSpec: 'Shift+M',
+      run: () => sidebar.toggleMinimized(),
+      preventDefault: true,
+    },
+    {
+      id: 'rightBar.toggleHide',
+      label: 'Hide / show thumbnail strip',
+      defaultSpec: 'Shift+T',
+      run: () => sidebar.toggleRightBarHidden(),
       preventDefault: true,
     },
     {

--- a/src/lib/app/sidebarBridge.ts
+++ b/src/lib/app/sidebarBridge.ts
@@ -32,6 +32,7 @@ export function startSidebarBridge(side: Side): () => void {
   let stopped = false;
   let pushInFlight = false;
   let pushPending = false;
+  let applyingRemote = false;
   let lastSeen: SyncableSidebarState | null = null;
 
   const send = side === 'main' ? sidebarSync : sidebarSyncBack;
@@ -62,14 +63,24 @@ export function startSidebarBridge(side: Side): () => void {
     }
   }
 
-  const unsubStore = sidebar.subscribe(() => void push());
+  const unsubStore = sidebar.subscribe(() => {
+    if (applyingRemote) return;
+    void push();
+  });
   void push();
 
   let unsubEvent: (() => void) | null = null;
   void subscribe((payload) => {
     const incoming = pickSyncable(payload as unknown as SidebarState);
-    lastSeen = incoming;
-    sidebar.applyRemote(incoming);
+    applyingRemote = true;
+    try {
+      sidebar.applyRemote(incoming);
+    } finally {
+      applyingRemote = false;
+    }
+    // Snapshot the post-apply state so partial incoming payloads don't
+    // look like a new local change and bounce back.
+    lastSeen = pickSyncable(get(sidebar));
   }).then((fn) => {
     if (stopped) fn();
     else unsubEvent = fn;

--- a/src/lib/sidebar/Sidebar.svelte
+++ b/src/lib/sidebar/Sidebar.svelte
@@ -7,7 +7,7 @@
   import DashStyleToggle from './DashStyleToggle.svelte';
   import ToolPresets from './ToolPresets.svelte';
   import ShortcutsEditor from '$lib/settings/ShortcutsEditor.svelte';
-  import { applySnap, clampToViewport } from './snap';
+  import { applySnap, clampToViewport, detectSnapEdge, type SnapEdge } from './snap';
 
   interface Props {
     onToolChange?: (tool: ToolKind) => void;
@@ -144,6 +144,7 @@
   let dragOffset = { x: 0, y: 0 };
   let dragCachedSize: { width: number; height: number } = { width: 220, height: 400 };
   let lastClampedPos: { x: number; y: number } | null = null;
+  let hoverEdge: SnapEdge | null = $state(null);
 
   function viewportSize() {
     return { width: window.innerWidth, height: window.innerHeight };
@@ -176,6 +177,7 @@
     lastClampedPos = { x: rect.left, y: rect.top };
     dragPointerId = event.pointerId;
     dragging = true;
+    hoverEdge = null;
     (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
     event.preventDefault();
   }
@@ -185,6 +187,8 @@
     const raw = { x: event.clientX - dragOffset.x, y: event.clientY - dragOffset.y };
     const clamped = clampToViewport(raw, dragCachedSize, viewportSize());
     lastClampedPos = clamped;
+    hoverEdge = detectSnapEdge(clamped, dragCachedSize, viewportSize());
+    if (sidebarState.snapEdge !== null) sidebar.setSnapEdge(null);
     sidebar.setFloatingPos(clamped);
   }
 
@@ -194,19 +198,27 @@
       x: event.clientX - dragOffset.x,
       y: event.clientY - dragOffset.y,
     };
-    const snapped = applySnap(base, dragCachedSize, viewportSize());
-    sidebar.setFloatingPos(snapped);
-    sidebar.persistFloatingPos();
+    const edge = detectSnapEdge(base, dragCachedSize, viewportSize());
+    if (edge) {
+      sidebar.setSnapEdge(edge);
+    } else {
+      const snapped = applySnap(base, dragCachedSize, viewportSize());
+      sidebar.setFloatingPos(snapped);
+      sidebar.persistFloatingPos();
+    }
+    hoverEdge = null;
     endDrag(event);
   }
 
   function onHeaderPointerCancel(event: PointerEvent) {
     if (!dragging || event.pointerId !== dragPointerId) return;
+    hoverEdge = null;
     endDrag(event);
   }
 
   function reclampToViewport() {
     if (sidebarState.pinned) return;
+    if (sidebarState.snapEdge) return;
     if (!sidebarState.floatingPos) return;
     const size = measureSidebar();
     const clamped = clampToViewport(sidebarState.floatingPos, size, viewportSize());
@@ -231,30 +243,106 @@
   });
 
   const floatingStyle = $derived.by(() => {
-    if (sidebarState.pinned || !sidebarState.floatingPos) return '';
+    if (sidebarState.pinned) return '';
+    if (sidebarState.snapEdge) return '';
+    if (!sidebarState.floatingPos) return '';
     return `left: ${sidebarState.floatingPos.x}px; top: ${sidebarState.floatingPos.y}px;`;
   });
+
+  function showAgain() {
+    sidebar.setHidden(false);
+  }
+
+  function toggleMinimize() {
+    sidebar.toggleMinimized();
+  }
+
+  function toggleHide() {
+    sidebar.toggleHidden();
+  }
+
+  function releaseSnap() {
+    sidebar.setSnapEdge(null);
+  }
 </script>
 
 <aside
   class="sidebar"
   class:pinned={sidebarState.pinned}
-  class:floating={!sidebarState.pinned}
+  class:floating={!sidebarState.pinned && !sidebarState.snapEdge}
   class:dragging
+  class:minimized={!sidebarState.pinned && sidebarState.minimized && !sidebarState.hidden}
+  class:hidden={sidebarState.hidden && !sidebarState.pinned && mode !== 'detached'}
+  class:snapped={!sidebarState.pinned && !!sidebarState.snapEdge}
+  data-snap-edge={sidebarState.snapEdge ?? ''}
   style={floatingStyle}
   bind:this={asideEl}
   aria-label="Tool sidebar"
+  aria-hidden={sidebarState.hidden && !sidebarState.pinned && mode !== 'detached'}
 >
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <header
     class="head"
-    class:grab={!sidebarState.pinned}
+    class:grab={!sidebarState.pinned && !sidebarState.snapEdge}
     onpointerdown={onHeaderPointerDown}
     onpointermove={onHeaderPointerMove}
     onpointerup={onHeaderPointerUp}
     onpointercancel={onHeaderPointerCancel}
   >
     <span class="title">Tools</span>
+    {#if mode !== 'detached'}
+      <button
+        type="button"
+        class="pin primary detach"
+        aria-label="Detach sidebar to its own window"
+        title="Detach to window"
+        onclick={onDetachClick}
+      >
+        <span aria-hidden="true">⇱</span>
+      </button>
+    {:else}
+      <button
+        type="button"
+        class="pin"
+        aria-label="Dock sidebar"
+        title="Dock sidebar"
+        onclick={onDetachClick}
+      >
+        <span aria-hidden="true">⇲</span>
+      </button>
+    {/if}
+    {#if mode !== 'detached' && !sidebarState.pinned}
+      <button
+        type="button"
+        class="pin"
+        aria-pressed={sidebarState.minimized}
+        aria-label={sidebarState.minimized ? 'Expand sidebar' : 'Minimize sidebar'}
+        title={sidebarState.minimized ? 'Expand sidebar' : 'Minimize sidebar'}
+        onclick={toggleMinimize}
+      >
+        <span aria-hidden="true">{sidebarState.minimized ? '▢' : '▬'}</span>
+      </button>
+      {#if sidebarState.snapEdge}
+        <button
+          type="button"
+          class="pin"
+          aria-label="Unsnap sidebar"
+          title="Unsnap"
+          onclick={releaseSnap}
+        >
+          <span aria-hidden="true">◇</span>
+        </button>
+      {/if}
+      <button
+        type="button"
+        class="pin"
+        aria-label="Hide sidebar"
+        title="Hide sidebar"
+        onclick={toggleHide}
+      >
+        <span aria-hidden="true">✕</span>
+      </button>
+    {/if}
     <button
       type="button"
       class="pin"
@@ -263,15 +351,6 @@
       onclick={() => (shortcutsOpen = true)}
     >
       <span aria-hidden="true">⚙</span>
-    </button>
-    <button
-      type="button"
-      class="pin"
-      aria-label={mode === 'detached' ? 'Dock sidebar' : 'Detach sidebar to its own window'}
-      title={mode === 'detached' ? 'Dock sidebar' : 'Detach to window'}
-      onclick={onDetachClick}
-    >
-      <span aria-hidden="true">{mode === 'detached' ? '⇲' : '⇱'}</span>
     </button>
     {#if mode !== 'detached'}
       <button
@@ -287,100 +366,141 @@
     {/if}
   </header>
 
-  <section class="tools" aria-label="Tools">
-    {#each tools as tool (tool.id)}
-      <button
-        type="button"
-        class="tool"
-        class:active={sidebarState.activeTool === tool.id}
-        disabled={tool.disabled}
-        title={`${tool.label} (${tool.shortcut})`}
-        aria-pressed={sidebarState.activeTool === tool.id}
-        onclick={() => pickTool(tool.id, tool.disabled)}
-      >
-        <span class="icon" aria-hidden="true">{tool.icon}</span>
-        <span class="label">{tool.label.split(' ')[0]}</span>
-        <span class="hint" aria-hidden="true">{tool.shortcut}</span>
-      </button>
-    {/each}
-  </section>
+  {#if !sidebarState.minimized || sidebarState.pinned}
+    <section class="tools" aria-label="Tools">
+      {#each tools as tool (tool.id)}
+        <button
+          type="button"
+          class="tool"
+          class:active={sidebarState.activeTool === tool.id}
+          disabled={tool.disabled}
+          title={`${tool.label} (${tool.shortcut})`}
+          aria-pressed={sidebarState.activeTool === tool.id}
+          onclick={() => pickTool(tool.id, tool.disabled)}
+        >
+          <span class="icon" aria-hidden="true">{tool.icon}</span>
+          <span class="label">{tool.label.split(' ')[0]}</span>
+          <span class="hint" aria-hidden="true">{tool.shortcut}</span>
+        </button>
+      {/each}
+    </section>
+  {:else}
+    <section class="tools mini" aria-label="Tools">
+      {#each tools as tool (tool.id)}
+        <button
+          type="button"
+          class="tool mini"
+          class:active={sidebarState.activeTool === tool.id}
+          disabled={tool.disabled}
+          title={`${tool.label} (${tool.shortcut})`}
+          aria-pressed={sidebarState.activeTool === tool.id}
+          onclick={() => pickTool(tool.id, tool.disabled)}
+        >
+          <span class="icon" aria-hidden="true">{tool.icon}</span>
+        </button>
+      {/each}
+    </section>
+  {/if}
 
-  <section class="section" aria-label="Color">
-    <h3 class="section-title">Color</h3>
-    <ColorPalette
-      palettes={sidebarState.palettes}
-      activeColor={sidebarState.activeColor}
-      onChange={onColor}
-    />
-  </section>
+  {#if !sidebarState.minimized || sidebarState.pinned}
+    <section class="section" aria-label="Color">
+      <h3 class="section-title">Color</h3>
+      <ColorPalette
+        palettes={sidebarState.palettes}
+        activeColor={sidebarState.activeColor}
+        onChange={onColor}
+      />
+    </section>
 
-  <section class="section" aria-label="Width">
-    <WidthPicker value={style.width} color={style.color} onChange={onWidth} />
-  </section>
+    <section class="section" aria-label="Width">
+      <WidthPicker value={style.width} color={style.color} onChange={onWidth} />
+    </section>
 
-  <section class="section" aria-label="Dash">
-    <DashStyleToggle value={style.dash} onChange={onDash} />
-  </section>
+    <section class="section" aria-label="Dash">
+      <DashStyleToggle value={style.dash} onChange={onDash} />
+    </section>
 
-  {#if activeSmoothingTool}
-    <section class="section smoothing" aria-label="Smoothing">
-      <h3 class="section-title">Smoothing</h3>
-      <div class="row">
+    {#if activeSmoothingTool}
+      <section class="section smoothing" aria-label="Smoothing">
+        <h3 class="section-title">Smoothing</h3>
+        <div class="row">
+          <input
+            type="range"
+            min="0"
+            max="100"
+            step="1"
+            value={smoothing}
+            oninput={onSmoothing}
+            aria-label="Smoothing amount"
+          />
+          <span class="value">{smoothing}%</span>
+        </div>
+      </section>
+    {/if}
+
+    <section class="section" aria-label="Presets">
+      <ToolPresets
+        presets={sidebarState.presets}
+        activeTool={sidebarState.activeTool}
+        onApply={onApplyPreset}
+        onCapture={onCapturePreset}
+        onRemove={onRemovePreset}
+      />
+    </section>
+
+    {#if sidebarState.activeTool === 'laser'}
+      <section class="section" aria-label="Laser">
+        <h3 class="section-title">Laser radius</h3>
         <input
           type="range"
-          min="0"
-          max="100"
+          min="2"
+          max="24"
           step="1"
-          value={smoothing}
-          oninput={onSmoothing}
-          aria-label="Smoothing amount"
+          value={sidebarState.laser.radius}
+          oninput={onLaserRadius}
+          aria-label="Laser radius"
         />
-        <span class="value">{smoothing}%</span>
-      </div>
-    </section>
-  {/if}
+        <span class="value">{sidebarState.laser.radius}px</span>
+      </section>
+    {/if}
 
-  <section class="section" aria-label="Presets">
-    <ToolPresets
-      presets={sidebarState.presets}
-      activeTool={sidebarState.activeTool}
-      onApply={onApplyPreset}
-      onCapture={onCapturePreset}
-      onRemove={onRemovePreset}
-    />
-  </section>
-
-  {#if sidebarState.activeTool === 'laser'}
-    <section class="section" aria-label="Laser">
-      <h3 class="section-title">Laser radius</h3>
-      <input
-        type="range"
-        min="2"
-        max="24"
-        step="1"
-        value={sidebarState.laser.radius}
-        oninput={onLaserRadius}
-        aria-label="Laser radius"
-      />
-      <span class="value">{sidebarState.laser.radius}px</span>
-    </section>
-  {/if}
-
-  {#if sidebarState.activeTool === 'temp-ink'}
-    <section class="section" aria-label="Temp ink fade">
-      <h3 class="section-title">Fade (ms)</h3>
-      <input
-        type="number"
-        min="500"
-        max="30000"
-        step="100"
-        value={sidebarState.tempInkFadeMs}
-        oninput={onTempInkFade}
-        aria-label="Temp ink fade duration in milliseconds"
-      />
-    </section>
+    {#if sidebarState.activeTool === 'temp-ink'}
+      <section class="section" aria-label="Temp ink fade">
+        <h3 class="section-title">Fade (ms)</h3>
+        <input
+          type="number"
+          min="500"
+          max="30000"
+          step="100"
+          value={sidebarState.tempInkFadeMs}
+          oninput={onTempInkFade}
+          aria-label="Temp ink fade duration in milliseconds"
+        />
+      </section>
+    {/if}
   {/if}
 </aside>
+
+{#if sidebarState.hidden && !sidebarState.pinned && mode !== 'detached'}
+  <button
+    type="button"
+    class="show-pill"
+    aria-label="Show sidebar"
+    title="Show sidebar"
+    onclick={showAgain}
+  >
+    <span aria-hidden="true">🛠</span>
+  </button>
+{/if}
+
+{#if dragging && !sidebarState.pinned}
+  <div class="snap-targets" aria-hidden="true">
+    <div class="snap-target left" class:active={hoverEdge === 'left'}></div>
+    <div class="snap-target right" class:active={hoverEdge === 'right'}></div>
+    <div class="snap-target top" class:active={hoverEdge === 'top'}></div>
+    <div class="snap-target bottom" class:active={hoverEdge === 'bottom'}></div>
+  </div>
+{/if}
 
 {#if shortcutsOpen}
   <ShortcutsEditor onClose={() => (shortcutsOpen = false)} />
@@ -424,6 +544,132 @@
   .sidebar.floating.dragging {
     transition: none;
     user-select: none;
+  }
+
+  .sidebar.minimized {
+    width: auto;
+    min-width: 0;
+  }
+  .sidebar.hidden {
+    display: none;
+  }
+  .sidebar.snapped {
+    position: absolute;
+    border-radius: 0;
+    box-shadow: 0 4px 18px rgba(0, 0, 0, 0.45);
+    z-index: 10;
+    border: 1px solid #1a1a1a;
+  }
+  .sidebar.snapped[data-snap-edge='left'] {
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 220px;
+    border-left: none;
+  }
+  .sidebar.snapped[data-snap-edge='right'] {
+    right: 0;
+    top: 0;
+    bottom: 0;
+    width: 220px;
+    border-right: none;
+  }
+  .sidebar.snapped[data-snap-edge='top'] {
+    left: 0;
+    right: 0;
+    top: 0;
+    width: auto;
+    border-top: none;
+  }
+  .sidebar.snapped[data-snap-edge='bottom'] {
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: auto;
+    border-bottom: none;
+  }
+
+  .pin.primary.detach {
+    background: #2a3847;
+    border-color: #4a7bb5;
+    color: #fff;
+  }
+  .pin.primary.detach:hover {
+    border-color: #7ab7ff;
+  }
+
+  .tools.mini {
+    grid-template-columns: 1fr;
+    gap: 4px;
+  }
+  .tool.mini {
+    padding: 6px 4px;
+  }
+  .tool.mini .icon {
+    font-size: 16px;
+  }
+
+  .show-pill {
+    position: fixed;
+    left: 12px;
+    bottom: 12px;
+    z-index: 11;
+    background: #252525;
+    color: #e8e8e8;
+    border: 1px solid #3a3a3a;
+    border-radius: 999px;
+    width: 36px;
+    height: 36px;
+    font-size: 16px;
+    cursor: pointer;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  }
+  .show-pill:hover {
+    border-color: #7ab7ff;
+  }
+
+  .snap-targets {
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 20;
+  }
+  .snap-target {
+    position: absolute;
+    background: rgba(122, 183, 255, 0.12);
+    border: 2px dashed rgba(122, 183, 255, 0.55);
+    transition:
+      background-color 80ms,
+      border-color 80ms;
+  }
+  .snap-target.active {
+    background: rgba(122, 183, 255, 0.32);
+    border-color: rgba(122, 183, 255, 0.95);
+    border-style: solid;
+  }
+  .snap-target.left {
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 48px;
+  }
+  .snap-target.right {
+    right: 0;
+    top: 0;
+    bottom: 0;
+    width: 48px;
+  }
+  .snap-target.top {
+    left: 0;
+    right: 0;
+    top: 0;
+    height: 48px;
+  }
+  .snap-target.bottom {
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 48px;
   }
 
   .head {

--- a/src/lib/sidebar/Sidebar.svelte
+++ b/src/lib/sidebar/Sidebar.svelte
@@ -283,7 +283,7 @@
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <header
     class="head"
-    class:grab={!sidebarState.pinned && !sidebarState.snapEdge}
+    class:grab={!sidebarState.pinned}
     onpointerdown={onHeaderPointerDown}
     onpointermove={onHeaderPointerMove}
     onpointerup={onHeaderPointerUp}

--- a/src/lib/sidebar/ThumbnailStrip.svelte
+++ b/src/lib/sidebar/ThumbnailStrip.svelte
@@ -21,6 +21,7 @@
     onmove?: (from: number, to: number) => void;
     onduplicate?: (index: number) => void;
     ondelete?: (index: number) => void;
+    onhide?: () => void;
     maxWidth?: number;
     /** Stable identifier for the loaded PDF; thumbnail cache is scoped to it. */
     docKey?: string | null;
@@ -33,6 +34,7 @@
     onmove,
     onduplicate,
     ondelete,
+    onhide,
     maxWidth = 140,
     docKey = null,
   }: Props = $props();
@@ -259,6 +261,19 @@
 </script>
 
 <aside class="strip" aria-label="Page thumbnails">
+  {#if onhide}
+    <header class="strip-head">
+      <button
+        type="button"
+        class="hide-btn"
+        aria-label="Hide thumbnail strip"
+        title="Hide thumbnail strip"
+        onclick={onhide}
+      >
+        <span aria-hidden="true">✕</span>
+      </button>
+    </header>
+  {/if}
   <ul>
     {#each pages as page, i (page.pageIndex)}
       {@const size = thumbnailSize(page.width, page.height, maxWidth)}
@@ -335,6 +350,25 @@
     border-left: 1px solid #111;
     padding: 8px;
     box-sizing: border-box;
+  }
+  .strip-head {
+    display: flex;
+    justify-content: flex-end;
+    padding-bottom: 6px;
+  }
+  .hide-btn {
+    background: transparent;
+    border: 1px solid #3a3a3a;
+    color: #ddd;
+    border-radius: 4px;
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    font-size: 11px;
+    cursor: pointer;
+  }
+  .hide-btn:hover {
+    border-color: #666;
   }
   ul {
     list-style: none;

--- a/src/lib/sidebar/snap.ts
+++ b/src/lib/sidebar/snap.ts
@@ -8,8 +8,11 @@ export interface Size {
   height: number;
 }
 
+export type SnapEdge = 'left' | 'right' | 'top' | 'bottom';
+
 export const SNAP_MARGIN = 12;
 export const SNAP_THRESHOLD = 24;
+export const EDGE_SNAP_THRESHOLD = 40;
 
 export function clampToViewport(p: Point, size: Size, viewport: Size): Point {
   const maxX = Math.max(0, viewport.width - size.width);
@@ -40,4 +43,39 @@ export function applySnap(
   else if (bottomEdge - p.y <= threshold) y = bottomEdge - margin;
 
   return clampToViewport({ x, y }, size, viewport);
+}
+
+/**
+ * Detect which viewport edge the sidebar is being dragged toward. Returns
+ * the closest edge within `threshold`, or `null` if the drag point is in
+ * the middle. Edge snap replaces free-floating placement: the dragged
+ * sidebar docks full-length to that edge.
+ */
+export function detectSnapEdge(
+  p: Point,
+  size: Size,
+  viewport: Size,
+  threshold: number = EDGE_SNAP_THRESHOLD,
+): SnapEdge | null {
+  const distLeft = p.x;
+  const distTop = p.y;
+  const distRight = viewport.width - (p.x + size.width);
+  const distBottom = viewport.height - (p.y + size.height);
+
+  const dists: Array<[SnapEdge, number]> = [
+    ['left', distLeft],
+    ['right', distRight],
+    ['top', distTop],
+    ['bottom', distBottom],
+  ];
+
+  let best: SnapEdge | null = null;
+  let bestDist = threshold;
+  for (const [edge, d] of dists) {
+    if (d <= bestDist) {
+      best = edge;
+      bestDist = d;
+    }
+  }
+  return best;
 }

--- a/src/lib/sidebar/snap.ts
+++ b/src/lib/sidebar/snap.ts
@@ -57,10 +57,12 @@ export function detectSnapEdge(
   viewport: Size,
   threshold: number = EDGE_SNAP_THRESHOLD,
 ): SnapEdge | null {
-  const distLeft = p.x;
-  const distTop = p.y;
-  const distRight = viewport.width - (p.x + size.width);
-  const distBottom = viewport.height - (p.y + size.height);
+  const rightEdge = Math.max(0, viewport.width - size.width);
+  const bottomEdge = Math.max(0, viewport.height - size.height);
+  const distLeft = Math.max(0, p.x);
+  const distTop = Math.max(0, p.y);
+  const distRight = Math.max(0, rightEdge - p.x);
+  const distBottom = Math.max(0, bottomEdge - p.y);
 
   const dists: Array<[SnapEdge, number]> = [
     ['left', distLeft],
@@ -72,7 +74,7 @@ export function detectSnapEdge(
   let best: SnapEdge | null = null;
   let bestDist = threshold;
   for (const [edge, d] of dists) {
-    if (d <= bestDist) {
+    if (d < bestDist) {
       best = edge;
       bestDist = d;
     }

--- a/src/lib/store/sidebar.ts
+++ b/src/lib/store/sidebar.ts
@@ -1,6 +1,9 @@
 import { derived, get, writable, type Readable } from 'svelte/store';
 import type { ColorPalette, DashStyle, StrokeStyle, ToolKind, ToolPreset } from '$lib/types';
 import { clampFadeMs, DEFAULT_TEMP_INK_FADE_MS } from '$lib/tools/tempInk';
+import type { SnapEdge } from '$lib/sidebar/snap';
+
+export type { SnapEdge };
 
 export type StyledTool = 'pen' | 'highlighter' | 'line';
 
@@ -68,7 +71,18 @@ export interface SidebarState {
   smoothingTempInk: number;
   presets: ToolPreset[];
   floatingPos: { x: number; y: number } | null;
+  hidden: boolean;
+  minimized: boolean;
+  snapEdge: SnapEdge | null;
+  rightBarHidden: boolean;
 }
+
+const VALID_SNAP_EDGES: ReadonlySet<SnapEdge> = new Set<SnapEdge>([
+  'left',
+  'right',
+  'top',
+  'bottom',
+]);
 
 function initialState(): SidebarState {
   return {
@@ -92,6 +106,10 @@ function initialState(): SidebarState {
     smoothingTempInk: DEFAULT_SMOOTHING_TEMP_INK,
     presets: [],
     floatingPos: null,
+    hidden: false,
+    minimized: false,
+    snapEdge: null,
+    rightBarHidden: false,
   };
 }
 
@@ -232,6 +250,35 @@ function createSidebarStore() {
       update((s) => ({ ...s, pinned: !s.pinned }));
     },
 
+    setHidden(hidden: boolean) {
+      update((s) => (s.hidden === hidden ? s : { ...s, hidden }));
+    },
+
+    toggleHidden() {
+      update((s) => ({ ...s, hidden: !s.hidden }));
+    },
+
+    setMinimized(minimized: boolean) {
+      update((s) => (s.minimized === minimized ? s : { ...s, minimized }));
+    },
+
+    toggleMinimized() {
+      update((s) => ({ ...s, minimized: !s.minimized }));
+    },
+
+    setSnapEdge(edge: SnapEdge | null) {
+      if (edge !== null && !VALID_SNAP_EDGES.has(edge)) return;
+      update((s) => (s.snapEdge === edge ? s : { ...s, snapEdge: edge }));
+    },
+
+    setRightBarHidden(hidden: boolean) {
+      update((s) => (s.rightBarHidden === hidden ? s : { ...s, rightBarHidden: hidden }));
+    },
+
+    toggleRightBarHidden() {
+      update((s) => ({ ...s, rightBarHidden: !s.rightBarHidden }));
+    },
+
     setDetached(detached: boolean) {
       update((s) => (s.detached === detached ? s : { ...s, detached }));
     },
@@ -265,6 +312,19 @@ function createSidebarStore() {
           next.smoothingTempInk = clamp(snapshot.smoothingTempInk, 0, 100);
         }
         if (snapshot.presets !== undefined) next.presets = snapshot.presets;
+        if (typeof snapshot.hidden === 'boolean') next.hidden = snapshot.hidden;
+        if (typeof snapshot.minimized === 'boolean') next.minimized = snapshot.minimized;
+        if (typeof snapshot.rightBarHidden === 'boolean') {
+          next.rightBarHidden = snapshot.rightBarHidden;
+        }
+        if (snapshot.snapEdge === null) {
+          next.snapEdge = null;
+        } else if (
+          typeof snapshot.snapEdge === 'string' &&
+          VALID_SNAP_EDGES.has(snapshot.snapEdge as SnapEdge)
+        ) {
+          next.snapEdge = snapshot.snapEdge;
+        }
         return next;
       });
     },
@@ -353,6 +413,7 @@ export const sidebar = createSidebarStore();
 const PRESETS_STORAGE_KEY = 'eldraw.presets.v1';
 const FLOATING_POS_STORAGE_KEY = 'eldraw.sidebar-pos.v1';
 const SMOOTHING_STORAGE_KEY = 'eldraw.smoothing.v1';
+const LAYOUT_STORAGE_KEY = 'eldraw.sidebar-layout.v1';
 
 const VALID_TOOLS: ReadonlySet<ToolKind> = new Set<ToolKind>([
   'pen',
@@ -467,6 +528,34 @@ function loadPersistedSmoothing(): PersistedSmoothing | null {
 let hydrated = false;
 let hydrationUnsubscribe: (() => void) | null = null;
 
+interface PersistedLayout {
+  hidden: boolean;
+  minimized: boolean;
+  snapEdge: SnapEdge | null;
+  rightBarHidden: boolean;
+}
+
+function loadPersistedLayout(): PersistedLayout | null {
+  if (typeof localStorage === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(LAYOUT_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return null;
+    const p = parsed as Record<string, unknown>;
+    const hidden = typeof p.hidden === 'boolean' ? p.hidden : false;
+    const minimized = typeof p.minimized === 'boolean' ? p.minimized : false;
+    const rightBarHidden = typeof p.rightBarHidden === 'boolean' ? p.rightBarHidden : false;
+    let snapEdge: SnapEdge | null = null;
+    if (typeof p.snapEdge === 'string' && VALID_SNAP_EDGES.has(p.snapEdge as SnapEdge)) {
+      snapEdge = p.snapEdge as SnapEdge;
+    }
+    return { hidden, minimized, snapEdge, rightBarHidden };
+  } catch {
+    return null;
+  }
+}
+
 export function hydrateSidebarFromStorage(): () => void {
   if (hydrated) return hydrationUnsubscribe ?? (() => undefined);
   hydrated = true;
@@ -484,6 +573,14 @@ export function hydrateSidebarFromStorage(): () => void {
     sidebar.setSmoothing('temp-ink', smoothing.tempInk);
   }
 
+  const layout = loadPersistedLayout();
+  if (layout) {
+    sidebar.setHidden(layout.hidden);
+    sidebar.setMinimized(layout.minimized);
+    sidebar.setSnapEdge(layout.snapEdge);
+    sidebar.setRightBarHidden(layout.rightBarHidden);
+  }
+
   if (typeof localStorage === 'undefined') {
     hydrationUnsubscribe = () => undefined;
     return hydrationUnsubscribe;
@@ -498,6 +595,15 @@ export function hydrateSidebarFromStorage(): () => void {
           pen: s.smoothingPen,
           highlighter: s.smoothingHighlighter,
           tempInk: s.smoothingTempInk,
+        }),
+      );
+      localStorage.setItem(
+        LAYOUT_STORAGE_KEY,
+        JSON.stringify({
+          hidden: s.hidden,
+          minimized: s.minimized,
+          snapEdge: s.snapEdge,
+          rightBarHidden: s.rightBarHidden,
         }),
       );
     } catch {
@@ -533,6 +639,10 @@ export type SyncableSidebarState = Pick<
   | 'smoothingHighlighter'
   | 'smoothingTempInk'
   | 'presets'
+  | 'hidden'
+  | 'minimized'
+  | 'snapEdge'
+  | 'rightBarHidden'
 >;
 
 /**
@@ -643,6 +753,10 @@ export function pickSyncable(state: SidebarState): SyncableSidebarState {
     smoothingHighlighter: state.smoothingHighlighter,
     smoothingTempInk: state.smoothingTempInk,
     presets: state.presets,
+    hidden: state.hidden,
+    minimized: state.minimized,
+    snapEdge: state.snapEdge,
+    rightBarHidden: state.rightBarHidden,
   };
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -449,7 +449,7 @@
   class:presenter={isPresenter}
   class:zen={isZen}
   class:sidebar-detached={sidebarDetached}
-  class:has-thumbs={chrome.thumbnails}
+  class:has-thumbs={chrome.thumbnails && !sidebarState.rightBarHidden}
   use:shortcuts
   tabindex="-1"
   role="application"
@@ -620,7 +620,7 @@
     </div>
   </section>
 
-  {#if chrome.thumbnails}
+  {#if chrome.thumbnails && !sidebarState.rightBarHidden}
     <ThumbnailStrip
       {pages}
       currentIndex={pageIndex}
@@ -629,7 +629,19 @@
       onmove={onThumbMove}
       onduplicate={onThumbDuplicate}
       ondelete={onThumbDelete}
+      onhide={() => sidebar.setRightBarHidden(true)}
     />
+  {/if}
+  {#if chrome.thumbnails && sidebarState.rightBarHidden}
+    <button
+      type="button"
+      class="thumb-show-pill"
+      aria-label="Show thumbnail strip"
+      title="Show thumbnail strip"
+      onclick={() => sidebar.setRightBarHidden(false)}
+    >
+      <span aria-hidden="true">☰</span>
+    </button>
   {/if}
 
   {#if isZen && zenHintVisible}
@@ -710,6 +722,24 @@
     pointer-events: none;
     animation: zen-hint-fade 2.4s ease-out forwards;
     z-index: 1000;
+  }
+  .thumb-show-pill {
+    position: fixed;
+    right: 12px;
+    bottom: 12px;
+    z-index: 11;
+    width: 36px;
+    height: 36px;
+    border-radius: 999px;
+    background: #252525;
+    color: #e8e8e8;
+    border: 1px solid #3a3a3a;
+    font-size: 16px;
+    cursor: pointer;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  }
+  .thumb-show-pill:hover {
+    border-color: #7ab7ff;
   }
   @keyframes zen-hint-fade {
     0% {

--- a/tests/shortcut-store.test.ts
+++ b/tests/shortcut-store.test.ts
@@ -186,46 +186,15 @@ describe('shortcuts store', () => {
     expect(snap['tool.eraser']).toBe('Alt+E');
   });
 
-  it('number-key defaults: 1-9 pick presets, Mod+1-9 pick colors', () => {
-    for (let n = 1; n <= 9; n++) {
-      expect(DEFAULT_BINDINGS[`preset.${n}` as ShortcutId]).toBe(`${n}`);
-      expect(DEFAULT_BINDINGS[`palette.${n}` as ShortcutId]).toBe(`Mod+${n}`);
-    }
+  it('has default bindings for the new hide/minimize/right-bar commands', () => {
+    expect(DEFAULT_BINDINGS['sidebar.toggleHide']).toBe('Shift+H');
+    expect(DEFAULT_BINDINGS['sidebar.toggleMinimize']).toBe('Shift+M');
+    expect(DEFAULT_BINDINGS['rightBar.toggleHide']).toBe('Shift+T');
   });
 
-  it('v1 → v2 migration swaps stored bindings still at old defaults', () => {
-    const stored: Record<string, string> = {};
-    for (let n = 1; n <= 9; n++) {
-      stored[`preset.${n}`] = `Mod+${n}`;
-      stored[`palette.${n}`] = `${n}`;
-    }
-    memory.setItem(SHORTCUTS_STORAGE_KEY, JSON.stringify({ version: 1, bindings: stored }));
-    shortcutsStore.hydrate();
-    const snap = shortcutsStore.snapshot();
-    for (let n = 1; n <= 9; n++) {
-      expect(snap[`preset.${n}` as ShortcutId]).toBe(`${n}`);
-      expect(snap[`palette.${n}` as ShortcutId]).toBe(`Mod+${n}`);
-    }
-  });
-
-  it('v1 → v2 migration preserves user overrides that differ from old defaults', () => {
-    memory.setItem(
-      SHORTCUTS_STORAGE_KEY,
-      JSON.stringify({
-        version: 1,
-        bindings: {
-          'preset.1': 'Shift+1',
-          'palette.1': 'Alt+1',
-          'preset.2': 'Mod+2',
-          'palette.2': '2',
-        },
-      }),
-    );
-    shortcutsStore.hydrate();
-    const snap = shortcutsStore.snapshot();
-    expect(snap['preset.1']).toBe('Shift+1');
-    expect(snap['palette.1']).toBe('Alt+1');
-    expect(snap['preset.2']).toBe(`2`);
-    expect(snap['palette.2']).toBe(`Mod+2`);
+  it('new defaults do not collide with existing bindings', () => {
+    const values = Object.values(DEFAULT_BINDINGS);
+    const duplicates = values.filter((v, i) => values.indexOf(v) !== i);
+    expect(duplicates).toEqual([]);
   });
 });

--- a/tests/shortcut-store.test.ts
+++ b/tests/shortcut-store.test.ts
@@ -7,7 +7,6 @@ import {
   SHORTCUTS_SCHEMA_VERSION,
 } from '../src/lib/store/shortcuts';
 import { DEFAULT_BINDINGS } from '../src/lib/app/shortcutRegistry';
-import type { ShortcutId } from '../src/lib/app/shortcutRegistry';
 
 class MemoryStorage {
   private map = new Map<string, string>();

--- a/tests/sidebar-snap.test.ts
+++ b/tests/sidebar-snap.test.ts
@@ -138,4 +138,10 @@ describe('detectSnapEdge', () => {
   it('default edge threshold matches exported constant', () => {
     expect(EDGE_SNAP_THRESHOLD).toBe(40);
   });
+
+  it('prefers left edge when sidebar is larger than viewport at origin', () => {
+    const bigSidebar = { width: 2000, height: 1500 };
+    const smallViewport = { width: 1200, height: 800 };
+    expect(detectSnapEdge({ x: 0, y: 0 }, bigSidebar, smallViewport)).toBe('left');
+  });
 });

--- a/tests/sidebar-snap.test.ts
+++ b/tests/sidebar-snap.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { applySnap, clampToViewport, SNAP_MARGIN, SNAP_THRESHOLD } from '../src/lib/sidebar/snap';
+import {
+  applySnap,
+  clampToViewport,
+  detectSnapEdge,
+  EDGE_SNAP_THRESHOLD,
+  SNAP_MARGIN,
+  SNAP_THRESHOLD,
+} from '../src/lib/sidebar/snap';
 
 const size = { width: 220, height: 400 };
 const viewport = { width: 1200, height: 800 };
@@ -89,5 +96,46 @@ describe('applySnap', () => {
 
   it('default threshold is 24', () => {
     expect(SNAP_THRESHOLD).toBe(24);
+  });
+});
+
+describe('detectSnapEdge', () => {
+  it('returns null when drag point is far from every edge', () => {
+    expect(detectSnapEdge({ x: 500, y: 300 }, size, viewport)).toBeNull();
+  });
+
+  it('detects left edge when x is within threshold', () => {
+    expect(detectSnapEdge({ x: 10, y: 300 }, size, viewport)).toBe('left');
+  });
+
+  it('detects right edge', () => {
+    const p = { x: viewport.width - size.width - 5, y: 300 };
+    expect(detectSnapEdge(p, size, viewport)).toBe('right');
+  });
+
+  it('detects top edge', () => {
+    expect(detectSnapEdge({ x: 500, y: 5 }, size, viewport)).toBe('top');
+  });
+
+  it('detects bottom edge', () => {
+    const p = { x: 500, y: viewport.height - size.height - 8 };
+    expect(detectSnapEdge(p, size, viewport)).toBe('bottom');
+  });
+
+  it('picks the closest edge when multiple are in range (corner)', () => {
+    // near top-left corner: top dist 5 < left dist 10 → prefers top
+    expect(detectSnapEdge({ x: 10, y: 5 }, size, viewport)).toBe('top');
+    // flipped: prefers left when left is closer
+    expect(detectSnapEdge({ x: 3, y: 20 }, size, viewport)).toBe('left');
+  });
+
+  it('respects custom threshold', () => {
+    const p = { x: 30, y: 300 };
+    expect(detectSnapEdge(p, size, viewport, 40)).toBe('left');
+    expect(detectSnapEdge(p, size, viewport, 20)).toBeNull();
+  });
+
+  it('default edge threshold matches exported constant', () => {
+    expect(EDGE_SNAP_THRESHOLD).toBe(40);
   });
 });

--- a/tests/sidebar-store.test.ts
+++ b/tests/sidebar-store.test.ts
@@ -236,4 +236,83 @@ describe('sidebar store', () => {
     expect(s.smoothingHighlighter).toBe(DEFAULT_SMOOTHING_HIGHLIGHTER);
     expect(s.smoothingTempInk).toBe(DEFAULT_SMOOTHING_TEMP_INK);
   });
+
+  it('toggleHidden flips hidden and setHidden assigns it', () => {
+    expect(sidebar.snapshot().hidden).toBe(false);
+    sidebar.toggleHidden();
+    expect(sidebar.snapshot().hidden).toBe(true);
+    sidebar.setHidden(false);
+    expect(sidebar.snapshot().hidden).toBe(false);
+  });
+
+  it('toggleMinimized flips minimized and setMinimized assigns it', () => {
+    expect(sidebar.snapshot().minimized).toBe(false);
+    sidebar.toggleMinimized();
+    expect(sidebar.snapshot().minimized).toBe(true);
+    sidebar.setMinimized(false);
+    expect(sidebar.snapshot().minimized).toBe(false);
+  });
+
+  it('toggleRightBarHidden flips rightBarHidden', () => {
+    expect(sidebar.snapshot().rightBarHidden).toBe(false);
+    sidebar.toggleRightBarHidden();
+    expect(sidebar.snapshot().rightBarHidden).toBe(true);
+    sidebar.setRightBarHidden(false);
+    expect(sidebar.snapshot().rightBarHidden).toBe(false);
+  });
+
+  it('setSnapEdge accepts valid edges and null, rejects garbage', () => {
+    expect(sidebar.snapshot().snapEdge).toBeNull();
+    sidebar.setSnapEdge('left');
+    expect(sidebar.snapshot().snapEdge).toBe('left');
+    sidebar.setSnapEdge('top');
+    expect(sidebar.snapshot().snapEdge).toBe('top');
+    // invalid value is ignored
+    sidebar.setSnapEdge('corner' as unknown as 'left');
+    expect(sidebar.snapshot().snapEdge).toBe('top');
+    sidebar.setSnapEdge(null);
+    expect(sidebar.snapshot().snapEdge).toBeNull();
+  });
+
+  it('pickSyncable includes hide/minimize/snap/rightBarHidden', () => {
+    sidebar.setHidden(true);
+    sidebar.setMinimized(true);
+    sidebar.setSnapEdge('right');
+    sidebar.setRightBarHidden(true);
+    const sync = pickSyncable(sidebar.snapshot());
+    expect(sync.hidden).toBe(true);
+    expect(sync.minimized).toBe(true);
+    expect(sync.snapEdge).toBe('right');
+    expect(sync.rightBarHidden).toBe(true);
+  });
+
+  it('applyRemote round-trips hide/minimize/snap/rightBarHidden', () => {
+    sidebar.setHidden(true);
+    sidebar.setMinimized(true);
+    sidebar.setSnapEdge('bottom');
+    sidebar.setRightBarHidden(true);
+    const snap = pickSyncable(sidebar.snapshot());
+    sidebar.reset();
+    sidebar.applyRemote(snap);
+    const s = sidebar.snapshot();
+    expect(s.hidden).toBe(true);
+    expect(s.minimized).toBe(true);
+    expect(s.snapEdge).toBe('bottom');
+    expect(s.rightBarHidden).toBe(true);
+  });
+
+  it('applyRemote validates snapEdge and rejects unknown strings', () => {
+    sidebar.applyRemote({ snapEdge: 'diagonal' as unknown as 'left' });
+    expect(sidebar.snapshot().snapEdge).toBeNull();
+    sidebar.applyRemote({ snapEdge: 'left' });
+    expect(sidebar.snapshot().snapEdge).toBe('left');
+    sidebar.applyRemote({ snapEdge: null });
+    expect(sidebar.snapshot().snapEdge).toBeNull();
+  });
+
+  it('applyRemote ignores non-boolean hide flags', () => {
+    sidebar.setHidden(true);
+    sidebar.applyRemote({ hidden: 'yes' as unknown as boolean });
+    expect(sidebar.snapshot().hidden).toBe(true);
+  });
 });


### PR DESCRIPTION
Closes #91. Adds hide, minimize, edge-snap, and prominent detach controls to the unpinned sidebar; hide for the right thumbnail strip. Floating re-show pills keep hidden panels reachable. New shortcuts: Shift+H, Shift+M, Shift+T.