### PR TITLE
perf(ink): coalesced + predicted events, rAF batching, Catmull-Rom, RDP simplify (#105)

### DIFF
--- a/src/lib/canvas/LiveLayer.svelte
+++ b/src/lib/canvas/LiveLayer.svelte
@@ -7,6 +7,9 @@
   import { cursorForTool } from './cursors';
   import { log } from '$lib/log';
   import { snapPointToRuler, snapStrokeToRuler, type RulerState } from '$lib/geometry/ruler';
+  import { catmullRomSmooth } from './catmullRom';
+  import { simplifyRdp } from './simplify';
+  import { createRafBatcher, type Batcher } from './inkBatch';
 
   interface Props {
     width: number;
@@ -34,14 +37,20 @@
     ongraph,
   }: Props = $props();
 
+  const MIN_GRAPH_SIZE_PT = 8;
+  const RDP_EPSILON_PX = 0.5;
+  const CATMULL_MAX_CHORD_PX = 6;
+  const HAS_RAW_UPDATE = typeof window !== 'undefined' && 'onpointerrawupdate' in window;
+
   let graphStart: { x: number; y: number } | null = null;
   let graphEnd: { x: number; y: number } | null = null;
-  const MIN_GRAPH_SIZE_PT = 8;
 
   let canvas: HTMLCanvasElement;
+  let ctx2d: CanvasRenderingContext2D | null = null;
   let activePointerId: number | null = null;
   let startTime = 0;
   let points: Point[] = [];
+  let predictedTail: Point[] = [];
   let currentTool: ToolKind = $state('pen');
   let currentStyle: StrokeStyle = {
     color: '#000',
@@ -50,19 +59,43 @@
     opacity: 1,
   };
 
+  type Sample = { point: Point; predicted: Point[] };
+  let batcher: Batcher<Sample> | null = null;
+
+  const debugEnabled =
+    typeof window !== 'undefined' &&
+    (new URLSearchParams(window.location.search).get('inkdebug') === '1' ||
+      (typeof localStorage !== 'undefined' && localStorage.getItem('eldrawInkDebug') === '1'));
+  let debugInfo = $state({ hz: 0, frameMs: 0, coalesced: 0, predicted: 0 });
+  let debugWindow: number[] = [];
+  let debugLastFrameTs = 0;
+
   const unsubscribeTool = toolStore.subscribe((s) => {
     currentTool = s.tool;
     currentStyle = s.style;
     log('tool', `live-layer sees tool=${s.tool}`, s.style);
   });
-  onDestroy(unsubscribeTool);
+  onDestroy(() => {
+    unsubscribeTool();
+    batcher?.cancel();
+  });
 
-  function ctx(): CanvasRenderingContext2D | null {
-    return canvas?.getContext('2d') ?? null;
+  function ensureCtx(): CanvasRenderingContext2D | null {
+    if (ctx2d) return ctx2d;
+    if (!canvas) return null;
+    // desynchronized: true is a meaningful latency win for inking because it
+    // lets the browser bypass the compositor for this canvas. alpha: true so
+    // we can sit on top of the static ink layer without an opaque background.
+    ctx2d = canvas.getContext('2d', {
+      alpha: true,
+      desynchronized: true,
+      willReadFrequently: false,
+    });
+    return ctx2d;
   }
 
   function clear() {
-    const c = ctx();
+    const c = ensureCtx();
     if (!c) return;
     c.clearRect(0, 0, canvas.width, canvas.height);
   }
@@ -77,8 +110,10 @@
     }
     activePointerId = null;
     points = [];
+    predictedTail = [];
     graphStart = null;
     graphEnd = null;
+    batcher?.cancel();
     clear();
   }
 
@@ -105,15 +140,19 @@
   }
 
   function redrawLive() {
-    const c = ctx();
+    const c = ensureCtx();
     if (!c) return;
     clear();
     if (currentTool === 'highlighter') {
       c.globalCompositeOperation = 'multiply';
-      drawLiveStroke(c, points, currentStyle, 'highlighter', ptToPx, highlighterStreamline);
+      const tail = points.concat(predictedTail);
+      const smoothed = catmullRomSmooth(tail, CATMULL_MAX_CHORD_PX / ptToPx);
+      drawLiveStroke(c, smoothed, currentStyle, 'highlighter', ptToPx, highlighterStreamline);
     } else if (currentTool === 'pen') {
       c.globalCompositeOperation = 'source-over';
-      drawLiveStroke(c, points, currentStyle, 'pen', ptToPx, penStreamline);
+      const tail = points.concat(predictedTail);
+      const smoothed = catmullRomSmooth(tail, CATMULL_MAX_CHORD_PX / ptToPx);
+      drawLiveStroke(c, smoothed, currentStyle, 'pen', ptToPx, penStreamline);
     } else if (currentTool === 'graph' && graphStart && graphEnd) {
       drawGraphRect(c);
     }
@@ -135,6 +174,58 @@
     c.setLineDash([]);
   }
 
