### PR TITLE
fix(presenter): true OS fullscreen without decorations (#103)

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -3,5 +3,12 @@
   "identifier": "default",
   "description": "Capability for the main, presenter, and sidebar windows",
   "windows": ["main", "presenter", "sidebar-window"],
-  "permissions": ["core:default", "opener:default", "dialog:allow-open"]
+  "permissions": [
+    "core:default",
+    "core:window:allow-set-fullscreen",
+    "core:window:allow-set-decorations",
+    "core:window:allow-set-always-on-top",
+    "opener:default",
+    "dialog:allow-open"
+  ]
 }

--- a/src-tauri/src/presenter.rs
+++ b/src-tauri/src/presenter.rs
@@ -74,6 +74,11 @@ fn monitor_key(m: &tauri::Monitor) -> (i32, i32, u32, u32) {
 #[allow(clippy::needless_pass_by_value)]
 pub fn open_presenter_window(app: AppHandle, monitor_index: Option<usize>) -> AppResult<()> {
     if let Some(existing) = app.get_webview_window(PRESENTER_LABEL) {
+        // Force-reapply the chromeless-fullscreen invariants. Some compositors
+        // drop decorations/fullscreen after the window has been re-presented.
+        existing.set_decorations(false).ok();
+        existing.set_always_on_top(true).ok();
+        existing.set_fullscreen(true).ok();
         existing.set_focus().ok();
         return Ok(());
     }
@@ -82,6 +87,7 @@ pub fn open_presenter_window(app: AppHandle, monitor_index: Option<usize>) -> Ap
         WebviewWindowBuilder::new(&app, PRESENTER_LABEL, WebviewUrl::App("presenter".into()))
             .title("eldraw presenter")
             .decorations(false)
+            .always_on_top(true)
             .resizable(true)
             .visible(false);
 
@@ -106,6 +112,10 @@ pub fn open_presenter_window(app: AppHandle, monitor_index: Option<usize>) -> Ap
             let _ = app_handle.emit(PRESENTER_WINDOW_CLOSED_EVENT, ());
         }
     });
+    // Re-apply the chromeless flags post-build: the builder hints are not
+    // always honored on GNOME/Wayland until the window is realized.
+    window.set_decorations(false).ok();
+    window.set_always_on_top(true).ok();
     window.set_fullscreen(true).ok();
     window.show()?;
     Ok(())
@@ -115,6 +125,9 @@ pub fn open_presenter_window(app: AppHandle, monitor_index: Option<usize>) -> Ap
 #[allow(clippy::needless_pass_by_value)]
 pub fn close_presenter_window(app: AppHandle) -> AppResult<()> {
     if let Some(w) = app.get_webview_window(PRESENTER_LABEL) {
+        // Exit fullscreen before tearing the window down to avoid the OS
+        // animating a decorated window into view on the way out.
+        w.set_fullscreen(false).ok();
         w.close()?;
     }
     app.emit(PRESENTER_WINDOW_CLOSED_EVENT, ())

--- a/src/lib/app/windowFullscreen.ts
+++ b/src/lib/app/windowFullscreen.ts
@@ -1,0 +1,32 @@
+import { getCurrentWindow } from '@tauri-apps/api/window';
+import { warn } from '$lib/log';
+
+/**
+ * Belt-and-braces helper for true OS-level fullscreen. Strips decorations
+ * before toggling fullscreen so the titlebar/taskbar animation cannot flash
+ * into view on the way in, and reverses the order on the way out.
+ *
+ * The Rust window builder already applies these flags, but some platforms
+ * (notably GNOME/Wayland) drop them when the window is re-presented, so we
+ * re-apply from the webview as well.
+ */
+export async function setWindowFullscreenChromeless(on: boolean): Promise<void> {
+  let w: ReturnType<typeof getCurrentWindow>;
+  try {
+    w = getCurrentWindow();
+  } catch (err) {
+    warn('ipc', 'getCurrentWindow unavailable', err);
+    return;
+  }
+  try {
+    if (on) {
+      await w.setDecorations(false);
+      await w.setFullscreen(true);
+    } else {
+      await w.setFullscreen(false);
+      await w.setDecorations(true);
+    }
+  } catch (err) {
+    warn('ipc', `setWindowFullscreenChromeless(${on}) failed`, err);
+  }
+}

--- a/src/lib/app/windowFullscreen.ts
+++ b/src/lib/app/windowFullscreen.ts
@@ -30,3 +30,26 @@ export async function setWindowFullscreenChromeless(on: boolean): Promise<void> 
     warn('ipc', `setWindowFullscreenChromeless(${on}) failed`, err);
   }
 }
