### PR TITLE
fix(ink): strengthen high-end stabilization (#121)

### DIFF
--- a/src/lib/canvas/stabilizer.ts
+++ b/src/lib/canvas/stabilizer.ts
@@ -91,9 +91,12 @@ export function createOneEuroFilter(config: OneEuroConfig): OneEuroFilter {
  * Map the 0..100 stabilization slider to a 1€ filter config.
  *
  * 0 → passthrough (no smoothing, preview bit-identical to raw input).
- * >0 → `minCutoff` drops from ~30 Hz down to ~0.8 Hz along a log curve so the
- * perceived difference is close to linear; `beta` scales up to 0.02 so the
- * cutoff loosens under fast motion.
+ * >0 → `minCutoff` drops geometrically from 30 Hz down to 1 Hz so the
+ * perceived smoothing tracks the slider near-linearly. `beta` rises
+ * quadratically up to 0.05 so slow tremor is filtered hard while fast
+ * intended motion still loosens the cutoff and tracks the pen.
+ * Reference points: amount=50 → ~5.5 Hz / β≈0.013, amount=100 → 1 Hz / β=0.05.
+ * Issue #121.
  */
 export function stabilizationToConfig(amount: number): OneEuroConfig {
   const clamped = Math.max(0, Math.min(100, Number.isFinite(amount) ? amount : 0));
@@ -101,7 +104,7 @@ export function stabilizationToConfig(amount: number): OneEuroConfig {
     return { minCutoff: Number.POSITIVE_INFINITY, beta: 0 };
   }
   const norm = clamped / 100;
-  const minCutoff = 30 * Math.pow(0.0267, norm);
-  const beta = 0.02 * norm;
+  const minCutoff = 30 * Math.pow(1 / 30, norm);
+  const beta = 0.05 * norm * norm;
   return { minCutoff, beta, dCutoff: 1.0 };
 }

--- a/src/lib/canvas/stabilizer.ts
+++ b/src/lib/canvas/stabilizer.ts
@@ -90,13 +90,18 @@ export function createOneEuroFilter(config: OneEuroConfig): OneEuroFilter {
 /**
  * Map the 0..100 stabilization slider to a 1€ filter config.
  *
- * 0 → passthrough (no smoothing, preview bit-identical to raw input).
- * >0 → `minCutoff` drops geometrically from 30 Hz down to 1 Hz so the
- * perceived smoothing tracks the slider near-linearly. `beta` rises
- * quadratically up to 0.05 so slow tremor is filtered hard while fast
- * intended motion still loosens the cutoff and tracks the pen.
- * Reference points: amount=50 → ~5.5 Hz / β≈0.013, amount=100 → 1 Hz / β=0.05.
- * Issue #121.
+ * 0 → passthrough (bit-identical to raw input).
+ * >0 → `minCutoff` drops geometrically from 30 Hz to 0.4 Hz and `beta`
+ * rises quadratically to 1.8e-3. Both values must DECREASE with amount:
+ * a lower minCutoff filters more at rest, and a lower beta keeps the
+ * cutoff from opening up during fast motion. Previous curves pushed both
+ * UP at the top end and left tremor almost unfiltered. Issue #121.
+ *
+ * Reference points:
+ *   amount=25  → minCutoff ≈ 10.2 Hz, β ≈ 1.1e-4
+ *   amount=50  → minCutoff ≈ 3.5 Hz,  β = 4.5e-4
+ *   amount=75  → minCutoff ≈ 1.2 Hz,  β ≈ 1.0e-3
+ *   amount=100 → minCutoff = 0.4 Hz,  β = 1.8e-3
  */
 export function stabilizationToConfig(amount: number): OneEuroConfig {
   const clamped = Math.max(0, Math.min(100, Number.isFinite(amount) ? amount : 0));
@@ -104,7 +109,10 @@ export function stabilizationToConfig(amount: number): OneEuroConfig {
     return { minCutoff: Number.POSITIVE_INFINITY, beta: 0 };
   }
   const norm = clamped / 100;
-  const minCutoff = 30 * Math.pow(1 / 30, norm);
-  const beta = 0.05 * norm * norm;
+  const minCutoffMax = 30;
+  const minCutoffMin = 0.4;
+  const betaMax = 0.0018;
+  const minCutoff = minCutoffMax * Math.pow(minCutoffMin / minCutoffMax, norm);
+  const beta = betaMax * norm * norm;
   return { minCutoff, beta, dCutoff: 1.0 };
 }

--- a/tests/stabilizer.test.ts
+++ b/tests/stabilizer.test.ts
@@ -21,6 +21,27 @@ describe('stabilizationToConfig', () => {
     expect(cfg.beta).toBeGreaterThan(0);
   });
 
+  it('pins strong smoothing at amount=100 (guards against regressing the curve)', () => {
+    const cfg = stabilizationToConfig(100);
+    expect(cfg.minCutoff).toBeLessThanOrEqual(0.5);
+    expect(cfg.beta).toBeLessThanOrEqual(0.01);
+  });
+
+  it('pins mid-range amount=50 between the extremes', () => {
+    const cfg = stabilizationToConfig(50);
+    expect(cfg.minCutoff).toBeGreaterThan(stabilizationToConfig(100).minCutoff);
+    expect(cfg.minCutoff).toBeLessThan(stabilizationToConfig(25).minCutoff);
+    expect(cfg.minCutoff).toBeGreaterThan(1);
+    expect(cfg.minCutoff).toBeLessThan(10);
+    expect(cfg.beta).toBeGreaterThan(stabilizationToConfig(25).beta);
+    expect(cfg.beta).toBeLessThan(stabilizationToConfig(100).beta);
+  });
+
+  it('beta decreases monotonically toward 0 as amount drops', () => {
+    const b = [0.1, 25, 50, 75, 100].map((a) => stabilizationToConfig(a).beta);
+    for (let i = 1; i < b.length; i++) expect(b[i]).toBeGreaterThan(b[i - 1]);
+  });
+
   it('cutoff decreases monotonically as amount rises', () => {
     const c = [0.1, 25, 50, 75, 100].map((a) => stabilizationToConfig(a).minCutoff);
     for (let i = 1; i < c.length; i++) expect(c[i]).toBeLessThan(c[i - 1]);
@@ -67,7 +88,7 @@ describe('createOneEuroFilter', () => {
     let prevIn = 0;
     let prevOut = 0;
     for (let i = 0; i < count; i++) {
-      const x = i * 0.05;
+      const x = i * 0.5;
       const y = rand() * 0.5;
       const out = filter.filter({ x, y }, i * dtMs);
       if (i > 10) {
@@ -98,7 +119,7 @@ describe('createOneEuroFilter', () => {
       const jitter: number[] = [];
       let prev = 0;
       for (let i = 0; i < count; i++) {
-        const out = filter.filter({ x: i * 0.05, y: rand() * 0.5 }, i * dtMs);
+        const out = filter.filter({ x: i * 0.5, y: rand() * 0.5 }, i * dtMs);
         if (i > 10) jitter.push(Math.abs(out.y - prev));
         prev = out.y;
       }
@@ -107,7 +128,7 @@ describe('createOneEuroFilter', () => {
 
     const avg50 = measureJitter(50);
     const avg100 = measureJitter(100);
-    expect(avg100).toBeLessThan(avg50 * 0.7);
+    expect(avg100).toBeLessThan(avg50 * 0.5);
   });
 
   it('reset() clears state so a new stroke starts cold', () => {

--- a/tests/stabilizer.test.ts
+++ b/tests/stabilizer.test.ts
@@ -50,7 +50,7 @@ describe('createOneEuroFilter', () => {
     expect(out.y).toBe(-7);
   });
 
-  it('significantly reduces jitter on a noisy straight line at max stabilization', () => {
+  it('significantly reduces jitter on a noisy slow stroke at max stabilization', () => {
     const filter = createOneEuroFilter(stabilizationToConfig(100));
     const samplesPerSec = 120;
     const dtMs = 1000 / samplesPerSec;
@@ -67,7 +67,7 @@ describe('createOneEuroFilter', () => {
     let prevIn = 0;
     let prevOut = 0;
     for (let i = 0; i < count; i++) {
-      const x = i * 0.5;
+      const x = i * 0.05;
       const y = rand() * 0.5;
       const out = filter.filter({ x, y }, i * dtMs);
       if (i > 10) {
@@ -80,7 +80,34 @@ describe('createOneEuroFilter', () => {
 
     const avgIn = inputJitter.reduce((a, b) => a + b, 0) / inputJitter.length;
     const avgOut = outputJitter.reduce((a, b) => a + b, 0) / outputJitter.length;
-    expect(avgOut).toBeLessThan(avgIn * 0.5);
+    expect(avgOut).toBeLessThan(avgIn * 0.2);
+  });
+
+  it('amount=100 smooths noticeably more than amount=50 on the same noisy input', () => {
+    const samplesPerSec = 120;
+    const dtMs = 1000 / samplesPerSec;
+    const count = 200;
+
+    const measureJitter = (amount: number) => {
+      const filter = createOneEuroFilter(stabilizationToConfig(amount));
+      let seed = 1;
+      const rand = () => {
+        seed = (seed * 1664525 + 1013904223) >>> 0;
+        return (seed / 0x100000000) * 2 - 1;
+      };
+      const jitter: number[] = [];
+      let prev = 0;
+      for (let i = 0; i < count; i++) {
+        const out = filter.filter({ x: i * 0.05, y: rand() * 0.5 }, i * dtMs);
+        if (i > 10) jitter.push(Math.abs(out.y - prev));
+        prev = out.y;
+      }
+      return jitter.reduce((a, b) => a + b, 0) / jitter.length;
+    };
+
+    const avg50 = measureJitter(50);
+    const avg100 = measureJitter(100);
+    expect(avg100).toBeLessThan(avg50 * 0.7);
   });
 
   it('reset() clears state so a new stroke starts cold', () => {


### PR DESCRIPTION
Closes #121.

Rebalances `stabilizationToConfig` with a quadratic beta and exponential minCutoff so amount=100 produces visibly heavier smoothing while amount=0 stays byte-identical passthrough. Tightened the jitter-reduction test to ≥80% and added a 100-vs-50 comparison test.