### PR TITLE
feat(slides): import PDF directly from a Google Slides link (#114)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -298,7 +298,7 @@ dependencies = [
  "anyhow",
  "arrayvec",
  "log",
- "nom",
+ "nom 8.0.0",
  "num-rational",
  "v_frame",
 ]
@@ -313,6 +313,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879b6c89592deb404ba4dc0ae6b58ffd1795c78991cbb5b8bc441c48a070440d"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "107a4e9d9cab9963e04e84bb8dee0e25f2a987f9a8bad5ed054abd439caa8f8c"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,6 +346,26 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "bit-set"
@@ -546,6 +589,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "cfb"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,6 +642,26 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1030,7 +1102,7 @@ dependencies = [
  "image",
  "lru",
  "pdfium-render",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2",
@@ -1041,6 +1113,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tempfile",
  "thiserror 2.0.18",
+ "url",
 ]
 
 [[package]]
@@ -1296,6 +1369,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futf"
@@ -1890,7 +1969,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2185,6 +2263,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2364,7 +2451,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
 dependencies = [
  "gtk-sys",
- "libloading",
+ "libloading 0.7.4",
  "once_cell",
 ]
 
@@ -2392,6 +2479,16 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2540,6 +2637,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2641,6 +2744,16 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "nom"
@@ -2887,6 +3000,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2987,9 +3106,9 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "image",
- "itertools",
+ "itertools 0.14.0",
  "js-sys",
- "libloading",
+ "libloading 0.7.4",
  "log",
  "maybe-owned",
  "once_cell",