+
+/**
+ * Exits OS fullscreen without restoring window decorations.
+ *
+ * Use this for windows that will be closed immediately after (e.g. the
+ * presenter window, whose teardown is handled by Rust's
+ * `close_presenter_window`). Restoring decorations here causes a brief
+ * decorated-window flash between the fullscreen exit and the close.
+ */
+export async function exitWindowFullscreen(): Promise<void> {
+  let w: ReturnType<typeof getCurrentWindow>;
+  try {
+    w = getCurrentWindow();
+  } catch (err) {
+    warn('ipc', 'getCurrentWindow unavailable', err);
+    return;
+  }
+  try {
+    await w.setFullscreen(false);
+  } catch (err) {
+    warn('ipc', 'exitWindowFullscreen failed', err);
+  }
+}

--- a/src/lib/store/zen.ts
+++ b/src/lib/store/zen.ts
@@ -4,6 +4,25 @@ export interface ZenState {
   active: boolean;
 }
 
+export interface ZenFullscreenBridge {
+  setFullscreen(on: boolean): void | Promise<void>;
+}
+
+let bridge: ZenFullscreenBridge | null = null;
+
+/**
+ * Inject the OS-level fullscreen bridge. The UI shell registers the real
+ * Tauri bridge on mount; tests register mocks. Pass `null` to unregister.
+ */
+export function registerZenFullscreenBridge(b: ZenFullscreenBridge | null): void {
+  bridge = b;
+}
+
+function pushFullscreen(on: boolean): void {
+  if (!bridge) return;
+  void Promise.resolve(bridge.setFullscreen(on)).catch(() => {});
+}
+
 function createZen() {
   const store = writable<ZenState>({ active: false });
   const { subscribe, update, set } = store;
@@ -16,19 +35,38 @@ function createZen() {
     },
 
     enter(): void {
-      update((s) => (s.active ? s : { ...s, active: true }));
+      let changed = false;
+      update((s) => {
+        if (s.active) return s;
+        changed = true;
+        return { ...s, active: true };
+      });
+      if (changed) pushFullscreen(true);
     },
 
     exit(): void {
-      update((s) => (s.active ? { ...s, active: false } : s));
+      let changed = false;
+      update((s) => {
+        if (!s.active) return s;
+        changed = true;
+        return { ...s, active: false };
+      });
+      if (changed) pushFullscreen(false);
     },
 
     toggle(): void {
-      update((s) => ({ ...s, active: !s.active }));
+      let next = false;
+      update((s) => {
+        next = !s.active;
+        return { ...s, active: next };
+      });
+      pushFullscreen(next);
     },
 
     reset(): void {
+      const wasActive = get(store).active;
       set({ active: false });
+      if (wasActive) pushFullscreen(false);
     },
   };
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -20,7 +20,7 @@
   import { startAutosave } from '$lib/store/autosave';
   import { viewport, viewportStore, MIN_SCALE, MAX_SCALE } from '$lib/store/viewport';
   import { presenter, presenterStore } from '$lib/store/presenter';
-  import { zenStore, chromeVisibility } from '$lib/store/zen';
+  import { zenStore, chromeVisibility, registerZenFullscreenBridge } from '$lib/store/zen';
   import { overlays } from '$lib/store/overlays';
   import { startToolBridge } from '$lib/app/toolBridge';
   import { startPresenterBridge } from '$lib/app/presenterBridge';
@@ -32,6 +32,7 @@
     onSidebarWindowClosed,
   } from '$lib/ipc/sidebar-window';
   import { shortcuts } from '$lib/app/shortcuts';
+  import { setWindowFullscreenChromeless } from '$lib/app/windowFullscreen';
   import { openPdfDialog } from '$lib/app/openPdfDialog';
   import { hitTestObjects } from '$lib/tools/eraser';
   import { activeGraph, clearActiveGraph, setActiveGraph } from '$lib/store/activeGraph';
