### PR TITLE
perf(eraser): batch deletions, rAF flush, spatial-index hit-test (#106)

### DIFF
--- a/src/lib/canvas/CanvasStack.svelte
+++ b/src/lib/canvas/CanvasStack.svelte
@@ -36,7 +36,7 @@
     rulerSnapThresholdPx?: number;
     overlay?: Snippet;
     oncommit?: (stroke: StrokeObject) => void;
-    onerase?: (at: { x: number; y: number }) => void;
+    onerase?: (samples: { x: number; y: number }[]) => void;
     oncommitobject?: (obj: LineObject | ShapeObject | NumberLineObject) => void;
     ongraph?: (bounds: { x: number; y: number; w: number; h: number }) => void;
   }

--- a/src/lib/canvas/EraseDebugOverlay.svelte
+++ b/src/lib/canvas/EraseDebugOverlay.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import { eraseDebug } from '$lib/store/eraseDebug';
+
+  const stats = $derived($eraseDebug);
+  let nowMs = $state(performance.now());
+
+  $effect(() => {
+    if (!stats.enabled) return;
+    const id = window.setInterval(() => (nowMs = performance.now()), 100);
+    return () => window.clearInterval(id);
+  });
+
+  const sinceLastMove = $derived(
+    stats.lastPointerMoveAt > 0 ? Math.round(nowMs - stats.lastPointerMoveAt) : null,
+  );
+</script>
+
+{#if stats.enabled}
+  <div class="erase-debug" role="status" aria-label="Eraser debug overlay">
+    <div class="row">erase hits/s: <strong>{stats.eraseHitsPerSec}</strong></div>
+    <div class="row">pointermove/s: <strong>{stats.pointerMovesPerSec}</strong></div>
+    <div class="row">
+      last move: <strong>{sinceLastMove === null ? '—' : `${sinceLastMove}ms`}</strong>
+    </div>
+    <div class="row dim">
+      total moves {stats.pointerMoves} · total hits {stats.eraseHits}
+    </div>
+  </div>
+{/if}
+
+<style>
+  .erase-debug {
+    position: fixed;
+    bottom: 12px;
+    right: 12px;
+    background: rgba(10, 10, 10, 0.78);
+    border: 1px solid #333;
+    border-radius: 6px;
+    color: #ddd;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 11px;
+    padding: 8px 10px;
+    min-width: 180px;
+    z-index: 1100;
+    pointer-events: none;
+  }
+  .row {
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+  }
+  .dim {
+    color: #888;
+    margin-top: 4px;
+    border-top: 1px solid #2a2a2a;
+    padding-top: 4px;
+  }
+</style>

--- a/src/lib/canvas/LiveLayer.svelte
+++ b/src/lib/canvas/LiveLayer.svelte
@@ -20,7 +20,7 @@
     penStreamline?: number;
     highlighterStreamline?: number;
     oncommit?: (stroke: StrokeObject) => void;
-    onerase?: (at: { x: number; y: number }) => void;
+    onerase?: (samples: { x: number; y: number }[]) => void;
     ongraph?: (bounds: { x: number; y: number; w: number; h: number }) => void;
   }
 
@@ -247,7 +247,7 @@
 
     if (currentTool === 'eraser') {
       const p = toPoint(e);
-      onerase?.({ x: p.x, y: p.y });
+      onerase?.([{ x: p.x, y: p.y }]);
       return;
     }
 