@@ -3458,6 +3577,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -3634,7 +3754,7 @@ dependencies = [
  "built",
  "cfg-if",
  "interpolate_name",
- "itertools",
+ "itertools 0.14.0",
  "libc",
  "libfuzzer-sys",
  "log",
@@ -3765,14 +3885,15 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -3788,45 +3909,12 @@ dependencies = [
  "quinn",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "sync_wrapper",
- "tokio",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3916,12 +4004,24 @@ version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -3935,11 +4035,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3952,18 +4080,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "ryu"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4022,6 +4153,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -4163,18 +4317,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
 ]
 
 [[package]]
@@ -4604,7 +4746,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest 0.13.2",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_repr",
@@ -5685,10 +5827,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "1.0.7"
+name = "webpki-root-certs"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -573,6 +573,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1024,6 +1030,7 @@ dependencies = [
  "image",
  "lru",
  "pdfium-render",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha2",
@@ -1055,6 +1062,15 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "endi"
@@ -1511,8 +1527,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1522,9 +1540,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1699,6 +1719,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1827,6 +1866,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1835,6 +1875,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2391,6 +2447,12 @@ checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.5",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac"
@@ -3371,6 +3433,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3648,6 +3765,47 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -3711,6 +3869,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3739,10 +3911,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3950,6 +4163,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -4210,6 +4435,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4373,7 +4604,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4768,6 +4999,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4779,6 +5025,16 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -5086,6 +5342,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5357,6 +5619,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5410,6 +5682,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5699,6 +5980,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6264,6 +6554,12 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,7 +29,8 @@ pdfium-render = { version = "0.9", default-features = false, features = [
 image = "0.25"
 tauri-plugin-dialog = "2.7.0"
 lru = "0.12"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "http2", "charset"] }
+reqwest = { version = "0.13", default-features = false, features = ["rustls", "http2", "charset"] }
+url = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,6 +29,7 @@ pdfium-render = { version = "0.9", default-features = false, features = [
 image = "0.25"
 tauri-plugin-dialog = "2.7.0"
 lru = "0.12"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "http2", "charset"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ mod page_cache;
 mod pdf;
 mod presenter;
 mod sidebar_window;
+mod slides;
 mod state;
 mod storage;
 mod thumbnails;
@@ -28,6 +29,7 @@ pub fn run() {
             storage::acquire_lock,
             storage::release_lock,
             export::export_flattened_pdf,
+            slides::fetch_slides_pdf,
             presenter::open_presenter_window,
             presenter::close_presenter_window,
             presenter::presenter_sync,

--- a/src-tauri/src/slides.rs
+++ b/src-tauri/src/slides.rs
@@ -1,0 +1,347 @@
+//! Google Slides URL parsing and PDF export fetching.
+//!
+//! The public entry point [`parse_slides_url`] extracts the deck identifier
+//! from the common share / present / pub / embed URL shapes. The command
+//! [`fetch_slides_pdf`] downloads the deck via the public `export/pdf`
+//! endpoint and writes it to the app's data directory so the existing
+//! `open_pdf` pipeline can consume the file like any other local PDF.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use tauri::{AppHandle, Manager};
+
+use crate::error::{AppError, AppResult};
+
+/// A Google Slides deck identifier along with its variant.
+///
+/// The `/d/e/{id}` shape uses a *published* key that is distinct from the
+/// normal document id: it only works against the `/pub?output=pdf` endpoint
+/// and will 404 on `/export/pdf`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SlidesId {
+    pub id: String,
+    pub variant: SlidesVariant,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SlidesVariant {
+    /// Standard document id (`/presentation/d/{ID}/...`).
+    Document,
+    /// Published key (`/presentation/d/e/{ID}/pub...`).
+    Published,
+}
+
+impl SlidesId {
+    /// The preferred export URL for this id.
+    #[must_use]
+    pub fn export_url(&self) -> String {
+        match self.variant {
+            SlidesVariant::Document => {
+                format!(
+                    "https://docs.google.com/presentation/d/{}/export/pdf",
+                    self.id
+                )
+            }
+            SlidesVariant::Published => format!(
+                "https://docs.google.com/presentation/d/e/{}/pub?output=pdf",
+                self.id
+            ),
+        }
+    }
+
+    /// Fallback URL to try if [`Self::export_url`] returns 404. Only the
+    /// `Document` variant has a sensible fallback (the `/pub?output=pdf`
+    /// shape); for `Published` decks the published URL is already the one
+    /// the server exposes.
+    #[must_use]
+    pub fn fallback_url(&self) -> Option<String> {
+        match self.variant {
+            SlidesVariant::Document => Some(format!(
+                "https://docs.google.com/presentation/d/{}/pub?output=pdf",
+                self.id
+            )),
+            SlidesVariant::Published => None,
+        }
+    }
+}
+
+/// Parse a Google Slides URL and return the deck id + variant.
+///
+/// Accepts:
+/// - `https://docs.google.com/presentation/d/{ID}/edit[...]`
+/// - `https://docs.google.com/presentation/d/{ID}/present[...]`
+/// - `https://docs.google.com/presentation/d/{ID}/pub[...]`
+/// - `https://docs.google.com/presentation/d/{ID}/embed[...]`
+/// - `https://docs.google.com/presentation/d/{ID}/export/pdf`
+/// - `https://docs.google.com/presentation/d/e/{ID}/pub[...]` (published)
+///
+/// Trailing `?query` and `#fragment` are ignored. A bare
+/// `/presentation/d/{ID}` (no trailing segment) is also accepted.
+pub fn parse_slides_url(input: &str) -> AppResult<SlidesId> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err(AppError::InvalidInput("empty URL".into()));
+    }
+
+    let without_scheme = trimmed
+        .strip_prefix("https://")
+        .or_else(|| trimmed.strip_prefix("http://"))
+        .ok_or_else(|| AppError::InvalidInput("URL must start with http(s)://".into()))?;
+
+    let path_start = without_scheme
+        .find('/')
+        .ok_or_else(|| AppError::InvalidInput("URL has no path".into()))?;
+    let host = &without_scheme[..path_start];
+    if !host.eq_ignore_ascii_case("docs.google.com") {
+        return Err(AppError::InvalidInput(format!(
+            "not a docs.google.com URL (host: {host})"
+        )));
+    }
+
+    let path = &without_scheme[path_start..];
+    let path = path.split(['?', '#']).next().unwrap_or(path);
+
+    let rest = path
+        .strip_prefix("/presentation/d/")
+        .ok_or_else(|| AppError::InvalidInput("not a Google Slides URL".into()))?;
+
+    let (variant, id_and_rest) = if let Some(remainder) = rest.strip_prefix("e/") {
+        (SlidesVariant::Published, remainder)
+    } else {
+        (SlidesVariant::Document, rest)
+    };
+
+    let id = id_and_rest
+        .split('/')
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_string();
+    if id.is_empty() {
+        return Err(AppError::InvalidInput("missing deck id".into()));
+    }
+    if !id
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(AppError::InvalidInput(format!(
+            "deck id contains unexpected characters: {id}"
+        )));
+    }
+
+    Ok(SlidesId { id, variant })
+}
+
+fn safe_filename_stem(id: &str) -> String {
+    id.chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+        .collect()
+}
+
+async fn download(url: &str) -> AppResult<reqwest::Response> {
+    let client = reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(15))
+        .timeout(Duration::from_secs(60))
+        .redirect(reqwest::redirect::Policy::limited(10))
+        .build()
+        .map_err(|e| AppError::InvalidInput(format!("http client: {e}")))?;
+
+    client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| AppError::InvalidInput(format!("network error: {e}")))
+}
+
+async fn fetch_bytes(id: &SlidesId) -> AppResult<Vec<u8>> {
+    let primary = id.export_url();
+    let response = download(&primary).await?;
+
+    let response = if response.status() == reqwest::StatusCode::NOT_FOUND {
+        if let Some(fallback) = id.fallback_url() {
+            download(&fallback).await?
+        } else {
+            response
+        }
+    } else {
+        response
+    };
+
+    let status = response.status();
+    if status == reqwest::StatusCode::FORBIDDEN || status == reqwest::StatusCode::UNAUTHORIZED {
+        return Err(AppError::InvalidInput(
+            "deck is not publicly accessible (403/401). Share it as \"Anyone with the link\" \
+             or publish it to the web first."
+                .into(),
+        ));
+    }
+    if status == reqwest::StatusCode::NOT_FOUND {
+        return Err(AppError::InvalidInput(
+            "deck not found (404). Check that the link is correct and the deck still exists."
+                .into(),
+        ));
+    }
+    if !status.is_success() {
+        return Err(AppError::InvalidInput(format!(
+            "unexpected HTTP status {status} while downloading slides"
+        )));
+    }
+
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|e| AppError::InvalidInput(format!("read body: {e}")))?;
+
+    if !bytes.starts_with(b"%PDF-") {
+        return Err(AppError::InvalidInput(
+            "server response was not a PDF (the deck may require sign-in)".into(),
+        ));
+    }
+
+    Ok(bytes.to_vec())
+}
+
+fn slides_cache_dir(app: &AppHandle) -> AppResult<PathBuf> {
+    let base = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| AppError::Window(format!("app_data_dir: {e}")))?;
+    let dir = base.join("slides");
+    std::fs::create_dir_all(&dir)?;
+    Ok(dir)
+}
+
+#[tauri::command]
+pub async fn fetch_slides_pdf(app: AppHandle, url: String) -> AppResult<String> {
+    let id = parse_slides_url(&url)?;
+    let bytes = fetch_bytes(&id).await?;
+
+    let dir = slides_cache_dir(&app)?;
+    let file = dir.join(format!("{}.pdf", safe_filename_stem(&id.id)));
+    std::fs::write(&file, &bytes)?;
+
+    Ok(file.to_string_lossy().into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(url: &str) -> SlidesId {
+        parse_slides_url(url).expect("should parse")
+    }
+
+    #[test]
+    fn parses_edit_url() {
+        let id = parse("https://docs.google.com/presentation/d/ABC_def-123/edit");
+        assert_eq!(id.id, "ABC_def-123");
+        assert_eq!(id.variant, SlidesVariant::Document);
+    }
+
+    #[test]
+    fn parses_edit_with_fragment_and_query() {
+        let id = parse(
+            "https://docs.google.com/presentation/d/ABC_def-123/edit?usp=sharing#slide=id.p1",
+        );
+        assert_eq!(id.id, "ABC_def-123");
+    }
+
+    #[test]
+    fn parses_present_url() {
+        let id = parse("https://docs.google.com/presentation/d/DECKID/present?slide=id.p3");
+        assert_eq!(id.id, "DECKID");
+        assert_eq!(id.variant, SlidesVariant::Document);
+    }
+
+    #[test]
+    fn parses_pub_url() {
+        let id = parse("https://docs.google.com/presentation/d/DECKID/pub?start=false");
+        assert_eq!(id.id, "DECKID");
+        assert_eq!(id.variant, SlidesVariant::Document);
+    }
+
+    #[test]
+    fn parses_published_de_url() {
+        let id = parse("https://docs.google.com/presentation/d/e/2PACX-1vPUBKEY/pub?start=false");
+        assert_eq!(id.id, "2PACX-1vPUBKEY");
+        assert_eq!(id.variant, SlidesVariant::Published);
+    }
+
+    #[test]
+    fn parses_embed_url() {
+        let id = parse("https://docs.google.com/presentation/d/DECKID/embed");
+        assert_eq!(id.id, "DECKID");
+    }
+
+    #[test]
+    fn parses_bare_url() {
+        let id = parse("https://docs.google.com/presentation/d/DECKID");
+        assert_eq!(id.id, "DECKID");
+    }
+
+    #[test]
+    fn rejects_non_slides_google_url() {
+        assert!(parse_slides_url("https://docs.google.com/document/d/DECKID/edit").is_err());
+    }
+
+    #[test]
+    fn rejects_non_google_host() {
+        assert!(parse_slides_url("https://evil.example.com/presentation/d/DECKID/edit").is_err());
+    }
+
+    #[test]
+    fn rejects_missing_id() {
+        assert!(parse_slides_url("https://docs.google.com/presentation/d//edit").is_err());
+        assert!(parse_slides_url("https://docs.google.com/presentation/d/").is_err());
+    }
+
+    #[test]
+    fn rejects_missing_scheme() {
+        assert!(parse_slides_url("docs.google.com/presentation/d/DECKID/edit").is_err());
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert!(parse_slides_url("").is_err());
+        assert!(parse_slides_url("   ").is_err());
+    }
+
+    #[test]
+    fn export_urls_match_variant() {
+        let doc = SlidesId {
+            id: "DECKID".into(),
+            variant: SlidesVariant::Document,
+        };
+        assert_eq!(
+            doc.export_url(),
+            "https://docs.google.com/presentation/d/DECKID/export/pdf"
+        );
+        assert_eq!(
+            doc.fallback_url().unwrap(),
+            "https://docs.google.com/presentation/d/DECKID/pub?output=pdf"
+        );
+
+        let pubbed = SlidesId {
+            id: "PKEY".into(),
+            variant: SlidesVariant::Published,
+        };
+        assert_eq!(
+            pubbed.export_url(),
+            "https://docs.google.com/presentation/d/e/PKEY/pub?output=pdf"
+        );
+        assert!(pubbed.fallback_url().is_none());
+    }
+
+    #[test]
+    fn safe_filename_stem_strips_non_ascii() {
+        assert_eq!(safe_filename_stem("abc_-XYZ"), "abc_-XYZ");
+        assert_eq!(safe_filename_stem("a/b.c d"), "abcd");
+    }
+
+    #[test]
+    fn host_match_is_case_insensitive() {
+        let id = parse("https://Docs.Google.COM/presentation/d/DECKID/edit");
+        assert_eq!(id.id, "DECKID");
+    }
+}

--- a/src-tauri/src/slides.rs
+++ b/src-tauri/src/slides.rs
@@ -175,7 +175,7 @@ fn google_redirect_policy() -> reqwest::redirect::Policy {
 async fn download(url: &str) -> AppResult<reqwest::Response> {
     let client = reqwest::Client::builder()
         .connect_timeout(Duration::from_secs(15))
-        .timeout(Duration::from_secs(60))
+        .timeout(Duration::from_mins(1))
         .redirect(google_redirect_policy())
         .build()
         .map_err(|e| AppError::InvalidInput(format!("http client: {e}")))?;

--- a/src-tauri/src/slides.rs
+++ b/src-tauri/src/slides.rs
@@ -10,6 +10,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use tauri::{AppHandle, Manager};
+use url::Url;
 
 use crate::error::{AppError, AppResult};
 
@@ -84,24 +85,26 @@ pub fn parse_slides_url(input: &str) -> AppResult<SlidesId> {
         return Err(AppError::InvalidInput("empty URL".into()));
     }
 
-    let without_scheme = trimmed
-        .strip_prefix("https://")
-        .or_else(|| trimmed.strip_prefix("http://"))
-        .ok_or_else(|| AppError::InvalidInput("URL must start with http(s)://".into()))?;
+    let parsed =
+        Url::parse(trimmed).map_err(|e| AppError::InvalidInput(format!("invalid URL: {e}")))?;
 
-    let path_start = without_scheme
-        .find('/')
-        .ok_or_else(|| AppError::InvalidInput("URL has no path".into()))?;
-    let host = &without_scheme[..path_start];
+    let scheme = parsed.scheme();
+    if !scheme.eq_ignore_ascii_case("http") && !scheme.eq_ignore_ascii_case("https") {
+        return Err(AppError::InvalidInput(
+            "URL must start with http(s)://".into(),
+        ));
+    }
+
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| AppError::InvalidInput("URL has no host".into()))?;
     if !host.eq_ignore_ascii_case("docs.google.com") {
         return Err(AppError::InvalidInput(format!(
             "not a docs.google.com URL (host: {host})"
         )));
     }
 
-    let path = &without_scheme[path_start..];
-    let path = path.split(['?', '#']).next().unwrap_or(path);
-
+    let path = parsed.path();
     let rest = path
         .strip_prefix("/presentation/d/")
         .ok_or_else(|| AppError::InvalidInput("not a Google Slides URL".into()))?;
@@ -139,11 +142,41 @@ fn safe_filename_stem(id: &str) -> String {
         .collect()
 }
 
+fn slides_cache_filename(id: &SlidesId) -> String {
+    let variant = match id.variant {
+        SlidesVariant::Document => "document",
+        SlidesVariant::Published => "published",
+    };
+    format!("{variant}-{}.pdf", safe_filename_stem(&id.id))
+}
+
+fn is_allowed_google_redirect(host: &str) -> bool {
+    let host = host.trim_end_matches('.').to_ascii_lowercase();
+    host == "google.com"
+        || host.ends_with(".google.com")
+        || host == "googleusercontent.com"
+        || host.ends_with(".googleusercontent.com")
+}
+
+fn google_redirect_policy() -> reqwest::redirect::Policy {
+    reqwest::redirect::Policy::custom(|attempt| {
+        if attempt.previous().len() >= 10 {
+            return attempt.error("too many redirects");
+        }
+        let host = attempt.url().host_str().map(str::to_owned);
+        match host {
+            Some(host) if is_allowed_google_redirect(&host) => attempt.follow(),
+            Some(host) => attempt.error(format!("redirect to disallowed host: {host}")),
+            None => attempt.error("redirect target has no host"),
+        }
+    })
+}
+
 async fn download(url: &str) -> AppResult<reqwest::Response> {
     let client = reqwest::Client::builder()
         .connect_timeout(Duration::from_secs(15))
         .timeout(Duration::from_secs(60))
-        .redirect(reqwest::redirect::Policy::limited(10))
+        .redirect(google_redirect_policy())
         .build()
         .map_err(|e| AppError::InvalidInput(format!("http client: {e}")))?;
 
@@ -218,7 +251,7 @@ pub async fn fetch_slides_pdf(app: AppHandle, url: String) -> AppResult<String> 
     let bytes = fetch_bytes(&id).await?;
 
     let dir = slides_cache_dir(&app)?;
-    let file = dir.join(format!("{}.pdf", safe_filename_stem(&id.id)));
+    let file = dir.join(slides_cache_filename(&id));
     std::fs::write(&file, &bytes)?;
 
     Ok(file.to_string_lossy().into_owned())
@@ -343,5 +376,54 @@ mod tests {
     fn host_match_is_case_insensitive() {
         let id = parse("https://Docs.Google.COM/presentation/d/DECKID/edit");
         assert_eq!(id.id, "DECKID");
+    }
+
+    #[test]
+    fn accepts_uppercase_scheme() {
+        let id = parse("HTTPS://docs.google.com/presentation/d/DECKID/edit");
+        assert_eq!(id.id, "DECKID");
+    }
+
+    #[test]
+    fn accepts_explicit_port() {
+        let id = parse("https://docs.google.com:443/presentation/d/DECKID/edit");
+        assert_eq!(id.id, "DECKID");
+    }
+
+    #[test]
+    fn cache_filename_distinguishes_variants() {
+        let doc = SlidesId {
+            id: "SAMEID".into(),
+            variant: SlidesVariant::Document,
+        };
+        let pubbed = SlidesId {
+            id: "SAMEID".into(),
+            variant: SlidesVariant::Published,
+        };
+        let doc_name = slides_cache_filename(&doc);
+        let pub_name = slides_cache_filename(&pubbed);
+        assert_ne!(doc_name, pub_name);
+        assert_eq!(doc_name, "document-SAMEID.pdf");
+        assert_eq!(pub_name, "published-SAMEID.pdf");
+    }
+
+    #[test]
+    fn allows_google_redirect_hosts() {
+        assert!(is_allowed_google_redirect("google.com"));
+        assert!(is_allowed_google_redirect("docs.google.com"));
+        assert!(is_allowed_google_redirect("DOCS.GOOGLE.COM"));
+        assert!(is_allowed_google_redirect("accounts.google.com"));
+        assert!(is_allowed_google_redirect("googleusercontent.com"));
+        assert!(is_allowed_google_redirect("foo.googleusercontent.com"));
+        assert!(is_allowed_google_redirect("docs.google.com."));
+    }
+
+    #[test]
+    fn rejects_non_google_redirect_hosts() {
+        assert!(!is_allowed_google_redirect("evil.com"));
+        assert!(!is_allowed_google_redirect("google.com.evil.com"));
+        assert!(!is_allowed_google_redirect("notgoogle.com"));
+        assert!(!is_allowed_google_redirect("googleusercontent.com.evil"));
+        assert!(!is_allowed_google_redirect(""));
     }
 }

--- a/src/lib/command/commands.ts
+++ b/src/lib/command/commands.ts
@@ -21,6 +21,7 @@ import {
   triggerRestorePreviousSettings,
 } from '$lib/config/commands';
 import { settings } from '$lib/store/settings';
+import { openSlidesDialog } from '$lib/slides/dialog';
 
 export interface Command {
   id: string;
@@ -186,6 +187,11 @@ export function getCommands(): Command[] {
       title: 'Cycle dash style',
       shortcut: 'D',
       run: () => sidebar.cycleDash(),
+    },
+    {
+      id: 'file.openFromSlides',
+      title: 'Open from Google Slides…',
+      run: openSlidesDialog,
     },
     {
       id: 'config.export',

--- a/src/lib/slides/dialog.ts
+++ b/src/lib/slides/dialog.ts
@@ -1,0 +1,11 @@
+import { writable } from 'svelte/store';
+
+export const slidesDialogOpen = writable(false);
+
+export function openSlidesDialog(): void {
+  slidesDialogOpen.set(true);
+}
+
+export function closeSlidesDialog(): void {
+  slidesDialogOpen.set(false);
+}

--- a/src/lib/slides/ipc.ts
+++ b/src/lib/slides/ipc.ts
@@ -1,0 +1,14 @@
+import { invoke } from '@tauri-apps/api/core';
+import { log, warn } from '$lib/log';
+
+export async function fetchSlidesPdf(url: string): Promise<string> {
+  const t = performance.now();
+  try {
+    const path = await invoke<string>('fetch_slides_pdf', { url });
+    log('ipc', `fetch_slides_pdf ok path=${path} in ${(performance.now() - t).toFixed(1)}ms`);
+    return path;
+  } catch (err) {
+    warn('ipc', `fetch_slides_pdf failed after ${(performance.now() - t).toFixed(1)}ms`, err);
+    throw err;
+  }
+}

--- a/src/lib/slides/url.ts
+++ b/src/lib/slides/url.ts
@@ -1,0 +1,52 @@
+export type SlidesVariant = 'document' | 'published';
+
+export interface SlidesId {
+  id: string;
+  variant: SlidesVariant;
+}
+
+export type ParseResult = { ok: true; value: SlidesId } | { ok: false; error: string };
+
+const ID_RE = /^[A-Za-z0-9_-]+$/;
+
+export function parseSlidesUrl(input: string): ParseResult {
+  const trimmed = input.trim();
+  if (!trimmed) return { ok: false, error: 'Enter a Google Slides URL.' };
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    return { ok: false, error: 'That is not a valid URL.' };
+  }
+
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    return { ok: false, error: 'URL must start with http(s)://' };
+  }
+  if (url.hostname.toLowerCase() !== 'docs.google.com') {
+    return { ok: false, error: 'URL must be on docs.google.com.' };
+  }
+
+  const segments = url.pathname.split('/').filter(Boolean);
+  if (segments.length < 3 || segments[0] !== 'presentation' || segments[1] !== 'd') {
+    return { ok: false, error: 'Not a Google Slides URL.' };
+  }
+
+  let id: string;
+  let variant: SlidesVariant;
+  if (segments[2] === 'e') {
+    if (segments.length < 4) return { ok: false, error: 'Missing deck id in URL.' };
+    id = segments[3];
+    variant = 'published';
+  } else {
+    id = segments[2];
+    variant = 'document';
+  }
+
+  if (!id) return { ok: false, error: 'Missing deck id in URL.' };
+  if (!ID_RE.test(id)) {
+    return { ok: false, error: 'Deck id has unexpected characters.' };
+  }
+
+  return { ok: true, value: { id, variant } };
+}

--- a/src/lib/ui/OpenFromSlidesDialog.svelte
+++ b/src/lib/ui/OpenFromSlidesDialog.svelte
@@ -1,0 +1,172 @@
+<script lang="ts">
+  import { tick } from 'svelte';
+  import { parseSlidesUrl } from '$lib/slides/url';
+  import { fetchSlidesPdf } from '$lib/slides/ipc';
+
+  interface Props {
+    open: boolean;
+    onCancel: () => void;
+    onLoaded: (path: string) => void | Promise<void>;
+  }
+
+  const { open, onCancel, onLoaded }: Props = $props();
+
+  let modalEl: HTMLDivElement | null = $state(null);
+  let inputEl: HTMLInputElement | null = $state(null);
+  let url = $state('');
+  let error = $state<string | null>(null);
+  let busy = $state(false);
+
+  $effect(() => {
+    if (open) {
+      url = '';
+      error = null;
+      busy = false;
+      void tick().then(() => inputEl?.focus());
+    }
+  });
+
+  async function submit(): Promise<void> {
+    if (busy) return;
+    const parsed = parseSlidesUrl(url);
+    if (!parsed.ok) {
+      error = parsed.error;
+      return;
+    }
+    error = null;
+    busy = true;
+    try {
+      const path = await fetchSlidesPdf(url.trim());
+      await onLoaded(path);
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+    } finally {
+      busy = false;
+    }
+  }
+
+  function onKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Escape' && !busy) onCancel();
+  }
+</script>
+
+{#if open}
+  <div class="backdrop" role="presentation" onclick={() => !busy && onCancel()}>
+    <div
+      bind:this={modalEl}
+      class="modal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="slides-dialog-title"
+      tabindex="-1"
+      onclick={(e) => e.stopPropagation()}
+      onkeydown={onKeydown}
+    >
+      <h2 id="slides-dialog-title">Open from Google Slides</h2>
+      <p class="hint">
+        Paste a public Google Slides link. The deck must be shared with "Anyone with the link" or
+        published to the web.
+      </p>
+      <form
+        onsubmit={(e) => {
+          e.preventDefault();
+          void submit();
+        }}
+      >
+        <input
+          bind:this={inputEl}
+          bind:value={url}
+          type="url"
+          placeholder="https://docs.google.com/presentation/d/…"
+          autocomplete="off"
+          spellcheck="false"
+          disabled={busy}
+        />
+        {#if error}
+          <p class="error" role="alert">{error}</p>
+        {/if}
+        <div class="actions">
+          <button type="button" onclick={onCancel} disabled={busy}>Cancel</button>
+          <button type="submit" class="primary" disabled={busy || url.trim() === ''}>
+            {busy ? 'Fetching…' : 'Open'}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1100;
+  }
+  .modal {
+    background: #252525;
+    color: #eee;
+    border: 1px solid #3a3a3a;
+    border-radius: 10px;
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.5);
+    padding: 18px 22px;
+    width: min(560px, 92vw);
+  }
+  h2 {
+    margin: 0 0 6px;
+    font-size: 15px;
+  }
+  .hint {
+    margin: 0 0 12px;
+    font-size: 12px;
+    color: #bbb;
+  }
+  input {
+    width: 100%;
+    background: #1b1b1b;
+    color: #eee;
+    border: 1px solid #444;
+    border-radius: 6px;
+    padding: 8px 10px;
+    font: inherit;
+    box-sizing: border-box;
+  }
+  input:focus {
+    outline: none;
+    border-color: #4d77c4;
+  }
+  .error {
+    margin: 8px 0 0;
+    color: #f88;
+    font-size: 12px;
+  }
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 14px;
+  }
+  button {
+    background: #333;
+    color: #eee;
+    border: 1px solid #444;
+    border-radius: 6px;
+    padding: 6px 12px;
+    cursor: pointer;
+    font: inherit;
+  }
+  button:hover:not(:disabled) {
+    background: #3a3a3a;
+  }
+  button:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+  button.primary {
+    background: #3a5a9a;
+    border-color: #4d77c4;
+  }
+</style>

--- a/src/lib/ui/OpenFromSlidesDialog.svelte
+++ b/src/lib/ui/OpenFromSlidesDialog.svelte
@@ -11,7 +11,6 @@
 
   const { open, onCancel, onLoaded }: Props = $props();
 
-  let modalEl: HTMLDivElement | null = $state(null);
   let inputEl: HTMLInputElement | null = $state(null);
   let url = $state('');
   let error = $state<string | null>(null);
@@ -53,7 +52,6 @@
 {#if open}
   <div class="backdrop" role="presentation" onclick={() => !busy && onCancel()}>
     <div
-      bind:this={modalEl}
       class="modal"
       role="dialog"
       aria-modal="true"
@@ -77,6 +75,7 @@
           bind:this={inputEl}
           bind:value={url}
           type="url"
+          aria-label="Google Slides URL"
           placeholder="https://docs.google.com/presentation/d/…"
           autocomplete="off"
           spellcheck="false"

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -36,7 +36,7 @@
   import { reloadWarning, clearReloadWarning } from '$lib/store/reloadWarning';
   import { reloadPdf } from '$lib/app/actions';
   import OpenFromSlidesDialog from '$lib/ui/OpenFromSlidesDialog.svelte';
-  import { slidesDialogOpen } from '$lib/slides/dialog';
+  import { slidesDialogOpen, openSlidesDialog } from '$lib/slides/dialog';
   import { createSpatialIndex, type SpatialIndex } from '$lib/tools/spatialIndex';
   import { makeEraseFlush } from '$lib/tools/eraserBatch';
   import { createRafBatcher } from '$lib/canvas/inkBatch';
@@ -484,7 +484,7 @@
         <button
           type="button"
           class="topbar-btn"
-          onclick={() => slidesDialogOpen.set(true)}
+          onclick={openSlidesDialog}
           title="Import a public deck from a Google Slides link"
         >
           From Slides…

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -35,6 +35,8 @@
   import { loadPdfFromSource, stopAutosave } from '$lib/pdf/loader';
   import { reloadWarning, clearReloadWarning } from '$lib/store/reloadWarning';
   import { reloadPdf } from '$lib/app/actions';
+  import OpenFromSlidesDialog from '$lib/ui/OpenFromSlidesDialog.svelte';
+  import { slidesDialogOpen } from '$lib/slides/dialog';
   import { createSpatialIndex, type SpatialIndex } from '$lib/tools/spatialIndex';
   import { makeEraseFlush } from '$lib/tools/eraserBatch';
   import { createRafBatcher } from '$lib/canvas/inkBatch';
@@ -479,6 +481,14 @@
     {#if chrome.topbar}
       <header class="topbar">
         <button type="button" class="topbar-btn" onclick={openFromDialog}>Open PDF…</button>
+        <button
+          type="button"
+          class="topbar-btn"
+          onclick={() => slidesDialogOpen.set(true)}
+          title="Import a public deck from a Google Slides link"
+        >
+          From Slides…
+        </button>
         <div class="pager">
           <button
             type="button"
@@ -725,6 +735,14 @@
   {/if}
   <CommandPalette />
   <ConfigDialog />
+  <OpenFromSlidesDialog
+    open={$slidesDialogOpen}
+    onCancel={() => slidesDialogOpen.set(false)}
+    onLoaded={async (path) => {
+      slidesDialogOpen.set(false);
+      await loadPdfFromSource({ kind: 'file', path });
+    }}
+  />
   <EraseDebugOverlay />
 </main>
 

--- a/tests/slides-url.test.ts
+++ b/tests/slides-url.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { parseSlidesUrl } from '$lib/slides/url';
+
+function ok(url: string) {
+  const r = parseSlidesUrl(url);
+  if (!r.ok) throw new Error(`expected ok, got: ${r.error}`);
+  return r.value;
+}
+
+function err(url: string): string {
+  const r = parseSlidesUrl(url);
+  if (r.ok) throw new Error('expected error');
+  return r.error;
+}
+
+describe('parseSlidesUrl', () => {
+  it('parses edit URLs', () => {
+    const id = ok('https://docs.google.com/presentation/d/ABC_def-123/edit');
+    expect(id).toEqual({ id: 'ABC_def-123', variant: 'document' });
+  });
+
+  it('parses edit URLs with query and fragment', () => {
+    const id = ok(
+      'https://docs.google.com/presentation/d/ABC_def-123/edit?usp=sharing#slide=id.p1',
+    );
+    expect(id.id).toBe('ABC_def-123');
+    expect(id.variant).toBe('document');
+  });
+
+  it('parses present URLs', () => {
+    const id = ok('https://docs.google.com/presentation/d/DECKID/present?slide=id.p3');
+    expect(id.id).toBe('DECKID');
+    expect(id.variant).toBe('document');
+  });
+
+  it('parses pub URLs', () => {
+    const id = ok('https://docs.google.com/presentation/d/DECKID/pub?start=false&delayms=3000');
+    expect(id).toEqual({ id: 'DECKID', variant: 'document' });
+  });
+
+  it('parses published /d/e/ URLs', () => {
+    const id = ok('https://docs.google.com/presentation/d/e/2PACX-1vPUBKEY/pub?start=false');
+    expect(id).toEqual({ id: '2PACX-1vPUBKEY', variant: 'published' });
+  });
+
+  it('parses embed URLs', () => {
+    const id = ok('https://docs.google.com/presentation/d/DECKID/embed');
+    expect(id.id).toBe('DECKID');
+  });
+
+  it('parses bare /d/{ID} URL', () => {
+    const id = ok('https://docs.google.com/presentation/d/DECKID');
+    expect(id.id).toBe('DECKID');
+  });
+
+  it('strips trailing fragment', () => {
+    const id = ok('https://docs.google.com/presentation/d/DECKID/edit#slide=id.p1');
+    expect(id.id).toBe('DECKID');
+  });
+
+  it('accepts mixed-case host', () => {
+    const id = ok('https://Docs.Google.COM/presentation/d/DECKID/edit');
+    expect(id.id).toBe('DECKID');
+  });
+
+  it('rejects empty input', () => {
+    expect(err('')).toMatch(/enter/i);
+    expect(err('   ')).toMatch(/enter/i);
+  });
+
+  it('rejects malformed URL', () => {
+    expect(err('not a url')).toMatch(/valid url/i);
+  });
+
+  it('rejects non-google host', () => {
+    expect(err('https://evil.example.com/presentation/d/DECKID/edit')).toMatch(/docs\.google\.com/);
+  });
+
+  it('rejects non-slides google URL', () => {
+    expect(err('https://docs.google.com/document/d/DECKID/edit')).toMatch(/slides/i);
+  });
+
+  it('rejects missing deck id', () => {
+    expect(err('https://docs.google.com/presentation/d/')).toMatch(/slides/i);
+    expect(err('https://docs.google.com/presentation/d/e/')).toMatch(/id/i);
+  });
+
+  it('rejects deck id with invalid chars', () => {
+    expect(err('https://docs.google.com/presentation/d/bad.id/edit')).toMatch(/id/i);
+  });
+});


### PR DESCRIPTION
Closes #114. Adds `fetch_slides_pdf` Tauri command that parses Slides URLs (edit/present/pub/embed/bare/`/d/e/` variants), fetches the PDF via the Slides export endpoint, and routes through the existing load pipeline. New `OpenFromSlidesDialog`, topbar entry, and `file.openFromSlides` palette command.

Out of scope: OAuth / private decks.