### PR TITLE
fix(ink): bake smoothing into each stroke at draw time (#104)

### DIFF
--- a/src/lib/canvas/CanvasStack.svelte
+++ b/src/lib/canvas/CanvasStack.svelte
@@ -67,7 +67,7 @@
 
 <div class="stack" style="width: {width}px; height: {height}px;">
   <div class="layer layer-highlight">
-    <HighlightLayer {strokes} {width} {height} {ptToPx} streamline={highlighterStreamline} />
+    <HighlightLayer {strokes} {width} {height} {ptToPx} />
   </div>
 
   <div class="layer layer-objects">
@@ -75,7 +75,7 @@
   </div>
 
   <div class="layer layer-ink">
-    <InkLayer {strokes} {width} {height} {ptToPx} streamline={penStreamline} />
+    <InkLayer {strokes} {width} {height} {ptToPx} />
   </div>
 
   <div class="layer layer-live">

--- a/src/lib/canvas/HighlightLayer.svelte
+++ b/src/lib/canvas/HighlightLayer.svelte
@@ -8,10 +8,9 @@
     width: number;
     height: number;
     ptToPx: number;
-    streamline?: number;
   }
 
-  let { strokes, width, height, ptToPx, streamline }: Props = $props();
+  let { strokes, width, height, ptToPx }: Props = $props();
 
   let canvas: HTMLCanvasElement;
 
@@ -27,7 +26,7 @@
         ...s,
         style: { ...s.style, opacity: Math.min(s.style.opacity, 0.3) },
       };
-      drawStroke(ctx, faded, { ptToPx, streamline });
+      drawStroke(ctx, faded, { ptToPx });
     }
   }
 
@@ -38,7 +37,6 @@
     void width;
     void height;
     void ptToPx;
-    void streamline;
     redraw();
   });
 </script>

--- a/src/lib/canvas/InkLayer.svelte
+++ b/src/lib/canvas/InkLayer.svelte
@@ -8,10 +8,9 @@
     width: number;
     height: number;
     ptToPx: number;
-    streamline?: number;
   }
 
-  let { strokes, width, height, ptToPx, streamline }: Props = $props();
+  let { strokes, width, height, ptToPx }: Props = $props();
 
   let canvas: HTMLCanvasElement;
 
@@ -22,7 +21,7 @@
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     ctx.globalCompositeOperation = 'source-over';
     for (const s of strokes) {
-      if (s.tool === 'pen') drawStroke(ctx, s, { ptToPx, streamline });
+      if (s.tool === 'pen') drawStroke(ctx, s, { ptToPx });
     }
   }
 
@@ -33,7 +32,6 @@
     void width;
     void height;
     void ptToPx;
-    void streamline;
     redraw();
   });
 </script>

--- a/src/lib/canvas/LiveLayer.svelte
+++ b/src/lib/canvas/LiveLayer.svelte
@@ -203,7 +203,8 @@
       const finalPoints = rulerSnap
         ? snapStrokeToRuler(points, rulerSnap, rulerSnapThresholdPx / ptToPx)
         : points;
-      const stroke = strokeFromInput(finalPoints, currentStyle, currentTool);
+      const bakedStreamline = currentTool === 'highlighter' ? highlighterStreamline : penStreamline;
+      const stroke = strokeFromInput(finalPoints, currentStyle, currentTool, bakedStreamline);
       log('live', `commit ${currentTool} stroke points=${points.length}`);
       oncommit?.(stroke);
     }

--- a/src/lib/canvas/TempInkLayer.svelte
+++ b/src/lib/canvas/TempInkLayer.svelte
@@ -51,7 +51,7 @@
       const a = fadeOpacity(s, now);
       if (a <= 0) continue;
       c.globalAlpha = a * s.style.opacity;
-      drawLiveStroke(c, s.points, { ...s.style, opacity: 1 }, 'pen', ptToPx, streamline);
+      drawLiveStroke(c, s.points, { ...s.style, opacity: 1 }, 'pen', ptToPx, s.streamline);
     }
     c.restore();
 
@@ -115,7 +115,7 @@
     activePointerId = null;
 
     if (commit && livePoints.length > 0) {
-      const stroke = createTempStroke(livePoints, liveStyle, fadeMs, performance.now());
+      const stroke = createTempStroke(livePoints, liveStyle, fadeMs, performance.now(), streamline);
       strokes = [...strokes, stroke];
     }
     livePoints = [];

--- a/src/lib/canvas/strokeRenderer.ts
+++ b/src/lib/canvas/strokeRenderer.ts
@@ -4,7 +4,11 @@ import type { Point, StrokeObject } from '$lib/types';
 export interface StrokeRenderOptions {
   ptToPx: number;
   simulatePressure?: boolean;
-  /** perfect-freehand `streamline` in [0, 1). Defaults to 0.5. */
+  /**
+   * Fallback perfect-freehand `streamline` used only when the stroke does
+   * not carry its own baked value. Committed strokes should carry their
+   * own; this exists for live rendering where smoothing follows the slider.
+   */
   streamline?: number;
 }
 
