### PR TITLE
chore(release): v0.1.0-rc.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eldraw",
-  "version": "0.1.0-rc.10",
+  "version": "0.1.0-rc.11",
   "description": "PDF annotation tool for live math teaching",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1097,7 +1097,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "eldraw"
-version = "0.1.0-rc.10"
+version = "0.1.0-rc.11"
 dependencies = [
  "image",
  "lru",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eldraw"
-version = "0.1.0-rc.10"
+version = "0.1.0-rc.11"
 description = "PDF annotation tool for live math teaching"
 authors = ["Adam"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "eldraw",
-  "version": "0.1.0-rc.10",
+  "version": "0.1.0-rc.11",
   "identifier": "com.adamkadaban.eldraw",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release rc.11.

Changes since rc.10:
- #116 fix(ruler): passthrough so drawing works under the ruler overlay
- #117 feat(slides): import PDF from a Google Slides link
- #118 feat(reload): reload PDF with keep/discard annotation setting
- #119 feat(ink): live 1-euro stabilization replacing post-hoc streamline, fix fast-stroke jaggies