@@ -418,6 +419,9 @@
   onMount(() => {
     stopHydration = hydrateSidebarFromStorage();
     stopBridge = startToolBridge();
+    registerZenFullscreenBridge({
+      setFullscreen: (on) => setWindowFullscreenChromeless(on),
+    });
     let unlistenPresenterClose: (() => void) | null = null;
     let unlistenSidebarClose: (() => void) | null = null;
     void onPresenterWindowClosed(() => presenter.setWindowOpen(false)).then((fn) => {
@@ -438,6 +442,7 @@
     stopHydration?.();
     stopPresenterBridge?.();
     stopSidebarBridge?.();
+    registerZenFullscreenBridge(null);
   });
 </script>
 

--- a/src/routes/presenter/+page.svelte
+++ b/src/routes/presenter/+page.svelte
@@ -3,6 +3,9 @@
   import { CanvasStack, GraphLayer, PdfLayer, TextLayer } from '$lib/canvas';
   import { onPresenterSync, closePresenterWindow } from '$lib/ipc/presenter';
   import { setWindowFullscreenChromeless } from '$lib/app/windowFullscreen';
+  // Teardown deliberately leaves fullscreen/decorations to Rust's
+  // `close_presenter_window`: restoring decorations from JS before close
+  // causes a decorated-window flash.
   import { presenterMirror, presenterMirrorStore } from '$lib/store/presenterMirror';
   import { pdfPageIndexAt } from '$lib/store/document';
   import type { AnyObject, GraphObject, StrokeObject, TextObject } from '$lib/types';
@@ -44,10 +47,7 @@
 
   function onKey(event: KeyboardEvent): void {
     if (event.key === 'Escape') {
-      void (async () => {
-        await setWindowFullscreenChromeless(false);
-        await closePresenterWindow();
-      })();
+      void closePresenterWindow();
     }
   }
 
@@ -67,7 +67,6 @@
   onDestroy(() => {
     unlisten?.();
     presenterMirror.reset();
-    void setWindowFullscreenChromeless(false);
     if (typeof window !== 'undefined') {
       window.removeEventListener('keydown', onKey);
       window.removeEventListener('resize', onResize);

--- a/src/routes/presenter/+page.svelte
+++ b/src/routes/presenter/+page.svelte
@@ -2,6 +2,7 @@
   import { onDestroy, onMount } from 'svelte';
   import { CanvasStack, GraphLayer, PdfLayer, TextLayer } from '$lib/canvas';
   import { onPresenterSync, closePresenterWindow } from '$lib/ipc/presenter';
+  import { setWindowFullscreenChromeless } from '$lib/app/windowFullscreen';
   import { presenterMirror, presenterMirrorStore } from '$lib/store/presenterMirror';
   import { pdfPageIndexAt } from '$lib/store/document';
   import type { AnyObject, GraphObject, StrokeObject, TextObject } from '$lib/types';
@@ -43,7 +44,10 @@
 
   function onKey(event: KeyboardEvent): void {
     if (event.key === 'Escape') {
-      void closePresenterWindow();
+      void (async () => {
+        await setWindowFullscreenChromeless(false);
+        await closePresenterWindow();
+      })();
     }
   }
 
@@ -53,6 +57,7 @@
   }
 
   onMount(async () => {
+    await setWindowFullscreenChromeless(true);
     unlisten = await onPresenterSync((payload) => presenterMirror.apply(payload));
     window.addEventListener('keydown', onKey);
     window.addEventListener('resize', onResize);
@@ -62,6 +67,7 @@
   onDestroy(() => {
     unlisten?.();
     presenterMirror.reset();
+    void setWindowFullscreenChromeless(false);
     if (typeof window !== 'undefined') {
       window.removeEventListener('keydown', onKey);
       window.removeEventListener('resize', onResize);

--- a/tests/presenter.test.ts
+++ b/tests/presenter.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const setDecorations = vi.fn().mockResolvedValue(undefined);
@@ -24,7 +26,7 @@ describe('setWindowFullscreenChromeless', () => {
     expect(decorationsOrder).toBeLessThan(fullscreenOrder);
   });
 
-  it('on exit: leaves fullscreen before restoring decorations', async () => {
+  it('on exit: leaves fullscreen before restoring decorations (zen-mode regression guard)', async () => {
     const { setWindowFullscreenChromeless } = await import('../src/lib/app/windowFullscreen');
     await setWindowFullscreenChromeless(false);
     expect(setFullscreen).toHaveBeenCalledWith(false);
@@ -48,5 +50,56 @@ describe('setWindowFullscreenChromeless', () => {
     await expect(setWindowFullscreenChromeless(true)).resolves.toBeUndefined();
     expect(setDecorations).not.toHaveBeenCalled();
     expect(setFullscreen).not.toHaveBeenCalled();
+  });
+});
+
+describe('exitWindowFullscreen', () => {
+  beforeEach(() => {
+    setDecorations.mockClear();
+    setFullscreen.mockClear();
+    getCurrentWindow.mockClear();
+  });
+  afterEach(() => vi.resetModules());
+
+  it('exits fullscreen without restoring decorations', async () => {
+    const { exitWindowFullscreen } = await import('../src/lib/app/windowFullscreen');
+    await exitWindowFullscreen();
+    expect(setFullscreen).toHaveBeenCalledWith(false);
+    expect(setDecorations).not.toHaveBeenCalled();
+  });
+
+  it('swallows errors from the window API', async () => {
+    setFullscreen.mockRejectedValueOnce(new Error('boom'));
+    const { exitWindowFullscreen } = await import('../src/lib/app/windowFullscreen');
+    await expect(exitWindowFullscreen()).resolves.toBeUndefined();
+  });
+
+  it('returns early if the window API is unavailable', async () => {
+    getCurrentWindow.mockImplementationOnce(() => {
+      throw new Error('no window');
+    });
+    const { exitWindowFullscreen } = await import('../src/lib/app/windowFullscreen');
+    await expect(exitWindowFullscreen()).resolves.toBeUndefined();
+    expect(setFullscreen).not.toHaveBeenCalled();
+  });
+});
+
+describe('presenter window teardown', () => {
+  const presenterSource = readFileSync(
+    fileURLToPath(new URL('../src/routes/presenter/+page.svelte', import.meta.url)),
+    'utf8',
+  );
+
+  it('does not restore window decorations from JS on Escape or destroy', () => {
+    // Restoring decorations (via setWindowFullscreenChromeless(false)) between
+    // the fullscreen exit and window close produces a brief decorated-window
+    // flash. The Rust `close_presenter_window` command exits fullscreen
+    // before closing, so the JS side must not re-chrome the window.
+    expect(presenterSource).not.toMatch(/setWindowFullscreenChromeless\(\s*false\s*\)/);
+    expect(presenterSource).not.toMatch(/exitWindowFullscreen\s*\(/);
+  });
+
+  it('still enters chromeless fullscreen on mount', () => {
+    expect(presenterSource).toMatch(/setWindowFullscreenChromeless\(\s*true\s*\)/);
   });
 });

--- a/tests/presenter.test.ts
+++ b/tests/presenter.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const setDecorations = vi.fn().mockResolvedValue(undefined);
+const setFullscreen = vi.fn().mockResolvedValue(undefined);
+const getCurrentWindow = vi.fn(() => ({ setDecorations, setFullscreen }));
+
+vi.mock('@tauri-apps/api/window', () => ({ getCurrentWindow }));
+
+describe('setWindowFullscreenChromeless', () => {
+  beforeEach(() => {
+    setDecorations.mockClear();
+    setFullscreen.mockClear();
+    getCurrentWindow.mockClear();
+  });
+  afterEach(() => vi.resetModules());
+
+  it('on enter: strips decorations before entering fullscreen', async () => {
+    const { setWindowFullscreenChromeless } = await import('../src/lib/app/windowFullscreen');
+    await setWindowFullscreenChromeless(true);
+    expect(setDecorations).toHaveBeenCalledWith(false);
+    expect(setFullscreen).toHaveBeenCalledWith(true);
+    const decorationsOrder = setDecorations.mock.invocationCallOrder[0];
+    const fullscreenOrder = setFullscreen.mock.invocationCallOrder[0];
+    expect(decorationsOrder).toBeLessThan(fullscreenOrder);
+  });
+
+  it('on exit: leaves fullscreen before restoring decorations', async () => {
+    const { setWindowFullscreenChromeless } = await import('../src/lib/app/windowFullscreen');
+    await setWindowFullscreenChromeless(false);
+    expect(setFullscreen).toHaveBeenCalledWith(false);
+    expect(setDecorations).toHaveBeenCalledWith(true);
+    const fullscreenOrder = setFullscreen.mock.invocationCallOrder[0];
+    const decorationsOrder = setDecorations.mock.invocationCallOrder[0];
+    expect(fullscreenOrder).toBeLessThan(decorationsOrder);
+  });
+
+  it('swallows errors from the window API', async () => {
+    setFullscreen.mockRejectedValueOnce(new Error('boom'));
+    const { setWindowFullscreenChromeless } = await import('../src/lib/app/windowFullscreen');
+    await expect(setWindowFullscreenChromeless(true)).resolves.toBeUndefined();
+  });
+
+  it('returns early if the window API is unavailable', async () => {
+    getCurrentWindow.mockImplementationOnce(() => {
+      throw new Error('no window');
+    });
+    const { setWindowFullscreenChromeless } = await import('../src/lib/app/windowFullscreen');
+    await expect(setWindowFullscreenChromeless(true)).resolves.toBeUndefined();
+    expect(setDecorations).not.toHaveBeenCalled();
+    expect(setFullscreen).not.toHaveBeenCalled();
+  });
+});

--- a/tests/zen-store.test.ts
+++ b/tests/zen-store.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it, beforeEach } from 'vitest';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import { get } from 'svelte/store';
-import { zen, chromeVisibility } from '../src/lib/store/zen';
+import { zen, chromeVisibility, registerZenFullscreenBridge } from '../src/lib/store/zen';
 
 describe('zen store', () => {
   beforeEach(() => zen.reset());
@@ -45,6 +45,61 @@ describe('zen store', () => {
     zen.toggle();
     unsubscribe();
     expect(observed).toEqual([false, true, false]);
+  });
+});
+
+describe('zen fullscreen bridge', () => {
+  const setFullscreen = vi.fn();
+
+  beforeEach(() => {
+    zen.reset();
+    setFullscreen.mockClear();
+    registerZenFullscreenBridge({ setFullscreen });
+  });
+  afterEach(() => registerZenFullscreenBridge(null));
+
+  it('enter calls the bridge with true', () => {
+    zen.enter();
+    expect(setFullscreen).toHaveBeenCalledTimes(1);
+    expect(setFullscreen).toHaveBeenCalledWith(true);
+  });
+
+  it('enter is idempotent and only calls the bridge on state change', () => {
+    zen.enter();
+    zen.enter();
+    expect(setFullscreen).toHaveBeenCalledTimes(1);
+  });
+
+  it('exit calls the bridge with false', () => {
+    zen.enter();
+    setFullscreen.mockClear();
+    zen.exit();
+    expect(setFullscreen).toHaveBeenCalledTimes(1);
+    expect(setFullscreen).toHaveBeenCalledWith(false);
+  });
+
+  it('toggle drives the bridge on every flip', () => {
+    zen.toggle();
+    zen.toggle();
+    expect(setFullscreen.mock.calls.map((c) => c[0])).toEqual([true, false]);
+  });
+
+  it('reset exits fullscreen when zen was active', () => {
+    zen.enter();
+    setFullscreen.mockClear();
+    zen.reset();
+    expect(setFullscreen).toHaveBeenCalledWith(false);
+  });
+
+  it('reset does not call the bridge when zen was already inactive', () => {
+    zen.reset();
+    expect(setFullscreen).not.toHaveBeenCalled();
+  });
+
+  it('unregistering the bridge stops bridge calls', () => {
+    registerZenFullscreenBridge(null);
+    zen.toggle();
+    expect(setFullscreen).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Closes #103. Presenter window now opens with decorations off, always-on-top, positioned on the target monitor, then fullscreen applied in the correct order. Zen mode on the main window uses the same bridge. Escape exit path drops fullscreen before close to avoid visual flash.