### PR TITLE
chore(release): v0.1.0-rc.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eldraw",
-  "version": "0.1.0-rc.8",
+  "version": "0.1.0-rc.9",
   "description": "PDF annotation tool for live math teaching",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1019,7 +1019,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "eldraw"
-version = "0.1.0-rc.8"
+version = "0.1.0-rc.9"
 dependencies = [
  "image",
  "lru",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eldraw"
-version = "0.1.0-rc.8"
+version = "0.1.0-rc.9"
 description = "PDF annotation tool for live math teaching"
 authors = ["Adam"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "eldraw",
-  "version": "0.1.0-rc.8",
+  "version": "0.1.0-rc.9",
   "identifier": "com.adamkadaban.eldraw",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Batch A + B of the rc.9 cycle: smoothing slider (#86), zen fullscreen (#87), eraser hit-test (#88), Ctrl+P palette (#89), swap number-key bindings (#90), sidebar hide/minimize/snap (#91), thumbnail annotations (#92), config import/export (#93). All 8 issues closed via PRs #94–#101.