@@ -53,6 +57,7 @@ export function drawStroke(
   const { ptToPx } = opts;
   const widthPx = stroke.style.width * ptToPx;
   const input = inputToPx(stroke.points, ptToPx);
+  const streamline = stroke.streamline ?? opts.streamline ?? 0;
 
   const outline =
     stroke.style.dash === 'solid'
@@ -60,7 +65,7 @@ export function drawStroke(
           size: widthPx * 2,
           thinning: 0.6,
           smoothing: 0.5,
-          streamline: opts.streamline ?? 0.5,
+          streamline,
           simulatePressure: opts.simulatePressure ?? false,
           last: true,
         })

--- a/src/lib/tools/pen.ts
+++ b/src/lib/tools/pen.ts
@@ -4,6 +4,7 @@ export function strokeFromInput(
   points: Point[],
   style: StrokeStyle,
   tool: 'pen' | 'highlighter',
+  streamline?: number,
 ): StrokeObject {
   return {
     id: crypto.randomUUID(),
@@ -12,5 +13,6 @@ export function strokeFromInput(
     tool,
     style: { ...style },
     points: points.map((p) => ({ ...p })),
+    ...(streamline !== undefined ? { streamline } : {}),
   };
 }

--- a/src/lib/tools/tempInk.ts
+++ b/src/lib/tools/tempInk.ts
@@ -29,7 +29,7 @@ export interface TempInkStroke {
   /** Wall-clock ms when the stroke finished (or was last extended). */
   endedAt: number;
   fadeMs: number;
-  /** Baked perfect-freehand streamline; `undefined` means no smoothing. */
+  /** perfect-freehand `streamline` baked when the stroke is committed; `undefined` means no smoothing. */
   streamline?: number;
 }
 

--- a/src/lib/tools/tempInk.ts
+++ b/src/lib/tools/tempInk.ts
@@ -29,6 +29,8 @@ export interface TempInkStroke {
   /** Wall-clock ms when the stroke finished (or was last extended). */
   endedAt: number;
   fadeMs: number;
+  /** Baked perfect-freehand streamline; `undefined` means no smoothing. */
+  streamline?: number;
 }
 
 export function newTempStrokeId(): string {
@@ -42,6 +44,7 @@ export function createTempStroke(
   style: StrokeStyle,
   fadeMs: number,
   endedAt: number,
+  streamline?: number,
 ): TempInkStroke {
   return {
     id: newTempStrokeId(),
@@ -49,6 +52,7 @@ export function createTempStroke(
     points: points.map((p) => ({ ...p })),
     endedAt,
     fadeMs: clampFadeMs(fadeMs),
+    ...(streamline !== undefined ? { streamline } : {}),
   };
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -67,6 +67,11 @@ export interface StrokeObject extends ObjectBase {
   tool: 'pen' | 'highlighter';
   style: StrokeStyle;
   points: Point[];
+  /**
+   * perfect-freehand `streamline` in [0, 1) baked at stroke-start time.
+   * Legacy strokes predate per-stroke smoothing and render as if 0.
+   */
+  streamline?: number;
 }
 
 export interface LineObject extends ObjectBase {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -68,7 +68,7 @@ export interface StrokeObject extends ObjectBase {
   style: StrokeStyle;
   points: Point[];
   /**
-   * perfect-freehand `streamline` in [0, 1) baked at stroke-start time.
+   * perfect-freehand `streamline` in [0, 1) baked when the stroke is committed.
    * Legacy strokes predate per-stroke smoothing and render as if 0.
    */
   streamline?: number;

--- a/tests/document-store.test.ts
+++ b/tests/document-store.test.ts
@@ -252,4 +252,16 @@ describe('documentStore', () => {
 
     expect(events).toEqual([0]);
   });
+
+  it('strokes round-trip their baked streamline through document load/save', () => {
+    const store = createDocumentStore();
+    const baked: StrokeObject = { ...stroke('s1'), streamline: 0.792 };
+    const legacy: StrokeObject = stroke('s2');
+    const doc = docWithPages([{ ...pdfPage(0), objects: [baked, legacy] }]);
+    store.load(doc);
+    const serialized = JSON.parse(JSON.stringify(get(store)!));
+    const [a, b] = serialized.pages[0].objects as StrokeObject[];
+    expect(a.streamline).toBe(0.792);
+    expect(b.streamline).toBeUndefined();
+  });
 });

--- a/tests/stroke-from-input.test.ts
+++ b/tests/stroke-from-input.test.ts
@@ -60,4 +60,22 @@ describe('strokeFromInput', () => {
     expect(s.points[0].pressure).toBe(0.5);
     expect(s.points[0].t).toBe(0);
   });
+
+  it('omits streamline when caller does not pass one (legacy)', () => {
+    const p: Point[] = [{ x: 0, y: 0, pressure: 0.5, t: 0 }];
+    const s = strokeFromInput(p, style, 'pen');
+    expect(s.streamline).toBeUndefined();
+  });
+
+  it('bakes the caller-provided streamline into the stroke', () => {
+    const p: Point[] = [{ x: 0, y: 0, pressure: 0.5, t: 0 }];
+    const s = strokeFromInput(p, style, 'pen', 0.792);
+    expect(s.streamline).toBe(0.792);
+  });
+
+  it('bakes streamline 0 (no smoothing) when explicitly requested', () => {
+    const p: Point[] = [{ x: 0, y: 0, pressure: 0.5, t: 0 }];
+    const s = strokeFromInput(p, style, 'highlighter', 0);
+    expect(s.streamline).toBe(0);
+  });
 });

--- a/tests/stroke-renderer-smoothing.test.ts
+++ b/tests/stroke-renderer-smoothing.test.ts
@@ -57,17 +57,34 @@ describe('strokeRenderer streamline wiring', () => {
   });
   afterEach(() => vi.unstubAllGlobals());
 
-  it('defaults streamline to 0.5 when not provided', async () => {
+  it('defaults streamline to 0 when the stroke and options omit it (legacy strokes)', async () => {
     const { drawStroke } = await import('$lib/canvas/strokeRenderer');
     drawStroke(makeCtx(), stroke(), { ptToPx: 1 });
     expect(getStroke).toHaveBeenCalledTimes(1);
-    expect(getStroke.mock.calls[0][1]).toMatchObject({ streamline: 0.5 });
+    expect(getStroke.mock.calls[0][1]).toMatchObject({ streamline: 0 });
   });
 
   it('forwards explicit streamline option to perfect-freehand', async () => {
     const { drawStroke } = await import('$lib/canvas/strokeRenderer');
     drawStroke(makeCtx(), stroke(), { ptToPx: 1, streamline: 0.25 });
     expect(getStroke.mock.calls[0][1]).toMatchObject({ streamline: 0.25 });
+  });
+
+  it('prefers baked stroke.streamline over opts.streamline', async () => {
+    const { drawStroke } = await import('$lib/canvas/strokeRenderer');
+    const baked = { ...stroke(), streamline: streamlineFromSmoothing(80) };
+    drawStroke(makeCtx(), baked, { ptToPx: 1, streamline: streamlineFromSmoothing(0) });
+    expect(getStroke.mock.calls[0][1].streamline).toBeCloseTo(0.792);
+  });
+
+  it('live slider does not change a baked stroke across re-renders', async () => {
+    const { drawStroke } = await import('$lib/canvas/strokeRenderer');
+    const baked = { ...stroke(), streamline: streamlineFromSmoothing(80) };
+    for (const live of [0, 50, 100]) {
+      getStroke.mockClear();
+      drawStroke(makeCtx(), baked, { ptToPx: 1, streamline: streamlineFromSmoothing(live) });
+      expect(getStroke.mock.calls[0][1].streamline).toBeCloseTo(0.792);
+    }
   });
 
   it('drawLiveStroke threads streamline through', async () => {

--- a/tests/stroke-renderer-smoothing.test.ts
+++ b/tests/stroke-renderer-smoothing.test.ts
@@ -72,18 +72,20 @@ describe('strokeRenderer streamline wiring', () => {
 
   it('prefers baked stroke.streamline over opts.streamline', async () => {
     const { drawStroke } = await import('$lib/canvas/strokeRenderer');
-    const baked = { ...stroke(), streamline: streamlineFromSmoothing(80) };
+    const expected = streamlineFromSmoothing(80);
+    const baked = { ...stroke(), streamline: expected };
     drawStroke(makeCtx(), baked, { ptToPx: 1, streamline: streamlineFromSmoothing(0) });
-    expect(getStroke.mock.calls[0][1].streamline).toBeCloseTo(0.792);
+    expect(getStroke.mock.calls[0][1].streamline).toBeCloseTo(expected);
   });
 
   it('live slider does not change a baked stroke across re-renders', async () => {
     const { drawStroke } = await import('$lib/canvas/strokeRenderer');
-    const baked = { ...stroke(), streamline: streamlineFromSmoothing(80) };
+    const expected = streamlineFromSmoothing(80);
+    const baked = { ...stroke(), streamline: expected };
     for (const live of [0, 50, 100]) {
       getStroke.mockClear();
       drawStroke(makeCtx(), baked, { ptToPx: 1, streamline: streamlineFromSmoothing(live) });
-      expect(getStroke.mock.calls[0][1].streamline).toBeCloseTo(0.792);
+      expect(getStroke.mock.calls[0][1].streamline).toBeCloseTo(expected);
     }
   });
 


### PR DESCRIPTION
Closes #104. Each stroke snapshots its smoothing value on commit. Moving the slider no longer re-renders committed strokes. Legacy strokes (no baked field) render with streamline=0 to preserve exact appearance.