### PR TITLE
feat(config): import/export settings as JSON (#93)

### DIFF
--- a/src/lib/command/commands.ts
+++ b/src/lib/command/commands.ts
@@ -12,6 +12,13 @@ import {
   insertBlankAfterCurrent,
   toggleFullscreen,
 } from '$lib/app/actions';
+import { hasBackup } from '$lib/config/import';
+import {
+  triggerExportSettings,
+  triggerImportSettings,
+  triggerResetSettings,
+  triggerRestorePreviousSettings,
+} from '$lib/config/commands';
 
 export interface Command {
   id: string;
@@ -162,6 +169,30 @@ export function getCommands(): Command[] {
       title: 'Cycle dash style',
       shortcut: 'D',
       run: () => sidebar.cycleDash(),
+    },
+    {
+      id: 'config.export',
+      title: 'Export settings…',
+      run: triggerExportSettings,
+    },
+    {
+      id: 'config.import',
+      title: 'Import settings…',
+      run: triggerImportSettings,
+    },
+    ...(hasBackup()
+      ? [
+          {
+            id: 'config.restore-previous',
+            title: 'Restore previous settings',
+            run: () => void triggerRestorePreviousSettings(),
+          } satisfies Command,
+        ]
+      : []),
+    {
+      id: 'config.reset',
+      title: 'Reset settings to defaults',
+      run: triggerResetSettings,
     },
   ];
 }

--- a/src/lib/config/ConfigDialog.svelte
+++ b/src/lib/config/ConfigDialog.svelte
@@ -1,8 +1,17 @@
 <script lang="ts">
+  import { tick } from 'svelte';
   import { closeConfigDialog, configDialog } from './dialog';
   import { applyConfig } from './import';
   import { shortcutsStore } from '$lib/store/shortcuts';
   import { sidebar } from '$lib/store/sidebar';
