### PR TITLE
fix(ruler): let pointer events pass through to canvas and protractor (#112)

### DIFF
--- a/src/lib/canvas/RulerOverlay.svelte
+++ b/src/lib/canvas/RulerOverlay.svelte
@@ -185,18 +185,24 @@
 </svg>
 
 <style>
+  /* The outer SVG covers the whole canvas so ticks/labels can render
+     anywhere. It must not swallow pointer events — only the interactive
+     children below opt back in via pointer-events: auto. See #112. */
   .ruler {
     position: absolute;
     inset: 0;
-    pointer-events: auto;
+    pointer-events: none;
   }
   .body {
     cursor: grab;
+    pointer-events: auto;
   }
   .end-handle {
     cursor: grab;
+    pointer-events: auto;
   }
   .close {
     cursor: pointer;
+    pointer-events: auto;
   }
 </style>

--- a/tests/ruler-overlay.test.ts
+++ b/tests/ruler-overlay.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(
+  fileURLToPath(new URL('../src/lib/canvas/RulerOverlay.svelte', import.meta.url)),
+  'utf8',
+);
+
+function styleRule(selector: string): string {
+  const re = new RegExp(`\\${selector}\\s*\\{([^}]*)\\}`);
+  const m = source.match(re);
+  if (!m) throw new Error(`no rule for ${selector}`);
+  return m[1];
+}
+
+describe('RulerOverlay pointer-events (regression for #112)', () => {
+  it('outer .ruler SVG is pointer-events: none so events pass through', () => {
+    expect(styleRule('.ruler')).toMatch(/pointer-events:\s*none/);
+  });
+
+  for (const sel of ['.body', '.end-handle', '.close'] as const) {
+    it(`${sel} opts back in with pointer-events: auto`, () => {
+      expect(styleRule(sel)).toMatch(/pointer-events:\s*auto/);
+    });
+  }
+
+  it('decorative close-button strokes keep pointer-events="none"', () => {
+    const decorativeLines = source.match(/<line[^>]*pointer-events="none"/g) ?? [];
+    expect(decorativeLines.length).toBeGreaterThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
Closes #112. Flips outer `.ruler` SVG to `pointer-events: none`; re-opts `.body`, `.end-handle`, `.close` back in with `pointer-events: auto`. Ruler handles still drag; ink + protractor underneath now receive pointer events again.