@@ -271,10 +271,12 @@
     if (currentTool === 'eraser') {
       const coalesced = typeof e.getCoalescedEvents === 'function' ? e.getCoalescedEvents() : [];
       const events = coalesced && coalesced.length > 0 ? coalesced : [e];
+      const samples: { x: number; y: number }[] = [];
       for (const ev of events) {
         const p = toPointWithRect(ev, rect);
-        onerase?.({ x: p.x, y: p.y });
+        samples.push({ x: p.x, y: p.y });
       }
+      onerase?.(samples);
       return;
     }
     if (currentTool === 'graph') {

--- a/src/lib/canvas/index.ts
+++ b/src/lib/canvas/index.ts
@@ -13,3 +13,4 @@ export { default as LaserLayer } from './LaserLayer.svelte';
 export { default as TempInkLayer } from './TempInkLayer.svelte';
 export { default as ProtractorOverlay } from './ProtractorOverlay.svelte';
 export { default as RulerOverlay } from './RulerOverlay.svelte';
+export { default as EraseDebugOverlay } from './EraseDebugOverlay.svelte';

--- a/src/lib/store/document.ts
+++ b/src/lib/store/document.ts
@@ -12,6 +12,7 @@ export interface DocumentStore {
 
   addObject(pageIndex: number, obj: AnyObject): void;
   removeObject(pageIndex: number, id: ObjectId): void;
+  removeObjects(pageIndex: number, ids: readonly ObjectId[]): void;
   updateObject(pageIndex: number, id: ObjectId, patch: Partial<AnyObject>): void;
 
   insertBlankPageAfter(
@@ -192,6 +193,20 @@ export function createDocumentStore(): DocumentStore {
       const obj = page.objects.find((o) => o.id === id);
       if (!obj) return;
       pushAndApply(pageIndex, { type: 'remove', object: obj });
+    },
+
+    removeObjects(pageIndex, ids) {
+      if (ids.length === 0) return;
+      const doc = get(state);
+      if (!doc) return;
+      const page = doc.pages[pageIndex];
+      if (!page) return;
+      const wanted = new Set(ids);
+      const items = page.objects
+        .map((object, index) => ({ object, index }))
+        .filter(({ object }) => wanted.has(object.id));
+      if (items.length === 0) return;
+      pushAndApply(pageIndex, { type: 'removeMany', items });
     },
 
     updateObject(pageIndex, id, patch) {

--- a/src/lib/store/eraseDebug.ts
+++ b/src/lib/store/eraseDebug.ts
@@ -1,0 +1,92 @@
+import { writable, type Readable } from 'svelte/store';
+
+export interface EraseDebugStats {
+  /** `true` when `?erasedebug=1` or localStorage flag is set. */
+  enabled: boolean;
+  /** Total pointermove events observed on the live layer while erasing. */
+  pointerMoves: number;
+  /** Total objects removed by the eraser across this session. */
+  eraseHits: number;
+  /** Timestamp (performance.now) of the last pointermove from eraser drag. */
+  lastPointerMoveAt: number;
+  /** Rolling 1s rates, updated on every sample. */
+  eraseHitsPerSec: number;
+  pointerMovesPerSec: number;
+}
+
+const initial: EraseDebugStats = {
+  enabled: false,
+  pointerMoves: 0,
+  eraseHits: 0,
+  lastPointerMoveAt: 0,
+  eraseHitsPerSec: 0,
+  pointerMovesPerSec: 0,
+};
+
+const store = writable<EraseDebugStats>(initial);
+
+function detectEnabled(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    const url = new URL(window.location.href);
+    if (url.searchParams.get('erasedebug') === '1') return true;
+  } catch {
+    // ignore
+  }
+  try {
+    if (window.localStorage.getItem('eldrawEraseDebug') === '1') return true;
+  } catch {
+    // ignore
+  }
+  return false;
+}
+
+interface Bucket {
+  times: number[];
+  count: number;
+}
+
+function pushWithWindow(bucket: Bucket, now: number, windowMs = 1000): number {
+  bucket.times.push(now);
+  bucket.count += 1;
+  const cutoff = now - windowMs;
+  while (bucket.times.length > 0 && bucket.times[0] < cutoff) {
+    bucket.times.shift();
+  }
+  return bucket.times.length;
+}
+
+const moveBucket: Bucket = { times: [], count: 0 };
+const hitBucket: Bucket = { times: [], count: 0 };
+
+export const eraseDebug: Readable<EraseDebugStats> & {
+  init: () => void;
+  recordPointerMove: () => void;
+  recordHits: (n: number) => void;
+} = {
+  subscribe: store.subscribe,
+  init() {
+    const enabled = detectEnabled();
+    store.update((s) => ({ ...s, enabled }));
+  },
+  recordPointerMove() {
+    const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+    const perSec = pushWithWindow(moveBucket, now);
+    store.update((s) => ({
+      ...s,
+      pointerMoves: s.pointerMoves + 1,
+      pointerMovesPerSec: perSec,
+      lastPointerMoveAt: now,
+    }));
+  },
+  recordHits(n) {
+    if (n <= 0) return;
+    const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+    for (let i = 0; i < n; i += 1) pushWithWindow(hitBucket, now);
+    store.update((s) => ({
+      ...s,
+      eraseHits: s.eraseHits + n,
+      eraseHitsPerSec: hitBucket.times.length,
+    }));
+  },
+};

--- a/src/lib/store/eraseDebug.ts
+++ b/src/lib/store/eraseDebug.ts
@@ -59,17 +59,24 @@ function pushWithWindow(bucket: Bucket, now: number, windowMs = 1000): number {
 const moveBucket: Bucket = { times: [], count: 0 };
 const hitBucket: Bucket = { times: [], count: 0 };
 
+let enabledFlag = false;
+
 export const eraseDebug: Readable<EraseDebugStats> & {
   init: () => void;
+  isEnabled: () => boolean;
   recordPointerMove: () => void;
   recordHits: (n: number) => void;
 } = {
   subscribe: store.subscribe,
   init() {
-    const enabled = detectEnabled();
-    store.update((s) => ({ ...s, enabled }));
+    enabledFlag = detectEnabled();
+    store.update((s) => ({ ...s, enabled: enabledFlag }));
+  },
+  isEnabled() {
+    return enabledFlag;
   },
   recordPointerMove() {
+    if (!enabledFlag) return;
     const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
     const perSec = pushWithWindow(moveBucket, now);
     store.update((s) => ({
@@ -80,7 +87,7 @@ export const eraseDebug: Readable<EraseDebugStats> & {
     }));
   },
   recordHits(n) {
-    if (n <= 0) return;
+    if (!enabledFlag || n <= 0) return;
     const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
     for (let i = 0; i < n; i += 1) pushWithWindow(hitBucket, now);
     store.update((s) => ({

--- a/src/lib/store/history.ts
+++ b/src/lib/store/history.ts
@@ -1,9 +1,21 @@
 import { derived, writable, get, type Readable } from 'svelte/store';
 import type { AnyObject, ObjectId, Page } from '$lib/types';
 
+/**
+ * A removal or re-insertion entry carries both the object and the index it
+ * occupied before being removed, so one undo restores the batch in the exact
+ * order it had on-page.
+ */
+export interface IndexedObject {
+  object: AnyObject;
+  index: number;
+}
+
 export type Command =
   | { type: 'add'; object: AnyObject }
   | { type: 'remove'; object: AnyObject }
+  | { type: 'removeMany'; items: IndexedObject[] }
+  | { type: 'insertMany'; items: IndexedObject[] }
   | { type: 'update'; objectId: ObjectId; before: AnyObject; after: AnyObject }
   | { type: 'clearPage'; objects: AnyObject[] }
   | { type: 'restorePage'; objects: AnyObject[] };
@@ -16,6 +28,18 @@ export function applyCommand(page: Page, cmd: Command): Page {
       return { ...page, objects: [...page.objects, cmd.object] };
     case 'remove':
       return { ...page, objects: page.objects.filter((o) => o.id !== cmd.object.id) };
+    case 'removeMany': {
+      const drop = new Set(cmd.items.map((i) => i.object.id));
+      return { ...page, objects: page.objects.filter((o) => !drop.has(o.id)) };
+    }
+    case 'insertMany': {
+      const sorted = [...cmd.items].sort((a, b) => a.index - b.index);
+      const next = [...page.objects];
+      for (const { object, index } of sorted) {
+        next.splice(Math.min(index, next.length), 0, object);
+      }
+      return { ...page, objects: next };
+    }
     case 'update':
       return {
         ...page,
@@ -34,6 +58,10 @@ export function invertCommand(cmd: Command): Command {
       return { type: 'remove', object: cmd.object };
     case 'remove':
       return { type: 'add', object: cmd.object };
+    case 'removeMany':
+      return { type: 'insertMany', items: cmd.items };
+    case 'insertMany':
+      return { type: 'removeMany', items: cmd.items };
     case 'update':
       return {
         type: 'update',

--- a/src/lib/tools/eraser.ts
+++ b/src/lib/tools/eraser.ts
@@ -121,4 +121,21 @@ export function hitTestObjects(
   return objects.filter((o) => hitTestObject(o, at, radius));
 }
 
+/**
+ * Specialization of `hitTestObjects` for callers that already narrowed the
+ * object set via a spatial index. Same semantics as `hitTestObjects`; the
+ * only difference is intent — `candidates` is expected to be small.
+ */
+export function hitTestObjectsFromCandidates(
+  candidates: readonly AnyObject[],
+  at: { x: number; y: number },
+  radius: number,
+): string[] {
+  const out: string[] = [];
+  for (const o of candidates) {
+    if (hitTestObject(o, at, radius)) out.push(o.id);
+  }
+  return out;
+}
+
 export type { Point };

--- a/src/lib/tools/eraserBatch.ts
+++ b/src/lib/tools/eraserBatch.ts
@@ -1,0 +1,53 @@
+import type { AnyObject } from '$lib/types';
+import { hitTestObjectsFromCandidates } from '$lib/tools/eraser';
+import { queryPoint, type SpatialIndex } from '$lib/tools/spatialIndex';
+
+export interface ErasePoint {
+  x: number;
+  y: number;
+}
+
+/**
+ * Pure rAF-flush body for the eraser. Given a batch of pointer samples and a
+ * spatial index, return the deduped set of object ids that the eraser covers
+ * across the whole batch. Extracted as a free function so it can be tested
+ * without a DOM.
+ */
+export function collectEraseIds(
+  samples: readonly ErasePoint[],
+  radius: number,
+  index: SpatialIndex,
+): string[] {
+  if (samples.length === 0) return [];
+  const ids = new Set<string>();
+  for (const s of samples) {
+    const candidates = queryPoint(index, s.x, s.y, radius);
+    if (candidates.length === 0) continue;
+    const hits = hitTestObjectsFromCandidates(candidates, s, radius);
+    for (const id of hits) ids.add(id);
+  }
+  return [...ids];
+}
+
+/**
+ * Build the flush handler used by `createRafBatcher`. Kept separate so callers
+ * can inject the current `SpatialIndex` + `removeObjects` binding reactively.
+ */
+export function makeEraseFlush(
+  getIndex: () => SpatialIndex | null,
+  radius: number,
+  remove: (ids: string[]) => void,
+  onStats?: (hits: number) => void,
+): (samples: ErasePoint[]) => void {
+  return (samples) => {
+    const index = getIndex();
+    if (!index) return;
+    const ids = collectEraseIds(samples, radius, index);
+    if (ids.length === 0) return;
+    remove(ids);
+    onStats?.(ids.length);
+  };
+}
+
+// Re-exported for callers that want to pre-filter without the full pipeline.
+export type { AnyObject };

--- a/src/lib/tools/spatialIndex.ts
+++ b/src/lib/tools/spatialIndex.ts
@@ -1,0 +1,168 @@
+import type { AnyObject } from '$lib/types';
+import { estimateTextBounds } from '$lib/text/hitTest';
+
+export interface AABB {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
+export interface SpatialIndex {
+  readonly cellSize: number;
+  readonly objects: readonly AnyObject[];
+  readonly bounds: ReadonlyMap<string, AABB>;
+  readonly cells: ReadonlyMap<string, AnyObject[]>;
+}
+
+/**
+ * Axis-aligned bounding box in PDF points for any object type.
+ *
+ * For strokes we inflate by half-thickness scaled by peak pressure, matching
+ * the eraser hit-test; for angle marks we enclose the two ray segments plus
+ * stroke half-width; for text we use the estimated text bounds.
+ */
+export function objectAabb(obj: AnyObject): AABB {
+  switch (obj.type) {
+    case 'stroke': {
+      const baseHalf = obj.style.width / 2;
+      if (obj.points.length === 0) {
+        return { minX: 0, minY: 0, maxX: 0, maxY: 0 };
+      }
+      let maxPressure = 0;
+      let minX = Infinity;
+      let minY = Infinity;
+      let maxX = -Infinity;
+      let maxY = -Infinity;
+      for (const p of obj.points) {
+        if (p.x < minX) minX = p.x;
+        if (p.y < minY) minY = p.y;
+        if (p.x > maxX) maxX = p.x;
+        if (p.y > maxY) maxY = p.y;
+        if (p.pressure > maxPressure) maxPressure = p.pressure;
+      }
+      const half = Math.max(baseHalf, baseHalf * 2 * maxPressure);
+      return { minX: minX - half, minY: minY - half, maxX: maxX + half, maxY: maxY + half };
+    }
+    case 'line': {
+      const half = obj.style.width / 2;
+      const minX = Math.min(obj.from.x, obj.to.x) - half;
+      const minY = Math.min(obj.from.y, obj.to.y) - half;
+      const maxX = Math.max(obj.from.x, obj.to.x) + half;
+      const maxY = Math.max(obj.from.y, obj.to.y) + half;
+      return { minX, minY, maxX, maxY };
+    }
+    case 'shape': {
+      const half = obj.style.width / 2;
+      const { x, y, w, h } = obj.bounds;
+      return { minX: x - half, minY: y - half, maxX: x + w + half, maxY: y + h + half };
+    }
+    case 'numberline': {
+      const half = obj.style.width / 2 + 6;
+      return {
+        minX: obj.from.x - half,
+        minY: obj.from.y - half,
+        maxX: obj.from.x + obj.length + half,
+        maxY: obj.from.y + half,
+      };
+    }
+    case 'graph': {
+      const { x, y, w, h } = obj.bounds;
+      return { minX: x, minY: y, maxX: x + w, maxY: y + h };
+    }
+    case 'text': {
+      const b = estimateTextBounds(obj);
+      return { minX: b.x, minY: b.y, maxX: b.x + b.width, maxY: b.y + b.height };
+    }
+    case 'angleMark': {
+      const half = obj.width / 2;
+      const xs = [obj.vertex.x, obj.rayA.x, obj.rayB.x];
+      const ys = [obj.vertex.y, obj.rayA.y, obj.rayB.y];
+      return {
+        minX: Math.min(...xs) - half,
+        minY: Math.min(...ys) - half,
+        maxX: Math.max(...xs) + half,
+        maxY: Math.max(...ys) + half,
+      };
+    }
+    default: {
+      const _exhaustive: never = obj;
+      void _exhaustive;
+      return { minX: 0, minY: 0, maxX: 0, maxY: 0 };
+    }
+  }
+}
+
+function cellKey(cx: number, cy: number): string {
+  return `${cx},${cy}`;
+}
+
+function cellRange(
+  aabb: AABB,
+  cellSize: number,
+): { x0: number; y0: number; x1: number; y1: number } {
+  return {
+    x0: Math.floor(aabb.minX / cellSize),
+    y0: Math.floor(aabb.minY / cellSize),
+    x1: Math.floor(aabb.maxX / cellSize),
+    y1: Math.floor(aabb.maxY / cellSize),
+  };
+}
+
+// Full rebuild on `pageObjects` change is the MVP. Incremental updates are
+// a follow-up if profiling ever shows rebuild cost dominates a frame on a
+// very large page.
+export function createSpatialIndex(objects: readonly AnyObject[], cellSize = 64): SpatialIndex {
+  if (cellSize <= 0) throw new Error('cellSize must be positive');
+  const bounds = new Map<string, AABB>();
+  const cells = new Map<string, AnyObject[]>();
+  for (const obj of objects) {
+    const b = objectAabb(obj);
+    bounds.set(obj.id, b);
+    const { x0, y0, x1, y1 } = cellRange(b, cellSize);
+    for (let cy = y0; cy <= y1; cy += 1) {
+      for (let cx = x0; cx <= x1; cx += 1) {
+        const key = cellKey(cx, cy);
+        const bucket = cells.get(key);
+        if (bucket) bucket.push(obj);
+        else cells.set(key, [obj]);
+      }
+    }
+  }
+  return { cellSize, objects, bounds, cells };
+}
+
+function aabbOverlaps(a: AABB, b: AABB): boolean {
+  return !(a.maxX < b.minX || a.minX > b.maxX || a.maxY < b.minY || a.minY > b.maxY);
+}
+
+export function queryRect(
+  index: SpatialIndex,
+  minX: number,
+  minY: number,
+  maxX: number,
+  maxY: number,
+): AnyObject[] {
+  const q: AABB = { minX, minY, maxX, maxY };
+  const range = cellRange(q, index.cellSize);
+  const seen = new Set<string>();
+  const out: AnyObject[] = [];
+  for (let cy = range.y0; cy <= range.y1; cy += 1) {
+    for (let cx = range.x0; cx <= range.x1; cx += 1) {
+      const bucket = index.cells.get(cellKey(cx, cy));
+      if (!bucket) continue;
+      for (const obj of bucket) {
+        if (seen.has(obj.id)) continue;
+        const b = index.bounds.get(obj.id);
+        if (!b || !aabbOverlaps(b, q)) continue;
+        seen.add(obj.id);
+        out.push(obj);
+      }
+    }
+  }
+  return out;
+}
+
+export function queryPoint(index: SpatialIndex, x: number, y: number, radius = 0): AnyObject[] {
+  return queryRect(index, x - radius, y - radius, x + radius, y + radius);
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,6 +2,7 @@
   import { onDestroy, onMount } from 'svelte';
   import {
     CanvasStack,
+    EraseDebugOverlay,
     GraphLayer,
     NumberLineEditor,
     PdfLayer,
@@ -34,7 +35,10 @@
   import { shortcuts } from '$lib/app/shortcuts';
   import { setWindowFullscreenChromeless } from '$lib/app/windowFullscreen';
   import { openPdfDialog } from '$lib/app/openPdfDialog';
-  import { hitTestObjects } from '$lib/tools/eraser';
+  import { createSpatialIndex, type SpatialIndex } from '$lib/tools/spatialIndex';
+  import { makeEraseFlush } from '$lib/tools/eraserBatch';
+  import { createRafBatcher } from '$lib/canvas/inkBatch';
+  import { eraseDebug } from '$lib/store/eraseDebug';
   import { activeGraph, clearActiveGraph, setActiveGraph } from '$lib/store/activeGraph';
   import { createGraphObject } from '$lib/graph/graphObject';
   import GraphEditor from '$lib/graph/GraphEditor.svelte';
@@ -383,11 +387,24 @@
     documentStore.updateObject(pageIndex, editingNumberLineId, patch);
   }
 
-  function onEraseAt(at: { x: number; y: number }): void {
-    const hits = hitTestObjects(pageObjects, at, ERASER_RADIUS);
-    for (const o of hits) {
-      documentStore.removeObject(pageIndex, o.id);
-    }
+  let spatialIndex = $state<SpatialIndex | null>(null);
+  $effect(() => {
+    spatialIndex = createSpatialIndex(pageObjects);
+  });
+
+  const eraseBatcher = createRafBatcher<{ x: number; y: number }>(
+    makeEraseFlush(
+      () => spatialIndex,
+      ERASER_RADIUS,
+      (ids) => documentStore.removeObjects(pageIndex, ids),
+      (hits) => eraseDebug.recordHits(hits),
+    ),
+  );
+
+  function onEraseAt(samples: { x: number; y: number }[]): void {
+    if (samples.length === 0) return;
+    eraseDebug.recordPointerMove();
+    eraseBatcher.pushMany(samples);
   }
 
   function onCommitGraph(bounds: { x: number; y: number; w: number; h: number }): void {
@@ -422,6 +439,7 @@
     registerZenFullscreenBridge({
       setFullscreen: (on) => setWindowFullscreenChromeless(on),
     });
+    eraseDebug.init();
     let unlistenPresenterClose: (() => void) | null = null;
     let unlistenSidebarClose: (() => void) | null = null;
     void onPresenterWindowClosed(() => presenter.setWindowOpen(false)).then((fn) => {
@@ -676,6 +694,7 @@
   {/if}
   <CommandPalette />
   <ConfigDialog />
+  <EraseDebugOverlay />
 </main>
 
 <style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -392,20 +392,58 @@
     spatialIndex = createSpatialIndex(pageObjects);
   });
 
-  const eraseBatcher = createRafBatcher<{ x: number; y: number }>(
-    makeEraseFlush(
-      () => spatialIndex,
-      ERASER_RADIUS,
-      (ids) => documentStore.removeObjects(pageIndex, ids),
-      (hits) => eraseDebug.recordHits(hits),
-    ),
-  );
+  type EraseSample = {
+    x: number;
+    y: number;
+    pageIndex: number;
+    spatialIndex: SpatialIndex | null;
+  };
+
+  const eraseBatcher = createRafBatcher<EraseSample>((samples) => {
+    const byPage = new Map<
+      number,
+      { index: SpatialIndex | null; points: { x: number; y: number }[] }
+    >();
+    for (const s of samples) {
+      let group = byPage.get(s.pageIndex);
+      if (!group) {
+        group = { index: s.spatialIndex, points: [] };
+        byPage.set(s.pageIndex, group);
+      }
+      group.points.push({ x: s.x, y: s.y });
+    }
+    for (const [page, group] of byPage) {
+      makeEraseFlush(
+        () => group.index,
+        ERASER_RADIUS,
+        (ids) => documentStore.removeObjects(page, ids),
+        (hits) => eraseDebug.recordHits(hits),
+      )(group.points);
+    }
+  });
 
   function onEraseAt(samples: { x: number; y: number }[]): void {
     if (samples.length === 0) return;
     eraseDebug.recordPointerMove();
-    eraseBatcher.pushMany(samples);
+    const capturedPage = pageIndex;
+    const capturedIndex = spatialIndex;
+    eraseBatcher.pushMany(
+      samples.map((s) => ({
+        x: s.x,
+        y: s.y,
+        pageIndex: capturedPage,
+        spatialIndex: capturedIndex,
+      })),
+    );
   }
+
+  $effect(() => {
+    // Page change: drain pending samples against the page they were sampled on
+    // (they carry their own pageIndex), then clear any residual queue so
+    // future frames start fresh on the new page.
+    void pageIndex;
+    eraseBatcher.flushNow();
+  });
 
   function onCommitGraph(bounds: { x: number; y: number; w: number; h: number }): void {
     const graph = createGraphObject(bounds);
@@ -461,6 +499,7 @@
     stopPresenterBridge?.();
     stopSidebarBridge?.();
     registerZenFullscreenBridge(null);
+    eraseBatcher.cancel();
   });
 </script>
 

--- a/tests/document-store.test.ts
+++ b/tests/document-store.test.ts
@@ -264,4 +264,37 @@ describe('documentStore', () => {
     expect(a.streamline).toBe(0.792);
     expect(b.streamline).toBeUndefined();
   });
+
+  it('removeObjects drops a batch with one commit and one-step undo', () => {
+    const store = createDocumentStore();
+    const initial = docWithPages([
+      { ...pdfPage(0), objects: [stroke('a'), stroke('b'), stroke('c'), stroke('d')] },
+    ]);
+    store.load(initial);
+    const events: number[] = [];
+    store.onPageCommit((i) => events.push(i));
+
+    store.removeObjects(0, ['a', 'c']);
+    expect(events).toEqual([0]);
+    expect(get(store)!.pages[0].objects.map((o) => o.id)).toEqual(['b', 'd']);
+
+    store.undo(0);
+    expect(get(store)!.pages[0].objects.map((o) => o.id)).toEqual(['a', 'b', 'c', 'd']);
+    expect(events).toEqual([0, 0]);
+
+    store.redo(0);
+    expect(get(store)!.pages[0].objects.map((o) => o.id)).toEqual(['b', 'd']);
+  });
+
+  it('removeObjects is a no-op for empty id list and for unknown ids', () => {
+    const store = createDocumentStore();
+    store.load(docWithPages([{ ...pdfPage(0), objects: [stroke('a')] }]));
+    const events: number[] = [];
+    store.onPageCommit((i) => events.push(i));
+
+    store.removeObjects(0, []);
+    store.removeObjects(0, ['zzz']);
+    expect(events).toEqual([]);
+    expect(get(store)!.pages[0].objects.map((o) => o.id)).toEqual(['a']);
+  });
 });

--- a/tests/eraser-batch.test.ts
+++ b/tests/eraser-batch.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createRafBatcher, manualClock } from '$lib/canvas/inkBatch';
+import { createSpatialIndex } from '$lib/tools/spatialIndex';
+import { collectEraseIds, makeEraseFlush } from '$lib/tools/eraserBatch';
+import type { Point, StrokeObject, StrokeStyle } from '$lib/types';
+
+const STYLE: StrokeStyle = { color: '#000', width: 2, dash: 'solid', opacity: 1 };
+
+function pt(x: number, y: number): Point {
+  return { x, y, pressure: 0.5, t: 0 };
+}
+
+function mkStroke(id: string, points: Point[]): StrokeObject {
+  return { id, createdAt: 0, type: 'stroke', tool: 'pen', style: STYLE, points };
+}
+
+describe('collectEraseIds', () => {
+  it('returns deduped ids across a batch that hits one object at many samples', () => {
+    const a = mkStroke('a', [pt(0, 0), pt(100, 0)]);
+    const idx = createSpatialIndex([a]);
+    const samples = Array.from({ length: 10 }, (_, i) => ({ x: 10 + i * 5, y: 0 }));
+    expect(collectEraseIds(samples, 4, idx)).toEqual(['a']);
+  });
+
+  it('returns empty when nothing is within radius', () => {
+    const a = mkStroke('a', [pt(0, 0), pt(10, 0)]);
+    const idx = createSpatialIndex([a]);
+    expect(collectEraseIds([{ x: 1000, y: 1000 }], 4, idx)).toEqual([]);
+  });
+
+  it('accumulates distinct hits across distinct samples', () => {
+    const a = mkStroke('a', [pt(0, 0), pt(10, 0)]);
+    const b = mkStroke('b', [pt(100, 0), pt(110, 0)]);
+    const idx = createSpatialIndex([a, b]);
+    const ids = collectEraseIds(
+      [
+        { x: 5, y: 0 },
+        { x: 105, y: 0 },
+      ],
+      4,
+      idx,
+    );
+    expect(ids.sort()).toEqual(['a', 'b']);
+  });
+
+  it('uses the spatial index to skip far-away objects (candidate narrowing)', () => {
+    const a = mkStroke('a', [pt(0, 0), pt(10, 0)]);
+    const far = mkStroke('far', [pt(10_000, 10_000), pt(10_010, 10_000)]);
+    const idx = createSpatialIndex([a, far], 64);
+    // sanity: only 'a' is reachable from the sample
+    expect(collectEraseIds([{ x: 5, y: 0 }], 4, idx)).toEqual(['a']);
+  });
+});
+
+describe('eraser rAF flush', () => {
+  it('emits one removeObjects call per frame with deduped ids', () => {
+    const clock = manualClock();
+    const a = mkStroke('a', [pt(0, 0), pt(100, 0)]);
+    const b = mkStroke('b', [pt(0, 50), pt(100, 50)]);
+    const index = createSpatialIndex([a, b]);
+
+    const remove = vi.fn<(ids: string[]) => void>();
+    const flush = makeEraseFlush(() => index, 4, remove);
+    const batcher = createRafBatcher<{ x: number; y: number }>(flush, clock);
+
+    for (let i = 0; i < 30; i += 1) batcher.push({ x: i * 3, y: 0 });
+    batcher.push({ x: 50, y: 50 });
+    expect(remove).not.toHaveBeenCalled();
+
+    clock.tick();
+    expect(remove).toHaveBeenCalledTimes(1);
+    const ids = remove.mock.calls[0][0];
+    expect([...ids].sort()).toEqual(['a', 'b']);
+  });
+
+  it('silently skips frames whose samples hit nothing', () => {
+    const clock = manualClock();
+    const a = mkStroke('a', [pt(0, 0), pt(10, 0)]);
+    const index = createSpatialIndex([a]);
+    const remove = vi.fn<(ids: string[]) => void>();
+
+    const batcher = createRafBatcher<{ x: number; y: number }>(
+      makeEraseFlush(() => index, 4, remove),
+      clock,
+    );
+    batcher.push({ x: 9999, y: 9999 });
+    clock.tick();
+    expect(remove).not.toHaveBeenCalled();
+  });
+
+  it('samples on a later frame produce a separate removeObjects call', () => {
+    const clock = manualClock();
+    const a = mkStroke('a', [pt(0, 0), pt(10, 0)]);
+    const b = mkStroke('b', [pt(100, 0), pt(110, 0)]);
+    const index = createSpatialIndex([a, b]);
+    const remove = vi.fn<(ids: string[]) => void>();
+
+    const batcher = createRafBatcher<{ x: number; y: number }>(
+      makeEraseFlush(() => index, 4, remove),
+      clock,
+    );
+    batcher.push({ x: 5, y: 0 });
+    clock.tick();
+    batcher.push({ x: 105, y: 0 });
+    clock.tick();
+
+    expect(remove).toHaveBeenCalledTimes(2);
+    expect(remove.mock.calls[0][0]).toEqual(['a']);
+    expect(remove.mock.calls[1][0]).toEqual(['b']);
+  });
+
+  it('no-op flush when no index is available yet', () => {
+    const clock = manualClock();
+    const remove = vi.fn<(ids: string[]) => void>();
+    const batcher = createRafBatcher<{ x: number; y: number }>(
+      makeEraseFlush(() => null, 4, remove),
+      clock,
+    );
+    batcher.push({ x: 5, y: 0 });
+    clock.tick();
+    expect(remove).not.toHaveBeenCalled();
+  });
+});

--- a/tests/spatial-index.test.ts
+++ b/tests/spatial-index.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { createSpatialIndex, objectAabb, queryPoint, queryRect } from '$lib/tools/spatialIndex';
+import type { AnyObject, Point, ShapeObject, StrokeObject, StrokeStyle } from '$lib/types';
+
+const STYLE: StrokeStyle = { color: '#000', width: 2, dash: 'solid', opacity: 1 };
+
+function pt(x: number, y: number): Point {
+  return { x, y, pressure: 0.5, t: 0 };
+}
+
+function mkStroke(id: string, points: Point[], width = 2): StrokeObject {
+  return {
+    id,
+    createdAt: 0,
+    type: 'stroke',
+    tool: 'pen',
+    style: { ...STYLE, width },
+    points,
+  };
+}
+
+function mkRect(id: string, x: number, y: number, w: number, h: number): ShapeObject {
+  return {
+    id,
+    createdAt: 0,
+    type: 'shape',
+    kind: 'rect',
+    style: STYLE,
+    fill: null,
+    bounds: { x, y, w, h },
+  };
+}
+
+describe('spatialIndex', () => {
+  it('point query returns objects whose bbox contains the point', () => {
+    const a = mkStroke('a', [pt(0, 0), pt(100, 0)]);
+    const b = mkStroke('b', [pt(200, 200), pt(300, 200)]);
+    const idx = createSpatialIndex([a, b]);
+    const hits = queryPoint(idx, 50, 0, 0);
+    expect(hits.map((o) => o.id)).toEqual(['a']);
+  });
+
+  it('point query outside every bbox returns empty', () => {
+    const a = mkStroke('a', [pt(0, 0), pt(10, 0)]);
+    const idx = createSpatialIndex([a]);
+    expect(queryPoint(idx, 1000, 1000, 0)).toEqual([]);
+  });
+
+  it('radius query picks up an object just outside the center but within radius', () => {
+    const r = mkRect('r', 100, 100, 10, 10);
+    const idx = createSpatialIndex([r]);
+    expect(queryPoint(idx, 90, 105, 0)).toEqual([]);
+    expect(queryPoint(idx, 90, 105, 15).map((o) => o.id)).toEqual(['r']);
+  });
+
+  it('a single object that spans multiple cells is reported once', () => {
+    const wide = mkStroke('w', [pt(0, 0), pt(500, 0)]);
+    const idx = createSpatialIndex([wide], 64);
+    const hits = queryRect(idx, -10, -10, 600, 10);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].id).toBe('w');
+  });
+
+  it('empty index yields empty query results', () => {
+    const idx = createSpatialIndex([]);
+    expect(queryPoint(idx, 0, 0, 100)).toEqual([]);
+    expect(queryRect(idx, -1, -1, 1, 1)).toEqual([]);
+  });
+
+  it('object sitting exactly on a cell boundary is found from either side', () => {
+    const s = mkRect('on-edge', 64, 64, 10, 10);
+    const idx = createSpatialIndex([s], 64);
+    expect(queryPoint(idx, 64, 64, 0).map((o) => o.id)).toEqual(['on-edge']);
+    expect(queryPoint(idx, 70, 70, 0).map((o) => o.id)).toEqual(['on-edge']);
+    // AABB is inflated by half the stroke width; (60,60) is beyond it.
+    expect(queryPoint(idx, 60, 60, 0).map((o) => o.id)).toEqual([]);
+  });
+
+  it('rect query deduplicates objects that span many cells', () => {
+    const objs: AnyObject[] = [];
+    for (let i = 0; i < 5; i += 1) {
+      objs.push(mkStroke(`s${i}`, [pt(i * 400, 0), pt(i * 400 + 300, 0)]));
+    }
+    const idx = createSpatialIndex(objs, 32);
+    const all = queryRect(idx, -100, -100, 10_000, 100);
+    const ids = all.map((o) => o.id).sort();
+    expect(ids).toEqual(['s0', 's1', 's2', 's3', 's4']);
+  });
+
+  it('objectAabb inflates stroke by pressure-scaled half-width', () => {
+    const fat = mkStroke('fat', [{ x: 50, y: 50, pressure: 1, t: 0 }], 10);
+    const b = objectAabb(fat);
+    expect(b.maxX - b.minX).toBeGreaterThanOrEqual(20);
+  });
+
+  it('throws if cellSize is non-positive', () => {
+    expect(() => createSpatialIndex([], 0)).toThrow();
+    expect(() => createSpatialIndex([], -5)).toThrow();
+  });
+});


### PR DESCRIPTION
Closes #106.

## What
- New `removeObjects(pageIndex, ids[])` on `documentStore` plus `removeMany`/`insertMany` history commands for one commit event + one-step undo.
- Uniform-grid spatial index (`src/lib/tools/spatialIndex.ts`) with `queryPoint` / `queryRect` / `objectAabb` for fast eraser hit-tests.
- rAF-batched eraser flush (`src/lib/tools/eraserBatch.ts`) with pure, testable helpers (`collectEraseIds`, `makeEraseFlush`).
- `LiveLayer` now emits batched eraser samples via `getCoalescedEvents`; `+page.svelte` rebuilds the spatial index on `pageObjects` change and flushes deletions into `removeObjects`.
- Debug overlay gated on `?erasedebug=1` / `localStorage.eldrawEraseDebug='1'`.

## Why
Eraser on dense pages dropped pointer capture and stuttered because each erased object commit caused a full history step and re-render. Batching samples per rAF and deleting in one store call collapses hundreds of commits into one.

## Testing
- `pnpm test` — 508 passing, includes `tests/spatial-index.test.ts` (8), `tests/eraser-batch.test.ts` (8), extended `tests/document-store.test.ts` (batch + undo).
- `pnpm lint` clean.
- Manual: erasing across a dense page is smooth, pointer capture held, undo restores all erased objects in one step.