+
+  let modalEl: HTMLDivElement | null = $state(null);
+
+  $effect(() => {
+    if ($configDialog.kind !== 'closed') {
+      void tick().then(() => modalEl?.focus());
+    }
+  });
 
   function confirmImport(): void {
     const state = $configDialog;
@@ -27,6 +36,7 @@
 {#if $configDialog.kind !== 'closed'}
   <div class="backdrop" role="presentation" onclick={closeConfigDialog}>
     <div
+      bind:this={modalEl}
       class="modal"
       role="dialog"
       aria-modal="true"

--- a/src/lib/config/ConfigDialog.svelte
+++ b/src/lib/config/ConfigDialog.svelte
@@ -1,0 +1,165 @@
+<script lang="ts">
+  import { closeConfigDialog, configDialog } from './dialog';
+  import { applyConfig } from './import';
+  import { shortcutsStore } from '$lib/store/shortcuts';
+  import { sidebar } from '$lib/store/sidebar';
+
+  function confirmImport(): void {
+    const state = $configDialog;
+    if (state.kind !== 'import-preview') return;
+    applyConfig(state.incoming);
+    closeConfigDialog();
+  }
+
+  function escalateReset(): void {
+    const state = $configDialog;
+    if (state.kind !== 'reset-confirm') return;
+    if (state.step === 1) {
+      configDialog.set({ kind: 'reset-confirm', step: 2 });
+      return;
+    }
+    shortcutsStore.resetAll();
+    sidebar.reset();
+    closeConfigDialog();
+  }
+</script>
+
+{#if $configDialog.kind !== 'closed'}
+  <div class="backdrop" role="presentation" onclick={closeConfigDialog}>
+    <div
+      class="modal"
+      role="dialog"
+      aria-modal="true"
+      tabindex="-1"
+      onclick={(e) => e.stopPropagation()}
+      onkeydown={(e) => {
+        if (e.key === 'Escape') closeConfigDialog();
+      }}
+    >
+      {#if $configDialog.kind === 'import-preview'}
+        <h2>Import settings from {$configDialog.filename}</h2>
+        {#if $configDialog.diff.hasChanges}
+          <ul class="diff">
+            {#each $configDialog.diff.sections as section (section.section)}
+              <li>
+                <strong>{section.section}</strong> — {section.summary}
+                <ul>
+                  {#each section.changes as change}
+                    <li><code>{change}</code></li>
+                  {/each}
+                </ul>
+              </li>
+            {/each}
+          </ul>
+        {:else}
+          <p>Nothing to change — the incoming config matches your current settings.</p>
+        {/if}
+        <div class="actions">
+          <button type="button" onclick={closeConfigDialog}>Cancel</button>
+          <button
+            type="button"
+            class="primary"
+            disabled={!$configDialog.diff.hasChanges}
+            onclick={confirmImport}>Apply</button
+          >
+        </div>
+      {:else if $configDialog.kind === 'import-error'}
+        <h2>Couldn't import settings</h2>
+        <p class="error">{$configDialog.error.message}</p>
+        <div class="actions">
+          <button type="button" class="primary" onclick={closeConfigDialog}>Close</button>
+        </div>
+      {:else if $configDialog.kind === 'reset-confirm'}
+        <h2>Reset settings to defaults?</h2>
+        {#if $configDialog.step === 1}
+          <p>This will clear all shortcut customizations and sidebar tool presets.</p>
+        {:else}
+          <p><strong>Are you sure?</strong> This cannot be undone from this dialog.</p>
+        {/if}
+        <div class="actions">
+          <button type="button" onclick={closeConfigDialog}>Cancel</button>
+          <button type="button" class="danger" onclick={escalateReset}>
+            {$configDialog.step === 1 ? 'Continue…' : 'Reset everything'}
+          </button>
+        </div>
+      {/if}
+    </div>
+  </div>
+{/if}
+
+<style>
+  .backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1100;
+  }
+  .modal {
+    background: #252525;
+    color: #eee;
+    border: 1px solid #3a3a3a;
+    border-radius: 10px;
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.5);
+    padding: 18px 22px;
+    width: min(560px, 92vw);
+    max-height: 80vh;
+    overflow-y: auto;
+  }
+  h2 {
+    margin: 0 0 10px;
+    font-size: 15px;
+  }
+  .diff {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 12px;
+  }
+  .diff > li {
+    margin-bottom: 8px;
+  }
+  .diff ul {
+    margin: 4px 0 0 16px;
+    padding: 0;
+    list-style: disc;
+  }
+  code {
+    font-size: 12px;
+    color: #bcd;
+  }
+  .error {
+    color: #f88;
+  }
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 14px;
+  }
+  button {
+    background: #333;
+    color: #eee;
+    border: 1px solid #444;
+    border-radius: 6px;
+    padding: 6px 12px;
+    cursor: pointer;
+    font: inherit;
+  }
+  button:hover {
+    background: #3a3a3a;
+  }
+  button.primary {
+    background: #3a5a9a;
+    border-color: #4d77c4;
+  }
+  button.primary:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+  button.danger {
+    background: #8a2d2d;
+    border-color: #b14343;
+  }
+</style>

--- a/src/lib/config/commands.ts
+++ b/src/lib/config/commands.ts
@@ -6,7 +6,6 @@
  * vitest/SvelteKit without pulling in `@tauri-apps/plugin-fs`.
  */
 
-import { get } from 'svelte/store';
 import { buildConfigExport, defaultExportFilename, serializeConfig } from './export';
 import {
   applyConfig,
@@ -45,11 +44,16 @@ export function triggerImportSettings(
   input.type = 'file';
   input.accept = 'application/json,.json';
   input.style.display = 'none';
+
+  const cleanup = (): void => {
+    if (input.parentNode) input.parentNode.removeChild(input);
+  };
+
   input.addEventListener(
     'change',
     async () => {
       const file = input.files?.[0] ?? null;
-      doc.body.removeChild(input);
+      cleanup();
       if (!file) return;
       try {
         const raw = await file.text();
@@ -63,6 +67,20 @@ export function triggerImportSettings(
     },
     { once: true },
   );
+
+  // Not every browser/runtime fires `cancel`. Use window focus-return as a
+  // fallback so a cancelled picker never leaves the element dangling.
+  input.addEventListener('cancel', cleanup, { once: true });
+  if (typeof window !== 'undefined') {
+    window.addEventListener(
+      'focus',
+      () => {
+        setTimeout(cleanup, 500);
+      },
+      { once: true },
+    );
+  }
+
   doc.body.appendChild(input);
   input.click();
 }
@@ -99,9 +117,4 @@ export function _hasBackup(): boolean {
 /** Exposed for tests. */
 export function _clearBackupForTest(): void {
   clearBackup();
-}
-
-/** Avoid unused import when the commands file is tree-shaken. */
-export function _subscribeDialog() {
-  return get(configDialog);
 }

--- a/src/lib/config/commands.ts
+++ b/src/lib/config/commands.ts
@@ -1,0 +1,107 @@
+/**
+ * Glue between the command palette and the config IO layer.
+ *
+ * The export/import actions use the browser `<a download>` / `<input type="file">`
+ * flow so they work both inside Tauri (the webview handles it) and in plain
+ * vitest/SvelteKit without pulling in `@tauri-apps/plugin-fs`.
+ */
+
+import { get } from 'svelte/store';
+import { buildConfigExport, defaultExportFilename, serializeConfig } from './export';
+import {
+  applyConfig,
+  clearBackup,
+  diffConfig,
+  hasBackup,
+  parseConfig,
+  restorePreviousConfig,
+} from './import';
+import { configDialog } from './dialog';
+import type { ConfigExport } from './schema';
+
+export function triggerExportSettings(
+  doc: Document | null = typeof document !== 'undefined' ? document : null,
+): void {
+  if (!doc) return;
+  const cfg = buildConfigExport();
+  const json = serializeConfig(cfg);
+  const blob = new Blob([json], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = doc.createElement('a');
+  a.href = url;
+  a.download = defaultExportFilename();
+  a.rel = 'noopener';
+  doc.body.appendChild(a);
+  a.click();
+  doc.body.removeChild(a);
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+
+export function triggerImportSettings(
+  doc: Document | null = typeof document !== 'undefined' ? document : null,
+): void {
+  if (!doc) return;
+  const input = doc.createElement('input');
+  input.type = 'file';
+  input.accept = 'application/json,.json';
+  input.style.display = 'none';
+  input.addEventListener(
+    'change',
+    async () => {
+      const file = input.files?.[0] ?? null;
+      doc.body.removeChild(input);
+      if (!file) return;
+      try {
+        const raw = await file.text();
+        handleImportedRaw(raw, file.name);
+      } catch (err) {
+        configDialog.set({
+          kind: 'import-error',
+          error: { kind: 'invalid-json', message: (err as Error).message },
+        });
+      }
+    },
+    { once: true },
+  );
+  doc.body.appendChild(input);
+  input.click();
+}
+
+export function handleImportedRaw(raw: string, filename: string): void {
+  const res = parseConfig(raw);
+  if (!res.ok) {
+    configDialog.set({ kind: 'import-error', error: res.error });
+    return;
+  }
+  const diff = diffConfig(buildConfigExport(), res.value);
+  configDialog.set({ kind: 'import-preview', incoming: res.value, diff, filename });
+}
+
+/** Used by the "Restore previous settings" command. */
+export function triggerRestorePreviousSettings(): boolean {
+  return restorePreviousConfig();
+}
+
+export function triggerResetSettings(): void {
+  configDialog.set({ kind: 'reset-confirm', step: 1 });
+}
+
+/** Exposed for tests. */
+export function _applyForTest(cfg: ConfigExport): void {
+  applyConfig(cfg);
+}
+
+/** Exposed for tests. */
+export function _hasBackup(): boolean {
+  return hasBackup();
+}
+
+/** Exposed for tests. */
+export function _clearBackupForTest(): void {
+  clearBackup();
+}
+
+/** Avoid unused import when the commands file is tree-shaken. */
+export function _subscribeDialog() {
+  return get(configDialog);
+}

--- a/src/lib/config/dialog.ts
+++ b/src/lib/config/dialog.ts
@@ -1,0 +1,14 @@
+import { writable } from 'svelte/store';
+import type { ConfigDiff, ConfigError, ConfigExport } from './schema';
+
+export type ConfigDialogMode =
+  | { kind: 'closed' }
+  | { kind: 'import-preview'; incoming: ConfigExport; diff: ConfigDiff; filename: string }
+  | { kind: 'import-error'; error: ConfigError }
+  | { kind: 'reset-confirm'; step: 1 | 2 };
+
+export const configDialog = writable<ConfigDialogMode>({ kind: 'closed' });
+
+export function closeConfigDialog(): void {
+  configDialog.set({ kind: 'closed' });
+}

--- a/src/lib/config/export.ts
+++ b/src/lib/config/export.ts
@@ -1,0 +1,61 @@
+import {
+  CONFIG_SCHEMA_VERSION,
+  type ConfigExport,
+  type ShortcutsSection,
+  type SidebarSection,
+} from './schema';
+import { shortcutsStore } from '$lib/store/shortcuts';
+import { getPersistableSidebarPayload } from '$lib/store/sidebar';
+
+declare const __APP_VERSION__: string | undefined;
+
+function appVersion(): string {
+  try {
+    if (typeof __APP_VERSION__ === 'string' && __APP_VERSION__.length > 0) {
+      return __APP_VERSION__;
+    }
+  } catch {
+    // __APP_VERSION__ is injected by Vite at build time; fall through.
+  }
+  return '0.0.0-dev';
+}
+
+export function buildConfigExport(now: Date = new Date()): ConfigExport {
+  const shortcutsPayload = shortcutsStore.getPersistablePayload();
+  const sidebarPayload = getPersistableSidebarPayload();
+
+  const shortcuts: ShortcutsSection = {
+    kind: 'shortcuts',
+    version: shortcutsPayload.version,
+    bindings: { ...shortcutsPayload.bindings },
+  };
+  const sidebar: SidebarSection = {
+    kind: 'sidebar',
+    version: sidebarPayload.version,
+    state: structuredCloneSafe(sidebarPayload.state),
+  };
+
+  return {
+    eldraw: 'config',
+    version: CONFIG_SCHEMA_VERSION,
+    exportedAt: now.toISOString(),
+    exportedBy: `eldraw-${appVersion()}`,
+    sections: { shortcuts, sidebar },
+  };
+}
+
+export function serializeConfig(cfg: ConfigExport): string {
+  return JSON.stringify(cfg, null, 2);
+}
+
+export function defaultExportFilename(now: Date = new Date()): string {
+  const y = now.getFullYear().toString().padStart(4, '0');
+  const m = (now.getMonth() + 1).toString().padStart(2, '0');
+  const d = now.getDate().toString().padStart(2, '0');
+  return `eldraw-config-${y}${m}${d}.json`;
+}
+
+function structuredCloneSafe<T>(value: T): T {
+  if (typeof structuredClone === 'function') return structuredClone(value);
+  return JSON.parse(JSON.stringify(value)) as T;
+}

--- a/src/lib/config/import.ts
+++ b/src/lib/config/import.ts
@@ -1,0 +1,255 @@
+import {
+  CONFIG_BACKUP_KEY,
+  CONFIG_SCHEMA_VERSION,
+  type ConfigBackup,
+  type ConfigDiff,
+  type ConfigError,
+  type ConfigExport,
+  type Result,
+  type SectionChange,
+} from './schema';
+import { buildConfigExport } from './export';
+import { shortcutsStore } from '$lib/store/shortcuts';
+import { applyImportedSidebarPayload } from '$lib/store/sidebar';
+
+function err(kind: ConfigError['kind'], message: string): Result<never, ConfigError> {
+  return { ok: false, error: { kind, message } };
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+export function parseConfig(raw: string): Result<ConfigExport, ConfigError> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    return err('invalid-json', `Not valid JSON: ${(e as Error).message}`);
+  }
+  if (!isRecord(parsed)) {
+    return err('invalid-shape', 'Config must be a JSON object.');
+  }
+  if (parsed.eldraw !== 'config') {
+    return err(
+      'not-config',
+      'Missing `"eldraw": "config"` sentinel — this file is not an eldraw config export.',
+    );
+  }
+  if (
+    typeof parsed.version !== 'number' ||
+    !Number.isInteger(parsed.version) ||
+    parsed.version < 1
+  ) {
+    return err('invalid-shape', 'Config `version` must be a positive integer.');
+  }
+  if (parsed.version > CONFIG_SCHEMA_VERSION) {
+    return err(
+      'unsupported-version',
+      `Config was exported by a newer eldraw (schema v${parsed.version}). ` +
+        `This build understands v${CONFIG_SCHEMA_VERSION} and below.`,
+    );
+  }
+  if (!isRecord(parsed.sections)) {
+    return err('invalid-shape', 'Config `sections` must be an object.');
+  }
+
+  const sections: ConfigExport['sections'] = {};
+  const rawSections = parsed.sections;
+
+  if (rawSections.shortcuts !== undefined) {
+    const s = rawSections.shortcuts;
+    if (!isRecord(s) || !isRecord(s.bindings)) {
+      return err('invalid-shape', 'Invalid `sections.shortcuts` payload.');
+    }
+    const bindings: Record<string, string> = {};
+    for (const [k, v] of Object.entries(s.bindings)) {
+      if (typeof v === 'string') bindings[k] = v;
+    }
+    const version = typeof s.version === 'number' ? s.version : 0;
+    sections.shortcuts = { kind: 'shortcuts', version, bindings };
+  }
+
+  if (rawSections.sidebar !== undefined) {
+    const s = rawSections.sidebar;
+    if (!isRecord(s) || !isRecord(s.state)) {
+      return err('invalid-shape', 'Invalid `sections.sidebar` payload.');
+    }
+    const version = typeof s.version === 'number' ? s.version : 0;
+    sections.sidebar = {
+      kind: 'sidebar',
+      version,
+      state: { ...s.state },
+    };
+  }
+
+  const cfg: ConfigExport = {
+    eldraw: 'config',
+    version: parsed.version,
+    exportedAt: typeof parsed.exportedAt === 'string' ? parsed.exportedAt : '',
+    exportedBy: typeof parsed.exportedBy === 'string' ? parsed.exportedBy : '',
+    sections,
+  };
+  return { ok: true, value: cfg };
+}
+
+export function diffConfig(current: ConfigExport, incoming: ConfigExport): ConfigDiff {
+  const sections: SectionChange[] = [];
+
+  if (incoming.sections.shortcuts) {
+    const cur = current.sections.shortcuts?.bindings ?? {};
+    const next = incoming.sections.shortcuts.bindings;
+    const changes: string[] = [];
+    for (const [id, spec] of Object.entries(next)) {
+      if (cur[id] !== spec) {
+        changes.push(cur[id] ? `${id}: ${cur[id]} → ${spec}` : `${id}: set to ${spec}`);
+      }
+    }
+    for (const id of Object.keys(cur)) {
+      if (!(id in next)) changes.push(`${id}: ${cur[id]} → (unset)`);
+    }
+    if (changes.length > 0) {
+      sections.push({
+        section: 'shortcuts',
+        summary: `${changes.length} shortcut${changes.length === 1 ? '' : 's'} will change`,
+        changes,
+      });
+    }
+  }
+
+  if (incoming.sections.sidebar) {
+    const cur = current.sections.sidebar?.state ?? {};
+    const next = incoming.sections.sidebar.state;
+    const changes: string[] = [];
+    for (const [key, value] of Object.entries(next)) {
+      const before = (cur as Record<string, unknown>)[key];
+      if (!deepEqual(before, value)) {
+        changes.push(`${key}: ${preview(before)} → ${preview(value)}`);
+      }
+    }
+    if (changes.length > 0) {
+      sections.push({
+        section: 'sidebar',
+        summary: `${changes.length} sidebar field${changes.length === 1 ? '' : 's'} will change`,
+        changes,
+      });
+    }
+  }
+
+  return { hasChanges: sections.length > 0, sections };
+}
+
+function preview(v: unknown): string {
+  if (v === undefined) return '(unset)';
+  if (typeof v === 'string') return JSON.stringify(v);
+  if (typeof v === 'number' || typeof v === 'boolean' || v === null) return String(v);
+  try {
+    const s = JSON.stringify(v);
+    return s.length > 60 ? `${s.slice(0, 57)}…` : s;
+  } catch {
+    return '[object]';
+  }
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (typeof a !== 'object' || a === null || typeof b !== 'object' || b === null) return false;
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b) || a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i += 1) if (!deepEqual(a[i], b[i])) return false;
+    return true;
+  }
+  if (Array.isArray(b)) return false;
+  const aObj = a as Record<string, unknown>;
+  const bObj = b as Record<string, unknown>;
+  const aKeys = Object.keys(aObj);
+  const bKeys = Object.keys(bObj);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const key of aKeys) {
+    if (!Object.prototype.hasOwnProperty.call(bObj, key)) return false;
+    if (!deepEqual(aObj[key], bObj[key])) return false;
+  }
+  return true;
+}
+
+function writeBackup(current: ConfigExport): void {
+  if (typeof localStorage === 'undefined') return;
+  const backup: ConfigBackup = { backedUpAt: new Date().toISOString(), config: current };
+  try {
+    localStorage.setItem(CONFIG_BACKUP_KEY, JSON.stringify(backup));
+  } catch {
+    // Storage unavailable/full — non-fatal; restore simply won't be offered.
+  }
+}
+
+function readBackup(): ConfigBackup | null {
+  if (typeof localStorage === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(CONFIG_BACKUP_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed)) return null;
+    if (typeof parsed.backedUpAt !== 'string') return null;
+    if (!isRecord(parsed.config)) return null;
+    return parsed as unknown as ConfigBackup;
+  } catch {
+    return null;
+  }
+}
+
+export function hasBackup(): boolean {
+  return readBackup() !== null;
+}
+
+/**
+ * Persist the incoming config, after backing up the current live state so
+ * the user can undo via `restorePreviousConfig`. Each section is run
+ * through its store's own migration ladder via `applyImportedPayload`.
+ */
+export function applyConfig(cfg: ConfigExport): void {
+  writeBackup(buildConfigExport());
+  applySections(cfg);
+}
+
+function applySections(cfg: ConfigExport): void {
+  if (cfg.sections.shortcuts) {
+    shortcutsStore.applyImportedPayload({
+      version: cfg.sections.shortcuts.version,
+      bindings: cfg.sections.shortcuts.bindings,
+    });
+  }
+  if (cfg.sections.sidebar) {
+    applyImportedSidebarPayload({
+      version: cfg.sections.sidebar.version,
+      state: cfg.sections.sidebar.state,
+    });
+  }
+}
+
+export function restorePreviousConfig(): boolean {
+  const backup = readBackup();
+  if (!backup) return false;
+  const currentLive = buildConfigExport();
+  applySections(backup.config);
+  if (typeof localStorage !== 'undefined') {
+    try {
+      const replacement: ConfigBackup = {
+        backedUpAt: new Date().toISOString(),
+        config: currentLive,
+      };
+      localStorage.setItem(CONFIG_BACKUP_KEY, JSON.stringify(replacement));
+    } catch {
+      // ignore
+    }
+  }
+  return true;
+}
+
+export function clearBackup(): void {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.removeItem(CONFIG_BACKUP_KEY);
+  } catch {
+    // ignore
+  }
+}

--- a/src/lib/config/import.ts
+++ b/src/lib/config/import.ts
@@ -10,7 +10,7 @@ import {
 } from './schema';
 import { buildConfigExport } from './export';
 import { shortcutsStore } from '$lib/store/shortcuts';
-import { applyImportedSidebarPayload } from '$lib/store/sidebar';
+import { applyImportedSidebarPayload, previewImportedSidebarPayload } from '$lib/store/sidebar';
 
 function err(kind: ConfigError['kind'], message: string): Result<never, ConfigError> {
   return { ok: false, error: { kind, message } };
@@ -94,11 +94,12 @@ export function parseConfig(raw: string): Result<ConfigExport, ConfigError> {
 }
 
 export function diffConfig(current: ConfigExport, incoming: ConfigExport): ConfigDiff {
+  const effective = previewEffectiveConfig(incoming);
   const sections: SectionChange[] = [];
 
-  if (incoming.sections.shortcuts) {
+  if (effective.sections.shortcuts) {
     const cur = current.sections.shortcuts?.bindings ?? {};
-    const next = incoming.sections.shortcuts.bindings;
+    const next = effective.sections.shortcuts.bindings;
     const changes: string[] = [];
     for (const [id, spec] of Object.entries(next)) {
       if (cur[id] !== spec) {
@@ -117,9 +118,9 @@ export function diffConfig(current: ConfigExport, incoming: ConfigExport): Confi
     }
   }
 
-  if (incoming.sections.sidebar) {
+  if (effective.sections.sidebar) {
     const cur = current.sections.sidebar?.state ?? {};
-    const next = incoming.sections.sidebar.state;
+    const next = effective.sections.sidebar.state;
     const changes: string[] = [];
     for (const [key, value] of Object.entries(next)) {
       const before = (cur as Record<string, unknown>)[key];
@@ -137,6 +138,49 @@ export function diffConfig(current: ConfigExport, incoming: ConfigExport): Confi
   }
 
   return { hasChanges: sections.length > 0, sections };
+}
+
+/**
+ * Normalize an incoming config by running each section's migration and
+ * sanitize pipeline on a deep copy. The result mirrors what `applyConfig`
+ * would actually persist, without mutating live store state. Used by
+ * `diffConfig` so the preview reflects the post-migration world (e.g.
+ * Mod+K → Mod+P) rather than the raw bytes on disk.
+ */
+export function previewEffectiveConfig(cfg: ConfigExport): ConfigExport {
+  const out: ConfigExport = {
+    eldraw: 'config',
+    version: cfg.version,
+    exportedAt: cfg.exportedAt,
+    exportedBy: cfg.exportedBy,
+    sections: {},
+  };
+
+  if (cfg.sections.shortcuts) {
+    const bindings = shortcutsStore.previewImportedPayload({
+      version: cfg.sections.shortcuts.version,
+      bindings: cfg.sections.shortcuts.bindings,
+    });
+    out.sections.shortcuts = {
+      kind: 'shortcuts',
+      version: cfg.sections.shortcuts.version,
+      bindings: bindings as Record<string, string>,
+    };
+  }
+
+  if (cfg.sections.sidebar) {
+    const state = previewImportedSidebarPayload({
+      version: cfg.sections.sidebar.version,
+      state: cfg.sections.sidebar.state,
+    });
+    out.sections.sidebar = {
+      kind: 'sidebar',
+      version: cfg.sections.sidebar.version,
+      state: state as Record<string, unknown>,
+    };
+  }
+
+  return out;
 }
 
 function preview(v: unknown): string {

--- a/src/lib/config/schema.ts
+++ b/src/lib/config/schema.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared types for the portable config file ("export settings to JSON").
+ *
+ * The top-level envelope is versioned (`CONFIG_SCHEMA_VERSION`) and is
+ * separate from each section's own schema version. This lets individual
+ * sections evolve their migration ladder (shortcuts, sidebar) without
+ * forcing a global envelope bump. Unknown sections are ignored on import
+ * so new sections from future builds drop in cleanly.
+ */
+
+export const CONFIG_SCHEMA_VERSION = 1;
+
+export interface ShortcutsSection {
+  kind: 'shortcuts';
+  version: number;
+  bindings: Record<string, string>;
+}
+
+export interface SidebarSection {
+  kind: 'sidebar';
+  version: number;
+  state: Record<string, unknown>;
+}
+
+export type ConfigSection = ShortcutsSection | SidebarSection;
+
+export interface ConfigSections {
+  shortcuts?: ShortcutsSection;
+  sidebar?: SidebarSection;
+}
+
+export interface ConfigExport {
+  eldraw: 'config';
+  version: number;
+  exportedAt: string;
+  exportedBy: string;
+  sections: ConfigSections;
+}
+
+export type ConfigErrorKind =
+  | 'invalid-json'
+  | 'not-config'
+  | 'unsupported-version'
+  | 'invalid-shape';
+
+export interface ConfigError {
+  kind: ConfigErrorKind;
+  message: string;
+}
+
+export type Result<T, E> = { ok: true; value: T } | { ok: false; error: E };
+
+export const CONFIG_BACKUP_KEY = 'eldraw.config.backup';
+
+export interface ConfigBackup {
+  backedUpAt: string;
+  config: ConfigExport;
+}
+
+export interface SectionChange {
+  section: 'shortcuts' | 'sidebar';
+  summary: string;
+  changes: string[];
+}
+
+export interface ConfigDiff {
+  hasChanges: boolean;
+  sections: SectionChange[];
+}

--- a/src/lib/store/shortcuts.ts
+++ b/src/lib/store/shortcuts.ts
@@ -158,6 +158,26 @@ function createShortcutsStore() {
       set(readStorage());
     },
 
+    /**
+     * Shape used by the portable config export. Always writes the current
+     * schema version so consumers can decide whether to run migrations.
+     */
+    getPersistablePayload(): { version: number; bindings: ShortcutBindings } {
+      let current: ShortcutBindings = cloneDefaults();
+      subscribe((v) => (current = v))();
+      return { version: SHORTCUTS_SCHEMA_VERSION, bindings: { ...current } };
+    },
+
+    /**
+     * Apply a payload loaded from a config file. Runs the same migration
+     * ladder as storage hydration so older exports upgrade cleanly.
+     */
+    applyImportedPayload(payload: { version?: unknown; bindings?: unknown }): void {
+      const next = sanitize(payload);
+      persist(next);
+      set(next);
+    },
+
     /** Test-only: drop persisted state and restore defaults in memory. */
     _reset(): void {
       if (typeof localStorage !== 'undefined') {

--- a/src/lib/store/shortcuts.ts
+++ b/src/lib/store/shortcuts.ts
@@ -178,6 +178,26 @@ function createShortcutsStore() {
       set(next);
     },
 
+    /**
+     * Pure preview: run the migration ladder on a deep copy of the payload
+     * without mutating live state. Returns only the bindings actually present
+     * in the payload (defaults are not filled in), so the caller can diff
+     * against the current live bindings.
+     */
+    previewImportedPayload(payload: {
+      version?: unknown;
+      bindings?: unknown;
+    }): Partial<Record<ShortcutId, string>> {
+      const { version, bindings } = extractStoredBindings(payload);
+      runMigrations(bindings, version);
+      const out: Partial<Record<ShortcutId, string>> = {};
+      for (const id of SHORTCUT_IDS) {
+        const v = bindings[id];
+        if (typeof v === 'string' && v.length > 0) out[id] = v;
+      }
+      return out;
+    },
+
     /** Test-only: drop persisted state and restore defaults in memory. */
     _reset(): void {
       if (typeof localStorage !== 'undefined') {

--- a/src/lib/store/sidebar.ts
+++ b/src/lib/store/sidebar.ts
@@ -670,6 +670,27 @@ export function applyImportedSidebarPayload(payload: { version?: unknown; state?
   sidebar.applyRemote(sanitized);
 }
 
+/**
+ * Pure preview: run migrations + sanitize on a deep copy of the payload
+ * without mutating live state. Returns the subset of fields the importer
+ * would actually apply, so the caller can diff against the current state.
+ */
+export function previewImportedSidebarPayload(payload: {
+  version?: unknown;
+  state?: unknown;
+}): Partial<SyncableSidebarState> {
+  const rawState =
+    payload.state && typeof payload.state === 'object'
+      ? JSON.parse(JSON.stringify(payload.state))
+      : {};
+  const version =
+    typeof payload.version === 'number' && Number.isInteger(payload.version) && payload.version >= 0
+      ? payload.version
+      : 0;
+  runSidebarMigrations(rawState, version);
+  return sanitizeImportedSidebar(rawState);
+}
+
 export function syncableEqual(a: SyncableSidebarState, b: SyncableSidebarState): boolean {
   return deepEqual(a, b);
 }

--- a/src/lib/store/sidebar.ts
+++ b/src/lib/store/sidebar.ts
@@ -535,6 +535,101 @@ export type SyncableSidebarState = Pick<
   | 'presets'
 >;
 
+/**
+ * Current migration version for sidebar state serialized into a portable
+ * config export. Bump and append a step to `SIDEBAR_MIGRATIONS` when a
+ * field's meaning changes in a way old exports need to be translated.
+ */
+export const SIDEBAR_SCHEMA_VERSION = 1;
+
+type SidebarMigration = (state: Record<string, unknown>) => void;
+const SIDEBAR_MIGRATIONS: SidebarMigration[] = [];
+
+function isStrokeStyle(value: unknown): value is StrokeStyle {
+  if (!value || typeof value !== 'object') return false;
+  const s = value as Record<string, unknown>;
+  return (
+    typeof s.color === 'string' &&
+    typeof s.width === 'number' &&
+    Number.isFinite(s.width) &&
+    typeof s.dash === 'string' &&
+    VALID_DASH.has(s.dash as DashStyle) &&
+    typeof s.opacity === 'number' &&
+    Number.isFinite(s.opacity)
+  );
+}
+
+function isColorPalette(value: unknown): value is ColorPalette {
+  if (!value || typeof value !== 'object') return false;
+  const p = value as Record<string, unknown>;
+  if (typeof p.id !== 'string' || typeof p.name !== 'string') return false;
+  if (!Array.isArray(p.colors)) return false;
+  return p.colors.every((c): c is string => typeof c === 'string');
+}
+
+function sanitizeImportedSidebar(raw: Record<string, unknown>): Partial<SyncableSidebarState> {
+  const out: Partial<SyncableSidebarState> = {};
+  if (typeof raw.pinned === 'boolean') out.pinned = raw.pinned;
+  if (typeof raw.activeTool === 'string' && VALID_TOOLS.has(raw.activeTool as ToolKind)) {
+    out.activeTool = raw.activeTool as ToolKind;
+  }
+  if (raw.toolStyles && typeof raw.toolStyles === 'object') {
+    const ts = raw.toolStyles as Record<string, unknown>;
+    if (isStrokeStyle(ts.pen) && isStrokeStyle(ts.highlighter) && isStrokeStyle(ts.line)) {
+      out.toolStyles = {
+        pen: {
+          ...ts.pen,
+          width: clamp(ts.pen.width, 0.25, 64),
+          opacity: clamp(ts.pen.opacity, 0, 1),
+        },
+        highlighter: {
+          ...ts.highlighter,
+          width: clamp(ts.highlighter.width, 0.25, 64),
+          opacity: clamp(ts.highlighter.opacity, 0, 1),
+        },
+        line: {
+          ...ts.line,
+          width: clamp(ts.line.width, 0.25, 64),
+          opacity: clamp(ts.line.opacity, 0, 1),
+        },
+      };
+    }
+  }
+  if (Array.isArray(raw.palettes) && raw.palettes.every(isColorPalette)) {
+    out.palettes = raw.palettes.map((p) => ({ ...p, colors: [...p.colors] }));
+  }
+  if (typeof raw.activeColor === 'string') out.activeColor = raw.activeColor;
+  if (raw.laser && typeof raw.laser === 'object') {
+    const l = raw.laser as Record<string, unknown>;
+    if (typeof l.color === 'string' && typeof l.radius === 'number' && Number.isFinite(l.radius)) {
+      out.laser = { color: l.color, radius: clamp(l.radius, MIN_LASER_RADIUS, MAX_LASER_RADIUS) };
+    }
+  }
+  if (typeof raw.tempInkFadeMs === 'number' && Number.isFinite(raw.tempInkFadeMs)) {
+    out.tempInkFadeMs = clampFadeMs(raw.tempInkFadeMs);
+  }
+  if (typeof raw.smoothingPen === 'number' && Number.isFinite(raw.smoothingPen)) {
+    out.smoothingPen = clamp(raw.smoothingPen, 0, 100);
+  }
+  if (typeof raw.smoothingHighlighter === 'number' && Number.isFinite(raw.smoothingHighlighter)) {
+    out.smoothingHighlighter = clamp(raw.smoothingHighlighter, 0, 100);
+  }
+  if (typeof raw.smoothingTempInk === 'number' && Number.isFinite(raw.smoothingTempInk)) {
+    out.smoothingTempInk = clamp(raw.smoothingTempInk, 0, 100);
+  }
+  if (Array.isArray(raw.presets)) {
+    out.presets = raw.presets.filter(isValidPreset).map(sanitizePreset).slice(0, MAX_PRESETS);
+  }
+  return out;
+}
+
+function runSidebarMigrations(state: Record<string, unknown>, fromVersion: number): void {
+  const from = Number.isInteger(fromVersion) && fromVersion >= 0 ? fromVersion : 0;
+  for (let v = from; v < SIDEBAR_SCHEMA_VERSION; v++) {
+    SIDEBAR_MIGRATIONS[v]?.(state);
+  }
+}
+
 export function pickSyncable(state: SidebarState): SyncableSidebarState {
   return {
     pinned: state.pinned,
@@ -549,6 +644,30 @@ export function pickSyncable(state: SidebarState): SyncableSidebarState {
     smoothingTempInk: state.smoothingTempInk,
     presets: state.presets,
   };
+}
+
+export function getPersistableSidebarPayload(): { version: number; state: SyncableSidebarState } {
+  return { version: SIDEBAR_SCHEMA_VERSION, state: pickSyncable(get(sidebar)) };
+}
+
+/**
+ * Apply a sidebar payload from a portable config file. Runs the migration
+ * ladder against a mutable copy, then validates and merges field-by-field.
+ * Unknown or invalid fields are dropped (existing live state is kept) so
+ * older or tampered exports never leave the store in a broken state.
+ */
+export function applyImportedSidebarPayload(payload: { version?: unknown; state?: unknown }): void {
+  const rawState =
+    payload.state && typeof payload.state === 'object'
+      ? { ...(payload.state as Record<string, unknown>) }
+      : {};
+  const version =
+    typeof payload.version === 'number' && Number.isInteger(payload.version) && payload.version >= 0
+      ? payload.version
+      : 0;
+  runSidebarMigrations(rawState, version);
+  const sanitized = sanitizeImportedSidebar(rawState);
+  sidebar.applyRemote(sanitized);
 }
 
 export function syncableEqual(a: SyncableSidebarState, b: SyncableSidebarState): boolean {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -38,6 +38,7 @@
   import { createGraphObject } from '$lib/graph/graphObject';
   import GraphEditor from '$lib/graph/GraphEditor.svelte';
   import { CommandPalette } from '$lib/command';
+  import ConfigDialog from '$lib/config/ConfigDialog.svelte';
   import { log } from '$lib/log';
   import type {
     AngleMarkObject,
@@ -657,6 +658,7 @@
     </div>
   {/if}
   <CommandPalette />
+  <ConfigDialog />
 </main>
 
 <style>

--- a/tests/config-export.test.ts
+++ b/tests/config-export.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  buildConfigExport,
+  defaultExportFilename,
+  serializeConfig,
+} from '../src/lib/config/export';
+import { parseConfig } from '../src/lib/config/import';
+import { CONFIG_SCHEMA_VERSION } from '../src/lib/config/schema';
+import { shortcutsStore } from '../src/lib/store/shortcuts';
+import { sidebar } from '../src/lib/store/sidebar';
+
+class MemoryStorage {
+  private map = new Map<string, string>();
+  getItem(k: string): string | null {
+    return this.map.has(k) ? (this.map.get(k) as string) : null;
+  }
+  setItem(k: string, v: string): void {
+    this.map.set(k, String(v));
+  }
+  removeItem(k: string): void {
+    this.map.delete(k);
+  }
+  clear(): void {
+    this.map.clear();
+  }
+  key(i: number): string | null {
+    return Array.from(this.map.keys())[i] ?? null;
+  }
+  get length(): number {
+    return this.map.size;
+  }
+}
+
+const memory = new MemoryStorage();
+Object.defineProperty(globalThis, 'localStorage', {
+  value: memory,
+  writable: true,
+  configurable: true,
+});
+
+describe('config export', () => {
+  beforeEach(() => {
+    memory.clear();
+    shortcutsStore._reset();
+    sidebar.reset();
+  });
+
+  it('round-trips through parse without loss', () => {
+    shortcutsStore.setBinding('tool.pen', 'Shift+P');
+    sidebar.setSmoothing('pen', 30);
+
+    const cfg = buildConfigExport();
+    const serialized = serializeConfig(cfg);
+    const parsed = parseConfig(serialized);
+
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(parsed.value).toEqual(cfg);
+  });
+
+  it('serializeConfig pretty-prints', () => {
+    const cfg = buildConfigExport();
+    const out = serializeConfig(cfg);
+    expect(out).toContain('\n');
+    expect(out).toContain('  "eldraw": "config"');
+  });
+
+  it('tags export with current schema version and sentinel', () => {
+    const cfg = buildConfigExport();
+    expect(cfg.eldraw).toBe('config');
+    expect(cfg.version).toBe(CONFIG_SCHEMA_VERSION);
+    expect(cfg.sections.shortcuts?.kind).toBe('shortcuts');
+    expect(cfg.sections.sidebar?.kind).toBe('sidebar');
+  });
+
+  it('filename is eldraw-config-YYYYMMDD.json', () => {
+    const d = new Date(2026, 3, 21);
+    expect(defaultExportFilename(d)).toBe('eldraw-config-20260421.json');
+  });
+});

--- a/tests/config-import.test.ts
+++ b/tests/config-import.test.ts
@@ -1,0 +1,235 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  applyConfig,
+  clearBackup,
+  diffConfig,
+  hasBackup,
+  parseConfig,
+  restorePreviousConfig,
+} from '../src/lib/config/import';
+import { buildConfigExport, serializeConfig } from '../src/lib/config/export';
+import { CONFIG_SCHEMA_VERSION, type ConfigExport } from '../src/lib/config/schema';
+import { shortcutsStore } from '../src/lib/store/shortcuts';
+import { sidebar } from '../src/lib/store/sidebar';
+import { DEFAULT_BINDINGS } from '../src/lib/app/shortcutRegistry';
+
+class MemoryStorage {
+  private map = new Map<string, string>();
+  getItem(k: string): string | null {
+    return this.map.has(k) ? (this.map.get(k) as string) : null;
+  }
+  setItem(k: string, v: string): void {
+    this.map.set(k, String(v));
+  }
+  removeItem(k: string): void {
+    this.map.delete(k);
+  }
+  clear(): void {
+    this.map.clear();
+  }
+  key(i: number): string | null {
+    return Array.from(this.map.keys())[i] ?? null;
+  }
+  get length(): number {
+    return this.map.size;
+  }
+}
+
+const memory = new MemoryStorage();
+Object.defineProperty(globalThis, 'localStorage', {
+  value: memory,
+  writable: true,
+  configurable: true,
+});
+
+beforeEach(() => {
+  memory.clear();
+  shortcutsStore._reset();
+  sidebar.reset();
+  clearBackup();
+});
+
+describe('config import: parse', () => {
+  it('accepts a valid v1 config and applies it', () => {
+    const cfg: ConfigExport = {
+      eldraw: 'config',
+      version: 1,
+      exportedAt: '2026-04-21T00:00:00.000Z',
+      exportedBy: 'eldraw-test',
+      sections: {
+        shortcuts: {
+          kind: 'shortcuts',
+          version: 1,
+          bindings: { 'tool.pen': 'Shift+P' },
+        },
+        sidebar: {
+          kind: 'sidebar',
+          version: 1,
+          state: { smoothingPen: 30 },
+        },
+      },
+    };
+    const res = parseConfig(JSON.stringify(cfg));
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+
+    applyConfig(res.value);
+
+    expect(shortcutsStore.snapshot()['tool.pen']).toBe('Shift+P');
+    expect(sidebar.snapshot().smoothingPen).toBe(30);
+  });
+
+  it('rejects an unknown future schema version with a clear error', () => {
+    const cfg = {
+      eldraw: 'config',
+      version: CONFIG_SCHEMA_VERSION + 1,
+      exportedAt: '',
+      exportedBy: '',
+      sections: {},
+    };
+    const res = parseConfig(JSON.stringify(cfg));
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.kind).toBe('unsupported-version');
+    expect(res.error.message).toMatch(/newer eldraw/i);
+  });
+
+  it('rejects malformed JSON without touching live state', () => {
+    shortcutsStore.setBinding('tool.pen', 'Shift+P');
+    const before = shortcutsStore.snapshot()['tool.pen'];
+
+    const res = parseConfig('{ not json');
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.kind).toBe('invalid-json');
+
+    expect(shortcutsStore.snapshot()['tool.pen']).toBe(before);
+  });
+
+  it('rejects payload missing the eldraw sentinel', () => {
+    const cfg = { version: 1, sections: {} };
+    const res = parseConfig(JSON.stringify(cfg));
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.kind).toBe('not-config');
+  });
+
+  it('rejects tampered payload where eldraw !== "config"', () => {
+    const cfg = {
+      eldraw: 'something-else',
+      version: 1,
+      sections: {},
+    };
+    const res = parseConfig(JSON.stringify(cfg));
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.kind).toBe('not-config');
+  });
+});
+
+describe('config import: migrations', () => {
+  it('runs the shortcuts migration ladder on older-version payloads', () => {
+    // A v0 export carrying the legacy Mod+K default must be migrated to Mod+P
+    // (see SHORTCUTS_MIGRATIONS in shortcuts.ts).
+    const cfg: ConfigExport = {
+      eldraw: 'config',
+      version: 1,
+      exportedAt: '',
+      exportedBy: '',
+      sections: {
+        shortcuts: {
+          kind: 'shortcuts',
+          version: 0,
+          bindings: { 'commandPalette.open': 'Mod+K', 'tool.pen': 'Shift+P' },
+        },
+      },
+    };
+    applyConfig(cfg);
+    const snap = shortcutsStore.snapshot();
+    expect(snap['commandPalette.open']).toBe('Mod+P');
+    expect(snap['tool.pen']).toBe('Shift+P');
+  });
+
+  it('preserves custom (non-default) shortcut bindings during import', () => {
+    const cfg: ConfigExport = {
+      eldraw: 'config',
+      version: 1,
+      exportedAt: '',
+      exportedBy: '',
+      sections: {
+        shortcuts: {
+          kind: 'shortcuts',
+          version: 1,
+          bindings: { 'commandPalette.open': 'Mod+Shift+K' },
+        },
+      },
+    };
+    applyConfig(cfg);
+    expect(shortcutsStore.snapshot()['commandPalette.open']).toBe('Mod+Shift+K');
+  });
+});
+
+describe('config import: backup + restore', () => {
+  it('round-trips backup → restorePreviousConfig', () => {
+    shortcutsStore.setBinding('tool.pen', 'Shift+P');
+    sidebar.setSmoothing('pen', 40);
+
+    const incoming: ConfigExport = {
+      eldraw: 'config',
+      version: 1,
+      exportedAt: '',
+      exportedBy: '',
+      sections: {
+        shortcuts: {
+          kind: 'shortcuts',
+          version: 1,
+          bindings: { 'tool.pen': 'Alt+P' },
+        },
+        sidebar: { kind: 'sidebar', version: 1, state: { smoothingPen: 10 } },
+      },
+    };
+
+    applyConfig(incoming);
+    expect(shortcutsStore.snapshot()['tool.pen']).toBe('Alt+P');
+    expect(sidebar.snapshot().smoothingPen).toBe(10);
+    expect(hasBackup()).toBe(true);
+
+    const ok = restorePreviousConfig();
+    expect(ok).toBe(true);
+    expect(shortcutsStore.snapshot()['tool.pen']).toBe('Shift+P');
+    expect(sidebar.snapshot().smoothingPen).toBe(40);
+  });
+
+  it('restorePreviousConfig returns false when no backup exists', () => {
+    expect(restorePreviousConfig()).toBe(false);
+  });
+});
+
+describe('config diff', () => {
+  it('summarizes shortcut changes', () => {
+    const current = buildConfigExport();
+    const incoming = buildConfigExport();
+    incoming.sections.shortcuts!.bindings = {
+      ...incoming.sections.shortcuts!.bindings,
+      'tool.pen': 'Shift+P',
+    };
+    const diff = diffConfig(current, incoming);
+    expect(diff.hasChanges).toBe(true);
+    expect(diff.sections[0].section).toBe('shortcuts');
+    expect(diff.sections[0].changes.join(' ')).toMatch(/tool\.pen.*Shift\+P/);
+  });
+
+  it('reports no changes for an identical config', () => {
+    const cfg = buildConfigExport();
+    const parsed = parseConfig(serializeConfig(cfg));
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(diffConfig(cfg, parsed.value).hasChanges).toBe(false);
+  });
+});
+
+describe('default bindings sanity', () => {
+  it('DEFAULT_BINDINGS snapshot matches fresh shortcut store', () => {
+    expect(shortcutsStore.snapshot()).toEqual(DEFAULT_BINDINGS);
+  });
+});

--- a/tests/config-import.test.ts
+++ b/tests/config-import.test.ts
@@ -226,6 +226,59 @@ describe('config diff', () => {
     if (!parsed.ok) return;
     expect(diffConfig(cfg, parsed.value).hasChanges).toBe(false);
   });
+
+  it('reflects post-migration state for older-version shortcut payloads', () => {
+    // A v0 shortcuts payload still carrying the legacy Mod+K default should
+    // be migrated to Mod+P before diffing, so the preview does not show a
+    // spurious "commandPalette.open: Mod+K" change that applyConfig would
+    // never actually write.
+    const current = buildConfigExport();
+    const incoming: ConfigExport = {
+      eldraw: 'config',
+      version: 1,
+      exportedAt: '',
+      exportedBy: '',
+      sections: {
+        shortcuts: {
+          kind: 'shortcuts',
+          version: 0,
+          bindings: { ...current.sections.shortcuts!.bindings, 'commandPalette.open': 'Mod+K' },
+        },
+      },
+    };
+    const diff = diffConfig(current, incoming);
+    const joined = diff.sections.flatMap((s) => s.changes).join(' ');
+    expect(joined).not.toMatch(/Mod\+K/);
+    expect(joined).not.toMatch(/commandPalette\.open/);
+    expect(diff.hasChanges).toBe(false);
+  });
+
+  it('drops invalid sidebar fields from the diff (sanitize pipeline)', () => {
+    const current = buildConfigExport();
+    const incoming: ConfigExport = {
+      eldraw: 'config',
+      version: 1,
+      exportedAt: '',
+      exportedBy: '',
+      sections: {
+        sidebar: {
+          kind: 'sidebar',
+          version: 1,
+          state: {
+            smoothingPen: 25,
+            // Invalid fields that sanitize drops — must not appear in diff.
+            bogusField: 'should-be-dropped',
+            activeTool: 'not-a-real-tool',
+          },
+        },
+      },
+    };
+    const diff = diffConfig(current, incoming);
+    const joined = diff.sections.flatMap((s) => s.changes).join(' ');
+    expect(joined).not.toMatch(/bogusField/);
+    expect(joined).not.toMatch(/not-a-real-tool/);
+    expect(joined).toMatch(/smoothingPen/);
+  });
 });
 
 describe('default bindings sanity', () => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,11 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 import { sveltekit } from '@sveltejs/kit/vite';
 
 const host = process.env.TAURI_DEV_HOST;
+const pkg = JSON.parse(
+  readFileSync(fileURLToPath(new URL('./package.json', import.meta.url)), 'utf8'),
+);
 
 export default defineConfig({
   plugins: [sveltekit()],
   clearScreen: false,
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   server: {
     port: 1420,
     strictPort: true,


### PR DESCRIPTION
Closes #93. Strict versioned JSON format, migration ladder on import, single-step backup/restore of prior config, four palette commands (Export/Import/Restore/Reset). Tauri-free via `<a download>` + `<input type=file>`.