+  function ensureBatcher(): Batcher<Sample> {
+    if (batcher) return batcher;
+    batcher = createRafBatcher<Sample>((samples) => {
+      // Committed strokes live on InkLayer/HighlightLayer; we only redraw the
+      // active stroke on this canvas. Reference: Excalidraw splits live vs
+      // committed the same way (see packages/excalidraw/renderer).
+      const t0 = performance.now();
+      let latestPredicted: Point[] = [];
+      for (const s of samples) {
+        points.push(s.point);
+        if (s.predicted.length > 0) latestPredicted = s.predicted;
+      }
+      predictedTail = latestPredicted;
+      redrawLive();
+
+      if (debugEnabled) {
+        const now = performance.now();
+        debugWindow.push(now);
+        const cutoff = now - 1000;
+        while (debugWindow.length > 0 && debugWindow[0] < cutoff) debugWindow.shift();
+        debugInfo = {
+          hz: debugWindow.length,
+          frameMs: Math.round(now - t0),
+          coalesced: samples.length,
+          predicted: latestPredicted.length,
+        };
+        if (debugLastFrameTs !== 0) {
+          // keep the most recent frame interval visible in the overlay
+          debugInfo.frameMs = Math.round(now - debugLastFrameTs);
+        }
+        debugLastFrameTs = now;
+      }
+    });
+    return batcher;
+  }
+
+  function coalescedPoints(e: PointerEvent): Point[] {
+    const native = typeof e.getCoalescedEvents === 'function' ? e.getCoalescedEvents() : [];
+    if (!native || native.length === 0) return [maybeSnap(toPoint(e))];
+    const out: Point[] = [];
+    for (const c of native) out.push(maybeSnap(toPoint(c)));
+    return out;
+  }
+
+  function predictedPoints(e: PointerEvent): Point[] {
+    const native = typeof e.getPredictedEvents === 'function' ? e.getPredictedEvents() : [];
+    if (!native || native.length === 0) return [];
+    const out: Point[] = [];
+    for (const c of native) out.push(maybeSnap(toPoint(c)));
+    return out;
+  }
+
   function onPointerDown(e: PointerEvent) {
     log('live', `pointerdown tool=${currentTool} type=${e.pointerType} id=${e.pointerId}`);
     if (e.pointerType === 'touch') return;
@@ -149,6 +240,7 @@
     canvas.setPointerCapture(e.pointerId);
     activePointerId = e.pointerId;
     startTime = performance.now();
+    predictedTail = [];
 
     if (currentTool === 'eraser') {
       const p = toPoint(e);
@@ -170,11 +262,15 @@
     e.preventDefault();
   }
 
-  function onPointerMove(e: PointerEvent) {
+  function handleMoveLike(e: PointerEvent) {
     if (activePointerId !== e.pointerId) return;
     if (currentTool === 'eraser') {
-      const p = toPoint(e);
-      onerase?.({ x: p.x, y: p.y });
+      const coalesced = typeof e.getCoalescedEvents === 'function' ? e.getCoalescedEvents() : [];
+      const events = coalesced && coalesced.length > 0 ? coalesced : [e];
+      for (const ev of events) {
+        const p = toPoint(ev);
+        onerase?.({ x: p.x, y: p.y });
+      }
       return;
     }
     if (currentTool === 'graph') {
@@ -185,9 +281,30 @@
       return;
     }
     if (currentTool !== 'pen' && currentTool !== 'highlighter') return;
-    points.push(maybeSnap(toPoint(e)));
-    redrawLive();
+
+    const cps = coalescedPoints(e);
+    const predicted = predictedPoints(e);
+    const b = ensureBatcher();
+    // getCoalescedEvents can return 10+ samples for a single pointermove at
+    // high stylus rates; we flatten them into the batcher so every sample is
+    // smoothed and rendered, but we still only paint once per frame.
+    for (let i = 0; i < cps.length; i++) {
+      const isLast = i === cps.length - 1;
+      b.push({ point: cps[i], predicted: isLast ? predicted : [] });
+    }
     e.preventDefault();
+  }
+
+  function onPointerMove(e: PointerEvent) {
+    // When pointerrawupdate is available we prefer it for sub-frame resolution.
+    // Fall back to pointermove transparently on browsers that lack it.
+    if (HAS_RAW_UPDATE && (currentTool === 'pen' || currentTool === 'highlighter')) return;
+    handleMoveLike(e);
+  }
+
+  function onPointerRawUpdate(e: PointerEvent) {
+    if (!HAS_RAW_UPDATE) return;
+    handleMoveLike(e);
   }
 
   function finish(e: PointerEvent, commit: boolean) {
@@ -199,13 +316,20 @@
     }
     activePointerId = null;
 
+    // Drain any samples still queued in the batcher before we commit so the
+    // final stroke contains every input sample.
+    batcher?.flushNow();
+    predictedTail = [];
+
     if (commit && (currentTool === 'pen' || currentTool === 'highlighter') && points.length > 0) {
-      const finalPoints = rulerSnap
+      const snapped = rulerSnap
         ? snapStrokeToRuler(points, rulerSnap, rulerSnapThresholdPx / ptToPx)
         : points;
+      const epsilonPt = RDP_EPSILON_PX / ptToPx;
+      const simplified = simplifyRdp(snapped, epsilonPt);
       const bakedStreamline = currentTool === 'highlighter' ? highlighterStreamline : penStreamline;
-      const stroke = strokeFromInput(finalPoints, currentStyle, currentTool, bakedStreamline);
-      log('live', `commit ${currentTool} stroke points=${points.length}`);
+      const stroke = strokeFromInput(simplified, currentStyle, currentTool, bakedStreamline);
+      log('live', `commit ${currentTool} raw=${points.length} simplified=${simplified.length}`);
       oncommit?.(stroke);
     }
     if (commit && currentTool === 'graph' && graphStart && graphEnd) {
@@ -231,7 +355,18 @@
     finish(e, false);
   }
 
-  onMount(clear);
+  onMount(() => {
+    clear();
+    if (HAS_RAW_UPDATE && canvas) {
+      canvas.addEventListener('pointerrawupdate', onPointerRawUpdate as (e: Event) => void);
+    }
+  });
+
+  onDestroy(() => {
+    if (HAS_RAW_UPDATE && canvas) {
+      canvas.removeEventListener('pointerrawupdate', onPointerRawUpdate as (e: Event) => void);
+    }
+  });
 
   $effect(() => {
     void width;
@@ -252,11 +387,38 @@
   onpointercancel={onPointerCancel}
 ></canvas>
 
+{#if debugEnabled}
+  <div class="ink-debug">
+    <div>flush/s: {debugInfo.hz}</div>
+    <div>frame: {debugInfo.frameMs}ms</div>
+    <div>coalesced: {debugInfo.coalesced}</div>
+    <div>predicted: {debugInfo.predicted}</div>
+    <div>raw: {HAS_RAW_UPDATE ? 'on' : 'off'}</div>
+  </div>
+{/if}
+
 <style>
   .live-layer {
     position: absolute;
     inset: 0;
     pointer-events: auto;
     touch-action: none;
+    user-select: none;
+    -webkit-user-select: none;
+  }
+  .ink-debug {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    z-index: 100;
+    padding: 4px 6px;
+    font:
+      10px/1.3 ui-monospace,
+      monospace;
+    color: #fff;
+    background: rgba(0, 0, 0, 0.6);
+    border-radius: 3px;
+    pointer-events: none;
+    white-space: nowrap;
   }
 </style>

--- a/src/lib/canvas/LiveLayer.svelte
+++ b/src/lib/canvas/LiveLayer.svelte
@@ -118,7 +118,10 @@
   }
 
   function toPoint(e: PointerEvent): Point {
-    const rect = canvas.getBoundingClientRect();
+    return toPointWithRect(e, canvas.getBoundingClientRect());
+  }
+
+  function toPointWithRect(e: PointerEvent, rect: DOMRect): Point {
     const px = e.clientX - rect.left;
     const py = e.clientY - rect.top;
     const pressure = e.pressure > 0 ? e.pressure : 0.5;
@@ -210,19 +213,19 @@
     return batcher;
   }
 
-  function coalescedPoints(e: PointerEvent): Point[] {
+  function coalescedPoints(e: PointerEvent, rect: DOMRect): Point[] {
     const native = typeof e.getCoalescedEvents === 'function' ? e.getCoalescedEvents() : [];
-    if (!native || native.length === 0) return [maybeSnap(toPoint(e))];
+    if (!native || native.length === 0) return [maybeSnap(toPointWithRect(e, rect))];
     const out: Point[] = [];
-    for (const c of native) out.push(maybeSnap(toPoint(c)));
+    for (const c of native) out.push(maybeSnap(toPointWithRect(c, rect)));
     return out;
   }
 
-  function predictedPoints(e: PointerEvent): Point[] {
+  function predictedPoints(e: PointerEvent, rect: DOMRect): Point[] {
     const native = typeof e.getPredictedEvents === 'function' ? e.getPredictedEvents() : [];
     if (!native || native.length === 0) return [];
     const out: Point[] = [];
-    for (const c of native) out.push(maybeSnap(toPoint(c)));
+    for (const c of native) out.push(maybeSnap(toPointWithRect(c, rect)));
     return out;
   }
 
@@ -264,17 +267,18 @@
 
   function handleMoveLike(e: PointerEvent) {
     if (activePointerId !== e.pointerId) return;
+    const rect = canvas.getBoundingClientRect();
     if (currentTool === 'eraser') {
       const coalesced = typeof e.getCoalescedEvents === 'function' ? e.getCoalescedEvents() : [];
       const events = coalesced && coalesced.length > 0 ? coalesced : [e];
       for (const ev of events) {
-        const p = toPoint(ev);
+        const p = toPointWithRect(ev, rect);
         onerase?.({ x: p.x, y: p.y });
       }
       return;
     }
     if (currentTool === 'graph') {
-      const p = toPoint(e);
+      const p = toPointWithRect(e, rect);
       graphEnd = { x: p.x, y: p.y };
       redrawLive();
       e.preventDefault();
@@ -282,8 +286,8 @@
     }
     if (currentTool !== 'pen' && currentTool !== 'highlighter') return;
 
-    const cps = coalescedPoints(e);
-    const predicted = predictedPoints(e);
+    const cps = coalescedPoints(e, rect);
+    const predicted = predictedPoints(e, rect);
     const b = ensureBatcher();
     // getCoalescedEvents can return 10+ samples for a single pointermove at
     // high stylus rates; we flatten them into the batcher so every sample is
@@ -304,6 +308,11 @@
 
   function onPointerRawUpdate(e: PointerEvent) {
     if (!HAS_RAW_UPDATE) return;
+    // Raw updates are only consumed for pen/highlighter; eraser/graph/shape
+    // and all other tools continue to use pointermove. Without this gate,
+    // both listeners would fire for every motion event and double-handle
+    // erase samples and graph rect updates.
+    if (currentTool !== 'pen' && currentTool !== 'highlighter') return;
     handleMoveLike(e);
   }
 

--- a/src/lib/canvas/catmullRom.ts
+++ b/src/lib/canvas/catmullRom.ts
@@ -1,0 +1,83 @@
+import type { Point } from '$lib/types';
+
+/**
+ * Centripetal Catmull-Rom interpolation over a pressure-aware point buffer.
+ *
+ * Input samples are passed through unchanged at their original indices; extra
+ * samples are inserted only in gaps where the chord length exceeds
+ * `maxChordPx`. This keeps already-dense input cheap (no-op) and only pays
+ * for interpolation when hardware sample density drops during fast strokes
+ * — which is exactly when polygonal kinks appear.
+ *
+ * Centripetal (alpha = 0.5) is used because it avoids the self-intersections
+ * and cusps that uniform/chordal Catmull-Rom produce around sharp corners.
+ * Reference: Yuksel, Schaefer, Keyser, "Parameterization and Applications of
+ * Catmull-Rom Curves" (2011).
+ */
+export function catmullRomSmooth(points: Point[], maxChordPx = 6): Point[] {
+  if (points.length < 2) return points.slice();
+  if (maxChordPx <= 0) return points.slice();
+
+  const out: Point[] = [points[0]];
+  for (let i = 0; i < points.length - 1; i++) {
+    const p0 = points[i - 1] ?? points[i];
+    const p1 = points[i];
+    const p2 = points[i + 1];
+    const p3 = points[i + 2] ?? points[i + 1];
+
+    const chord = Math.hypot(p2.x - p1.x, p2.y - p1.y);
+    if (chord <= maxChordPx) {
+      out.push(p2);
+      continue;
+    }
+
+    const steps = Math.min(16, Math.ceil(chord / maxChordPx));
+    for (let s = 1; s < steps; s++) {
+      const t = s / steps;
+      out.push(centripetal(p0, p1, p2, p3, t));
+    }
+    out.push(p2);
+  }
+  return out;
+}
+
+function centripetal(p0: Point, p1: Point, p2: Point, p3: Point, t: number): Point {
+  const t0 = 0;
+  const t1 = t0 + knot(p0, p1);
+  const t2 = t1 + knot(p1, p2);
+  const t3 = t2 + knot(p2, p3);
+
+  const u = t1 + (t2 - t1) * t;
+
+  const a1 = lerpXY(p0, p1, safeDiv(t1 - u, t1 - t0), safeDiv(u - t0, t1 - t0));
+  const a2 = lerpXY(p1, p2, safeDiv(t2 - u, t2 - t1), safeDiv(u - t1, t2 - t1));
+  const a3 = lerpXY(p2, p3, safeDiv(t3 - u, t3 - t2), safeDiv(u - t2, t3 - t2));
+
+  const b1 = {
+    x: a1.x * safeDiv(t2 - u, t2 - t0) + a2.x * safeDiv(u - t0, t2 - t0),
+    y: a1.y * safeDiv(t2 - u, t2 - t0) + a2.y * safeDiv(u - t0, t2 - t0),
+  };
+  const b2 = {
+    x: a2.x * safeDiv(t3 - u, t3 - t1) + a3.x * safeDiv(u - t1, t3 - t1),
+    y: a2.y * safeDiv(t3 - u, t3 - t1) + a3.y * safeDiv(u - t1, t3 - t1),
+  };
+  const x = b1.x * safeDiv(t2 - u, t2 - t1) + b2.x * safeDiv(u - t1, t2 - t1);
+  const y = b1.y * safeDiv(t2 - u, t2 - t1) + b2.y * safeDiv(u - t1, t2 - t1);
+
+  const pressure = p1.pressure + (p2.pressure - p1.pressure) * t;
+  const time = p1.t + (p2.t - p1.t) * t;
+  return { x, y, pressure, t: time };
+}
+
+function knot(a: Point, b: Point): number {
+  const d = Math.hypot(b.x - a.x, b.y - a.y);
+  return Math.sqrt(d) || 1e-6;
+}
+
+function lerpXY(a: Point, b: Point, wa: number, wb: number): { x: number; y: number } {
+  return { x: a.x * wa + b.x * wb, y: a.y * wa + b.y * wb };
+}
+
+function safeDiv(n: number, d: number): number {
+  return d === 0 ? 0 : n / d;
+}

--- a/src/lib/canvas/catmullRom.ts
+++ b/src/lib/canvas/catmullRom.ts
@@ -5,18 +5,23 @@ import type { Point } from '$lib/types';
  *
  * Input samples are passed through unchanged at their original indices; extra
  * samples are inserted only in gaps where the chord length exceeds
- * `maxChordPx`. This keeps already-dense input cheap (no-op) and only pays
+ * `maxChordPt`. This keeps already-dense input cheap (no-op) and only pays
  * for interpolation when hardware sample density drops during fast strokes
  * — which is exactly when polygonal kinks appear.
+ *
+ * Units: all coordinates — `points` and `maxChordPt` — are in the same
+ * coordinate space as the input `Point` values (PDF points in this app).
+ * Callers that have a pixel-space threshold must convert px → pt (divide by
+ * `ptToPx`) before calling.
  *
  * Centripetal (alpha = 0.5) is used because it avoids the self-intersections
  * and cusps that uniform/chordal Catmull-Rom produce around sharp corners.
  * Reference: Yuksel, Schaefer, Keyser, "Parameterization and Applications of
  * Catmull-Rom Curves" (2011).
  */
-export function catmullRomSmooth(points: Point[], maxChordPx = 6): Point[] {
+export function catmullRomSmooth(points: Point[], maxChordPt = 6): Point[] {
   if (points.length < 2) return points.slice();
-  if (maxChordPx <= 0) return points.slice();
+  if (maxChordPt <= 0) return points.slice();
 
   const out: Point[] = [points[0]];
   for (let i = 0; i < points.length - 1; i++) {
@@ -26,12 +31,12 @@ export function catmullRomSmooth(points: Point[], maxChordPx = 6): Point[] {
     const p3 = points[i + 2] ?? points[i + 1];
 
     const chord = Math.hypot(p2.x - p1.x, p2.y - p1.y);
-    if (chord <= maxChordPx) {
+    if (chord <= maxChordPt) {
       out.push(p2);
       continue;
     }
 
-    const steps = Math.min(16, Math.ceil(chord / maxChordPx));
+    const steps = Math.min(16, Math.ceil(chord / maxChordPt));
     for (let s = 1; s < steps; s++) {
       const t = s / steps;
       out.push(centripetal(p0, p1, p2, p3, t));

--- a/src/lib/canvas/inkBatch.ts
+++ b/src/lib/canvas/inkBatch.ts
@@ -1,0 +1,147 @@
+/**
+ * Pure, testable rAF batch scheduler for pointer-to-render pipelines.
+ *
+ * The live-drawing hot path receives many more pointer samples per second
+ * than we can realistically paint (coalesced events push this well past
+ * 240 Hz on some stylii). We don't want one render per sample — we want
+ * one render per frame, fed with *all* samples that arrived in between.
+ *
+ * This module is a plain function state machine; it has no DOM or Svelte
+ * dependencies so it can be unit-tested deterministically.
+ */
+
+export interface BatchClock {
+  now: () => number;
+  requestFrame: (cb: (t: number) => void) => number;
+  cancelFrame: (id: number) => void;
+}
+
+export interface BatchStats {
+  /** Samples consumed since the batcher was created. */
+  samples: number;
+  /** Render ticks emitted since the batcher was created. */
+  renders: number;
+  /** Samples consumed during the most recent render tick. */
+  lastBatchSize: number;
+  /** Largest batch ever flushed in a single tick. */
+  peakBatchSize: number;
+}
+
+export interface Batcher<T> {
+  push: (sample: T) => void;
+  pushMany: (samples: readonly T[]) => void;
+  flushNow: () => void;
+  cancel: () => void;
+  stats: () => BatchStats;
+}
+
+/**
+ * Create a batcher that coalesces `push` / `pushMany` calls into a single
+ * `onFlush` per animation frame. `onFlush` receives every pending sample
+ * in arrival order; the caller is responsible for ingesting them into the
+ * live stroke and repainting.
+ */
+export function createRafBatcher<T>(
+  onFlush: (samples: T[]) => void,
+  clock: BatchClock = defaultClock(),
+): Batcher<T> {
+  const queue: T[] = [];
+  let frameId: number | null = null;
+  const stats: BatchStats = { samples: 0, renders: 0, lastBatchSize: 0, peakBatchSize: 0 };
+
+  function schedule() {
+    if (frameId !== null) return;
+    frameId = clock.requestFrame(() => {
+      frameId = null;
+      flush();
+    });
+  }
+
+  function flush() {
+    if (queue.length === 0) return;
+    const batch = queue.splice(0, queue.length);
+    stats.renders += 1;
+    stats.lastBatchSize = batch.length;
+    if (batch.length > stats.peakBatchSize) stats.peakBatchSize = batch.length;
+    onFlush(batch);
+  }
+
+  return {
+    push(sample) {
+      queue.push(sample);
+      stats.samples += 1;
+      schedule();
+    },
+    pushMany(samples) {
+      if (samples.length === 0) return;
+      for (const s of samples) queue.push(s);
+      stats.samples += samples.length;
+      schedule();
+    },
+    flushNow() {
+      if (frameId !== null) {
+        clock.cancelFrame(frameId);
+        frameId = null;
+      }
+      flush();
+    },
+    cancel() {
+      if (frameId !== null) {
+        clock.cancelFrame(frameId);
+        frameId = null;
+      }
+      queue.length = 0;
+    },
+    stats: () => ({ ...stats }),
+  };
+}
+
+function defaultClock(): BatchClock {
+  if (typeof requestAnimationFrame === 'function') {
+    return {
+      now: () => (typeof performance !== 'undefined' ? performance.now() : Date.now()),
+      requestFrame: (cb) => requestAnimationFrame(cb),
+      cancelFrame: (id) => cancelAnimationFrame(id),
+    };
+  }
+  return {
+    now: () => Date.now(),
+    requestFrame: (cb) => setTimeout(() => cb(Date.now()), 16) as unknown as number,
+    cancelFrame: (id) => clearTimeout(id as unknown as ReturnType<typeof setTimeout>),
+  };
+}
+
+/**
+ * A manually-advanced clock for tests. `tick()` fires every pending frame
+ * callback once, in FIFO order, simulating one rAF boundary.
+ */
+export function manualClock(startMs = 0): BatchClock & {
+  tick: () => void;
+  advance: (ms: number) => void;
+  pending: () => number;
+} {
+  let nowMs = startMs;
+  let nextId = 1;
+  const pending = new Map<number, (t: number) => void>();
+
+  return {
+    now: () => nowMs,
+    requestFrame: (cb) => {
+      const id = nextId++;
+      pending.set(id, cb);
+      return id;
+    },
+    cancelFrame: (id) => {
+      pending.delete(id);
+    },
+    tick: () => {
+      const snapshot = Array.from(pending.entries());
+      pending.clear();
+      for (const [, cb] of snapshot) cb(nowMs);
+    },
+    advance: (ms) => {
+      nowMs += ms;
+    },
+    pending: () => pending.size,
+  };
+}

--- a/src/lib/canvas/simplify.ts
+++ b/src/lib/canvas/simplify.ts
@@ -1,0 +1,58 @@
+import type { Point } from '$lib/types';
+
+/**
+ * Ramer-Douglas-Peucker simplification for point buffers.
+ *
+ * Runs at stroke-commit time to trim redundant samples the pointer pipeline
+ * emitted (especially on slow/hovering pen moves) without visibly changing
+ * the curve. Keeps endpoints; operates in 2D and preserves the original
+ * Point metadata (pressure, t) for surviving samples.
+ */
+export function simplifyRdp(points: Point[], epsilon = 0.5): Point[] {
+  if (points.length <= 2 || epsilon <= 0) return points.slice();
+  const keep = new Uint8Array(points.length);
+  keep[0] = 1;
+  keep[points.length - 1] = 1;
+  rdp(points, 0, points.length - 1, epsilon * epsilon, keep);
+
+  const out: Point[] = [];
+  for (let i = 0; i < points.length; i++) if (keep[i]) out.push(points[i]);
+  return out;
+}
+
+function rdp(points: Point[], lo: number, hi: number, epsSq: number, keep: Uint8Array): void {
+  if (hi - lo < 2) return;
+  let maxSq = -1;
+  let idx = -1;
+  const a = points[lo];
+  const b = points[hi];
+  for (let i = lo + 1; i < hi; i++) {
+    const d = perpSq(points[i], a, b);
+    if (d > maxSq) {
+      maxSq = d;
+      idx = i;
+    }
+  }
+  if (maxSq > epsSq && idx !== -1) {
+    keep[idx] = 1;
+    rdp(points, lo, idx, epsSq, keep);
+    rdp(points, idx, hi, epsSq, keep);
+  }
+}
+
+function perpSq(p: Point, a: Point, b: Point): number {
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  const len2 = dx * dx + dy * dy;
+  if (len2 === 0) {
+    const ex = p.x - a.x;
+    const ey = p.y - a.y;
+    return ex * ex + ey * ey;
+  }
+  const t = ((p.x - a.x) * dx + (p.y - a.y) * dy) / len2;
+  const tx = a.x + t * dx;
+  const ty = a.y + t * dy;
+  const ex = p.x - tx;
+  const ey = p.y - ty;
+  return ex * ex + ey * ey;
+}

--- a/src/lib/canvas/simplify.ts
+++ b/src/lib/canvas/simplify.ts
@@ -49,7 +49,13 @@ function perpSq(p: Point, a: Point, b: Point): number {
     const ey = p.y - a.y;
     return ex * ex + ey * ey;
   }
-  const t = ((p.x - a.x) * dx + (p.y - a.y) * dy) / len2;
+  // Clamp the projection to the segment so backtracking/looping strokes are
+  // measured against the endpoints instead of the infinite line — otherwise
+  // a point that reverses course can land arbitrarily close to the line
+  // while being far from the segment, and RDP would drop it.
+  let t = ((p.x - a.x) * dx + (p.y - a.y) * dy) / len2;
+  if (t < 0) t = 0;
+  else if (t > 1) t = 1;
   const tx = a.x + t * dx;
   const ty = a.y + t * dy;
   const ex = p.x - tx;

--- a/tests/catmull-rom.test.ts
+++ b/tests/catmull-rom.test.ts
@@ -28,13 +28,13 @@ describe('catmullRomSmooth', () => {
     for (let i = 1; i < keepIdx.length; i++) expect(keepIdx[i]).toBeGreaterThan(keepIdx[i - 1]);
   });
 
-  it('no-op when every chord is within maxChordPx', () => {
+  it('no-op when every chord is within maxChordPt', () => {
     const input = [p(0, 0), p(1, 0), p(2, 0), p(3, 0)];
     const out = catmullRomSmooth(input, 10);
     expect(out).toHaveLength(input.length);
   });
 
-  it('inserts samples when chord exceeds maxChordPx', () => {
+  it('inserts samples when chord exceeds maxChordPt', () => {
     const input = [p(0, 0), p(100, 0), p(200, 0)];
     const out = catmullRomSmooth(input, 10);
     expect(out.length).toBeGreaterThan(input.length);

--- a/tests/catmull-rom.test.ts
+++ b/tests/catmull-rom.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { catmullRomSmooth } from '$lib/canvas/catmullRom';
+import type { Point } from '$lib/types';
+
+function p(x: number, y: number, pressure = 0.5, t = 0): Point {
+  return { x, y, pressure, t };
+}
+
+describe('catmullRomSmooth', () => {
+  it('returns the input unchanged for 0 or 1 points', () => {
+    expect(catmullRomSmooth([])).toEqual([]);
+    const one = [p(1, 2)];
+    expect(catmullRomSmooth(one)).toEqual(one);
+  });
+
+  it('preserves endpoints exactly', () => {
+    const input = [p(0, 0), p(100, 0), p(200, 0)];
+    const out = catmullRomSmooth(input, 10);
+    expect(out[0]).toEqual(input[0]);
+    expect(out[out.length - 1]).toEqual(input[input.length - 1]);
+  });
+
+  it('keeps every original sample in order', () => {
+    const input = [p(0, 0, 0.1, 0), p(50, 10, 0.5, 10), p(100, 0, 0.9, 20)];
+    const out = catmullRomSmooth(input, 5);
+    const keepIdx = input.map((orig) => out.findIndex((q) => q.x === orig.x && q.y === orig.y));
+    expect(keepIdx.every((i) => i >= 0)).toBe(true);
+    for (let i = 1; i < keepIdx.length; i++) expect(keepIdx[i]).toBeGreaterThan(keepIdx[i - 1]);
+  });
+
+  it('no-op when every chord is within maxChordPx', () => {
+    const input = [p(0, 0), p(1, 0), p(2, 0), p(3, 0)];
+    const out = catmullRomSmooth(input, 10);
+    expect(out).toHaveLength(input.length);
+  });
+
+  it('inserts samples when chord exceeds maxChordPx', () => {
+    const input = [p(0, 0), p(100, 0), p(200, 0)];
+    const out = catmullRomSmooth(input, 10);
+    expect(out.length).toBeGreaterThan(input.length);
+  });
+
+  it('interpolated samples lie near the input polyline for a straight line', () => {
+    const input = [p(0, 0), p(100, 0), p(200, 0), p(300, 0)];
+    const out = catmullRomSmooth(input, 5);
+    for (const q of out) expect(Math.abs(q.y)).toBeLessThan(1e-6);
+  });
+
+  it('parameterization is monotonic in time across each segment', () => {
+    const input = [p(0, 0, 0.5, 0), p(100, 0, 0.5, 100), p(200, 0, 0.5, 200)];
+    const out = catmullRomSmooth(input, 10);
+    for (let i = 1; i < out.length; i++) expect(out[i].t).toBeGreaterThanOrEqual(out[i - 1].t);
+  });
+
+  it('interpolates pressure linearly between anchors', () => {
+    const input = [p(0, 0, 0, 0), p(100, 0, 1, 100)];
+    const out = catmullRomSmooth(input, 10);
+    for (const q of out) {
+      expect(q.pressure).toBeGreaterThanOrEqual(0);
+      expect(q.pressure).toBeLessThanOrEqual(1);
+    }
+    expect(out[0].pressure).toBe(0);
+    expect(out[out.length - 1].pressure).toBe(1);
+  });
+
+  it('handles duplicate input samples without NaN', () => {
+    const input = [p(0, 0), p(50, 0), p(50, 0), p(100, 0)];
+    const out = catmullRomSmooth(input, 20);
+    for (const q of out) {
+      expect(Number.isFinite(q.x)).toBe(true);
+      expect(Number.isFinite(q.y)).toBe(true);
+    }
+  });
+});

--- a/tests/live-layer-batching.test.ts
+++ b/tests/live-layer-batching.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { createRafBatcher, manualClock } from '$lib/canvas/inkBatch';
+
+describe('createRafBatcher', () => {
+  it('emits one render per frame regardless of event density', () => {
+    const clock = manualClock();
+    let flushes = 0;
+    const batcher = createRafBatcher<number>(() => flushes++, clock);
+
+    for (let i = 0; i < 200; i++) batcher.push(i);
+    expect(flushes).toBe(0);
+
+    clock.tick();
+    expect(flushes).toBe(1);
+  });
+
+  it('passes all coalesced samples to the single flush in arrival order', () => {
+    const clock = manualClock();
+    const flushed: number[][] = [];
+    const batcher = createRafBatcher<number>((b) => flushed.push(b), clock);
+
+    batcher.pushMany([1, 2, 3]);
+    batcher.push(4);
+    batcher.pushMany([5, 6]);
+
+    clock.tick();
+    expect(flushed).toHaveLength(1);
+    expect(flushed[0]).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  it('coalesces across rapid frames: one flush per tick', () => {
+    const clock = manualClock();
+    const batches: number[][] = [];
+    const batcher = createRafBatcher<number>((b) => batches.push(b), clock);
+
+    batcher.push(1);
+    batcher.push(2);
+    clock.tick();
+    batcher.push(3);
+    clock.tick();
+    batcher.push(4);
+    batcher.push(5);
+    batcher.push(6);
+    clock.tick();
+
+    expect(batches).toEqual([[1, 2], [3], [4, 5, 6]]);
+  });
+
+  it('an empty frame does not flush', () => {
+    const clock = manualClock();
+    let flushes = 0;
+    const batcher = createRafBatcher<number>(() => flushes++, clock);
+
+    clock.tick();
+    expect(flushes).toBe(0);
+
+    batcher.push(1);
+    clock.tick();
+    expect(flushes).toBe(1);
+
+    clock.tick();
+    expect(flushes).toBe(1);
+  });
+
+  it('push after flush schedules a new frame', () => {
+    const clock = manualClock();
+    const batches: number[][] = [];
+    const batcher = createRafBatcher<number>((b) => batches.push(b), clock);
+
+    batcher.push(1);
+    clock.tick();
+    expect(batches).toEqual([[1]]);
+
+    batcher.push(2);
+    expect(clock.pending()).toBe(1);
+    clock.tick();
+    expect(batches).toEqual([[1], [2]]);
+  });
+
+  it('flushNow drains synchronously and cancels the pending frame', () => {
+    const clock = manualClock();
+    const batches: number[][] = [];
+    const batcher = createRafBatcher<number>((b) => batches.push(b), clock);
+
+    batcher.pushMany([1, 2, 3]);
+    expect(clock.pending()).toBe(1);
+    batcher.flushNow();
+    expect(batches).toEqual([[1, 2, 3]]);
+    expect(clock.pending()).toBe(0);
+
+    clock.tick();
+    expect(batches).toHaveLength(1);
+  });
+
+  it('cancel drops pending samples without flushing', () => {
+    const clock = manualClock();
+    let flushes = 0;
+    const batcher = createRafBatcher<number>(() => flushes++, clock);
+
+    batcher.pushMany([1, 2, 3]);
+    batcher.cancel();
+    clock.tick();
+    expect(flushes).toBe(0);
+    expect(clock.pending()).toBe(0);
+  });
+
+  it('stats track samples, renders, and peak batch size', () => {
+    const clock = manualClock();
+    const batcher = createRafBatcher<number>(() => undefined, clock);
+
+    batcher.pushMany([1, 2]);
+    clock.tick();
+    batcher.pushMany([3, 4, 5, 6]);
+    clock.tick();
+
+    const s = batcher.stats();
+    expect(s.samples).toBe(6);
+    expect(s.renders).toBe(2);
+    expect(s.lastBatchSize).toBe(4);
+    expect(s.peakBatchSize).toBe(4);
+  });
+});

--- a/tests/simplify.test.ts
+++ b/tests/simplify.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { simplifyRdp } from '$lib/canvas/simplify';
+import type { Point } from '$lib/types';
+
+function p(x: number, y: number, pressure = 0.5, t = 0): Point {
+  return { x, y, pressure, t };
+}
+
+describe('simplifyRdp', () => {
+  it('returns input unchanged when length <= 2', () => {
+    expect(simplifyRdp([])).toEqual([]);
+    const one = [p(1, 2)];
+    expect(simplifyRdp(one)).toEqual(one);
+    const two = [p(0, 0), p(5, 5)];
+    expect(simplifyRdp(two)).toEqual(two);
+  });
+
+  it('collapses a dense straight line to just the endpoints', () => {
+    const line: Point[] = [];
+    for (let i = 0; i <= 100; i++) line.push(p(i, 0));
+    const out = simplifyRdp(line, 0.5);
+    expect(out).toHaveLength(2);
+    expect(out[0]).toEqual(line[0]);
+    expect(out[1]).toEqual(line[line.length - 1]);
+  });
+
+  it('preserves endpoints for a curve', () => {
+    const pts: Point[] = [];
+    for (let i = 0; i <= 50; i++) pts.push(p(i, Math.sin(i / 5) * 20));
+    const out = simplifyRdp(pts, 0.5);
+    expect(out[0]).toEqual(pts[0]);
+    expect(out[out.length - 1]).toEqual(pts[pts.length - 1]);
+  });
+
+  it('stays within epsilon of the original curve', () => {
+    const pts: Point[] = [];
+    for (let i = 0; i <= 200; i++) pts.push(p(i, Math.sin(i / 10) * 30));
+    const eps = 0.5;
+    const out = simplifyRdp(pts, eps);
+
+    for (const orig of pts) {
+      let best = Infinity;
+      for (let j = 0; j < out.length - 1; j++) {
+        const d = distToSegment(orig, out[j], out[j + 1]);
+        if (d < best) best = d;
+      }
+      expect(best).toBeLessThanOrEqual(eps + 1e-6);
+    }
+  });
+
+  it('drops strictly colinear interior points', () => {
+    const pts = [p(0, 0), p(1, 0), p(2, 0), p(3, 0), p(4, 1)];
+    const out = simplifyRdp(pts, 0.1);
+    expect(out.some((q) => q.x === 0 && q.y === 0)).toBe(true);
+    expect(out.some((q) => q.x === 3 && q.y === 0)).toBe(true);
+    expect(out.some((q) => q.x === 4 && q.y === 1)).toBe(true);
+    expect(out.length).toBeLessThan(pts.length);
+  });
+
+  it('preserves surviving sample metadata (pressure, t)', () => {
+    const pts = [p(0, 0, 0.1, 0), p(100, 0, 0.9, 100), p(200, 100, 0.5, 200)];
+    const out = simplifyRdp(pts, 0.5);
+    expect(out[0]).toEqual(pts[0]);
+    expect(out[out.length - 1]).toEqual(pts[pts.length - 1]);
+  });
+
+  it('epsilon <= 0 is a no-op', () => {
+    const pts = [p(0, 0), p(1, 0.001), p(2, 0), p(3, 0)];
+    expect(simplifyRdp(pts, 0)).toEqual(pts);
+    expect(simplifyRdp(pts, -1)).toEqual(pts);
+  });
+});
+
+function distToSegment(p0: Point, a: Point, b: Point): number {
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  const len2 = dx * dx + dy * dy;
+  if (len2 === 0) return Math.hypot(p0.x - a.x, p0.y - a.y);
+  let t = ((p0.x - a.x) * dx + (p0.y - a.y) * dy) / len2;
+  t = Math.max(0, Math.min(1, t));
+  return Math.hypot(p0.x - (a.x + t * dx), p0.y - (a.y + t * dy));
+}

--- a/tests/simplify.test.ts
+++ b/tests/simplify.test.ts
@@ -69,6 +69,26 @@ describe('simplifyRdp', () => {
     expect(simplifyRdp(pts, 0)).toEqual(pts);
     expect(simplifyRdp(pts, -1)).toEqual(pts);
   });
+
+  it('does not collapse a backtrack of collinear-but-reversed points', () => {
+    // (0,0) -> (10,0) -> (5,0): the turnaround at (10,0) lies on the infinite
+    // line through the endpoints, so an infinite-line RDP would drop it and
+    // silently lose the backtrack. Point-to-segment distance correctly
+    // reports 5 here, well above epsilon.
+    const pts = [p(0, 0), p(10, 0), p(5, 0)];
+    const out = simplifyRdp(pts, 0.5);
+    expect(out).toHaveLength(3);
+    expect(out[1]).toEqual(pts[1]);
+  });
+
+  it('does not collapse a loop back to the start', () => {
+    // Square loop that returns to origin: endpoints are identical so the
+    // infinite-line "segment" is degenerate; clamped projection correctly
+    // measures distance to the shared endpoint.
+    const pts = [p(0, 0), p(10, 0), p(10, 10), p(0, 10), p(0, 0)];
+    const out = simplifyRdp(pts, 0.5);
+    expect(out.length).toBeGreaterThan(2);
+  });
 });
 
 function distToSegment(p0: Point, a: Point, b: Point): number {


### PR DESCRIPTION
Closes #105. Adds `getCoalescedEvents` + `getPredictedEvents` + `pointerrawupdate`; single-rAF-per-frame flush; centripetal Catmull-Rom gap-fill before `getStroke`; RDP simplify at commit; `desynchronized: true` canvas; debug overlay behind `?inkdebug=1`. Committed layers untouched during active drawing.