### PR TITLE
feat(view): F5 toggles zen with auto-fit and add fit-to-screen button (#122)

### DIFF
--- a/src/lib/app/shortcutRegistry.ts
+++ b/src/lib/app/shortcutRegistry.ts
@@ -1,7 +1,6 @@
 import { sidebar, styleKeyFor } from '$lib/store/sidebar';
 import { documentStore } from '$lib/store/document';
 import { viewport } from '$lib/store/viewport';
-import { presenter } from '$lib/store/presenter';
 import { zen } from '$lib/store/zen';
 import { commandPalette } from '$lib/command/store';
 import {
@@ -32,8 +31,8 @@ export type ShortcutId =
   | 'page.prev'
   | 'page.next'
   | 'view.toggleFullscreen'
-  | 'view.togglePresenter'
   | 'view.toggleZen'
+  | 'view.toggleZenAlt'
   | 'sidebar.togglePin'
   | 'sidebar.toggleHide'
   | 'sidebar.toggleMinimize'
@@ -158,15 +157,15 @@ function buildCommands(): ShortcutCommand[] {
       run: () => toggleFullscreen(),
     },
     {
-      id: 'view.togglePresenter',
-      label: 'Toggle presenter mode',
+      id: 'view.toggleZen',
+      label: 'Toggle zen mode',
       defaultSpec: 'F5',
-      run: () => presenter.toggle(),
+      run: () => zen.toggle(),
       preventDefault: true,
     },
     {
-      id: 'view.toggleZen',
-      label: 'Toggle zen mode',
+      id: 'view.toggleZenAlt',
+      label: 'Toggle zen mode (secondary)',
       defaultSpec: 'Shift+Z',
       run: () => zen.toggle(),
       preventDefault: true,

--- a/src/lib/command/commands.ts
+++ b/src/lib/command/commands.ts
@@ -119,7 +119,7 @@ export function getCommands(): Command[] {
     {
       id: 'view.toggle-zen',
       title: 'Toggle zen mode',
-      shortcut: 'Shift+Z',
+      shortcut: 'F5',
       run: () => zen.toggle(),
     },
     {
@@ -131,7 +131,6 @@ export function getCommands(): Command[] {
     {
       id: 'presenter.toggle',
       title: 'Toggle presenter view',
-      shortcut: 'F5',
       run: () => presenter.toggle(),
     },
     {

--- a/src/lib/store/shortcuts.ts
+++ b/src/lib/store/shortcuts.ts
@@ -10,7 +10,7 @@ const STORAGE_KEY = 'eldraw.shortcuts.v1';
  *
  * Legacy (unversioned) payloads are treated as version 0.
  */
-export const SHORTCUTS_SCHEMA_VERSION = 2;
+export const SHORTCUTS_SCHEMA_VERSION = 3;
 
 export type ShortcutBindings = Record<ShortcutId, string>;
 
@@ -33,6 +33,10 @@ type Migration = (bindings: Partial<Record<ShortcutId, string>>) => void;
  * slots (was color slots), `Mod+1`..`Mod+9` now select color slots (was
  * preset slots). Only stored bindings still matching the old defaults are
  * rewritten; user customizations are preserved.
+ *
+ * v2 → v3: F5 moved from presenter toggle to zen toggle (#122). Stored
+ * bindings still matching the old defaults are rewritten so the new F5
+ * behavior takes effect; user customizations are preserved.
  */
 const MIGRATIONS: Migration[] = [
   (bindings) => {
@@ -50,6 +54,16 @@ const MIGRATIONS: Migration[] = [
       if (bindings[paletteId] === `${n}`) {
         bindings[paletteId] = `Mod+${n}`;
       }
+    }
+  },
+  (bindings) => {
+    const legacyPresenterId = 'view.togglePresenter';
+    const loose = bindings as Record<string, string | undefined>;
+    if (loose[legacyPresenterId] === 'F5') {
+      delete loose[legacyPresenterId];
+    }
+    if (bindings['view.toggleZen'] === 'Shift+Z') {
+      bindings['view.toggleZen'] = 'F5';
     }
   },
 ];

--- a/src/lib/store/shortcuts.ts
+++ b/src/lib/store/shortcuts.ts
@@ -58,12 +58,18 @@ const MIGRATIONS: Migration[] = [
   },
   (bindings) => {
     const legacyPresenterId = 'view.togglePresenter';
+    const zenToggleId = 'view.toggleZen';
     const loose = bindings as Record<string, string | undefined>;
-    if (loose[legacyPresenterId] === 'F5') {
+    const presenterUsesLegacyF5 = loose[legacyPresenterId] === 'F5';
+    const f5UsedByAnotherBinding = Object.entries(loose).some(
+      ([id, binding]) => binding === 'F5' && id !== legacyPresenterId,
+    );
+
+    if (presenterUsesLegacyF5) {
       delete loose[legacyPresenterId];
     }
-    if (bindings['view.toggleZen'] === 'Shift+Z') {
-      bindings['view.toggleZen'] = 'F5';
+    if (bindings[zenToggleId] === 'Shift+Z' && !f5UsedByAnotherBinding) {
+      bindings[zenToggleId] = 'F5';
     }
   },
 ];

--- a/src/lib/store/viewport.ts
+++ b/src/lib/store/viewport.ts
@@ -3,6 +3,34 @@ import { get, writable, type Readable } from 'svelte/store';
 export const MIN_SCALE = 0.25;
 export const MAX_SCALE = 4.0;
 const ZOOM_STEP = 1.1;
+const FIT_PADDING_PX = 24;
+
+export interface PageDims {
+  width: number;
+  height: number;
+}
+
+export interface ViewportPx {
+  width: number;
+  height: number;
+}
+
+/**
+ * Compute the zoom that makes the entire page visible inside the viewport,
+ * letterboxing on the axis with extra room. Returns the clamped scale.
+ * The optional padding accounts for the .page-frame margin so the fit does
+ * not overflow into scrollbars.
+ */
+export function computeFitScale(
+  page: PageDims,
+  view: ViewportPx,
+  padding: number = FIT_PADDING_PX,
+): number {
+  if (page.width <= 0 || page.height <= 0) return 1;
+  const availW = Math.max(1, view.width - padding * 2);
+  const availH = Math.max(1, view.height - padding * 2);
+  return clampScale(Math.min(availW / page.width, availH / page.height));
+}
 
 export interface ViewportState {
   scale: number;
@@ -39,6 +67,17 @@ function createViewport() {
 
     zoomOut(): void {
       update((s) => ({ ...s, scale: clampScale(s.scale / ZOOM_STEP) }));
+    },
+
+    /**
+     * Fit the page to the viewport (letterbox on the larger axis) and
+     * recenter. Caller supplies the page size in points and the viewport
+     * pixel size; .page-frame's auto margin handles the visual centering,
+     * so we just zero the offset.
+     */
+    fitPageToViewport(page: PageDims, view: ViewportPx): void {
+      const scale = computeFitScale(page, view);
+      update((s) => ({ ...s, scale, offsetX: 0, offsetY: 0 }));
     },
 
     setOffset(offsetX: number, offsetY: number): void {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -129,6 +129,30 @@
   }
 
   let zenHintVisible = $state(false);
+  let canvasArea = $state<HTMLDivElement | null>(null);
+  let preZenViewport: { scale: number; offsetX: number; offsetY: number } | null = null;
+
+  function fitCurrentPage(): void {
+    const dims = pageDimsPt();
+    if (!dims || !canvasArea) return;
+    const rect = canvasArea.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return;
+    viewport.fitPageToViewport(dims, { width: rect.width, height: rect.height });
+  }
+
+  $effect(() => {
+    if (isZen) {
+      const snap = viewport.snapshot();
+      preZenViewport = { scale: snap.scale, offsetX: snap.offsetX, offsetY: snap.offsetY };
+      // Wait for chrome to collapse so canvas-area has its zen-mode size.
+      requestAnimationFrame(() => fitCurrentPage());
+    } else if (preZenViewport) {
+      const { scale, offsetX, offsetY } = preZenViewport;
+      viewport.setScale(scale);
+      viewport.setOffset(offsetX, offsetY);
+      preZenViewport = null;
+    }
+  });
   $effect(() => {
     if (!isZen) {
       zenHintVisible = false;
@@ -544,6 +568,25 @@
           <button type="button" aria-label="Zoom out" onclick={() => viewport.zoomOut()}>−</button>
           <span class="zoom-indicator">{Math.round(view.scale * 100)}%</span>
           <button type="button" aria-label="Zoom in" onclick={() => viewport.zoomIn()}>+</button>
+          <button
+            type="button"
+            class="zoom-fit"
+            aria-label="Fit page to screen"
+            title="Fit page"
+            disabled={!pageDimsPt()}
+            onclick={fitCurrentPage}
+          >
+            <svg viewBox="0 0 16 16" aria-hidden="true" width="14" height="14">
+              <path
+                d="M2 6V2h4M14 6V2h-4M2 10v4h4M14 10v4h-4"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.4"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </button>
         </div>
         <button
           type="button"
@@ -558,7 +601,7 @@
       </header>
     {/if}
 
-    <div class="canvas-area" onwheel={onWheel}>
+    <div class="canvas-area" bind:this={canvasArea} onwheel={onWheel}>
       {#if canvasSize()}
         {@const size = canvasSize()!}
         <div
@@ -698,7 +741,7 @@
   {/if}
 
   {#if isZen && zenHintVisible}
-    <div class="zen-hint" role="status">Zen mode — Shift+Z or Esc to exit</div>
+    <div class="zen-hint" role="status">Zen mode — F5, Shift+Z, or Esc to exit</div>
   {/if}
 
   {#if editor && editorInitial}
@@ -879,6 +922,15 @@
   .zoom button:disabled {
     opacity: 0.4;
     cursor: default;
+  }
+  .zoom-fit {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: #bbb;
+  }
+  .zoom-fit:hover:not(:disabled) {
+    color: #fff;
   }
   .page-indicator,
   .zoom-indicator {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -131,6 +131,7 @@
   let zenHintVisible = $state(false);
   let canvasArea = $state<HTMLDivElement | null>(null);
   let preZenViewport: { scale: number; offsetX: number; offsetY: number } | null = null;
+  let zenFitRaf: number | null = null;
 
   function fitCurrentPage(): void {
     const dims = pageDimsPt();
@@ -145,12 +146,22 @@
       const snap = viewport.snapshot();
       preZenViewport = { scale: snap.scale, offsetX: snap.offsetX, offsetY: snap.offsetY };
       // Wait for chrome to collapse so canvas-area has its zen-mode size.
-      requestAnimationFrame(() => fitCurrentPage());
-    } else if (preZenViewport) {
-      const { scale, offsetX, offsetY } = preZenViewport;
-      viewport.setScale(scale);
-      viewport.setOffset(offsetX, offsetY);
-      preZenViewport = null;
+      zenFitRaf = requestAnimationFrame(() => {
+        zenFitRaf = null;
+        if (!isZen) return;
+        fitCurrentPage();
+      });
+    } else {
+      if (zenFitRaf !== null) {
+        cancelAnimationFrame(zenFitRaf);
+        zenFitRaf = null;
+      }
+      if (preZenViewport) {
+        const { scale, offsetX, offsetY } = preZenViewport;
+        viewport.setScale(scale);
+        viewport.setOffset(offsetX, offsetY);
+        preZenViewport = null;
+      }
     }
   });
   $effect(() => {

--- a/tests/command-store.test.ts
+++ b/tests/command-store.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, beforeEach } from 'vitest';
 import { get } from 'svelte/store';
 import { commandPalette, openCommandPalette, closeCommandPalette } from '../src/lib/command/store';
+import { getCommands } from '../src/lib/command/commands';
+import { DEFAULT_BINDINGS } from '../src/lib/app/shortcutRegistry';
 
 describe('commandPalette store', () => {
   beforeEach(() => commandPalette.reset());
@@ -32,5 +34,30 @@ describe('commandPalette store', () => {
     openCommandPalette();
     openCommandPalette();
     expect(commandPalette.isOpen()).toBe(true);
+  });
+});
+
+describe('F5 binding (#122)', () => {
+  it('palette command "view.toggle-zen" advertises F5 as its shortcut', () => {
+    const cmd = getCommands().find((c) => c.id === 'view.toggle-zen');
+    expect(cmd?.shortcut).toBe('F5');
+  });
+
+  it('palette command "presenter.toggle" no longer advertises F5', () => {
+    const cmd = getCommands().find((c) => c.id === 'presenter.toggle');
+    expect(cmd).toBeDefined();
+    expect(cmd?.shortcut).toBeUndefined();
+  });
+
+  it('keyboard registry default for view.toggleZen is F5', () => {
+    expect(DEFAULT_BINDINGS['view.toggleZen']).toBe('F5');
+  });
+
+  it('keyboard registry keeps Shift+Z as a secondary zen binding', () => {
+    expect(DEFAULT_BINDINGS['view.toggleZenAlt']).toBe('Shift+Z');
+  });
+
+  it('keyboard registry no longer exposes a view.togglePresenter binding', () => {
+    expect((DEFAULT_BINDINGS as Record<string, string>)['view.togglePresenter']).toBeUndefined();
   });
 });

--- a/tests/viewport.test.ts
+++ b/tests/viewport.test.ts
@@ -71,7 +71,7 @@ describe('viewport', () => {
 
 describe('computeFitScale', () => {
   it('portrait page in landscape viewport is height-limited', () => {
-    // Page 612x792pt (US Letter portrait), viewport 1600x900 minus padding.
+    // Page 612x792pt (US Letter portrait), viewport 1600x900 with no padding.
     const scale = computeFitScale({ width: 612, height: 792 }, { width: 1600, height: 900 }, 0);
     expect(scale).toBeCloseTo(900 / 792, 6);
   });

--- a/tests/viewport.test.ts
+++ b/tests/viewport.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, beforeEach } from 'vitest';
 import { get } from 'svelte/store';
-import { viewport, MIN_SCALE, MAX_SCALE } from '../src/lib/store/viewport';
+import { viewport, MIN_SCALE, MAX_SCALE, computeFitScale } from '../src/lib/store/viewport';
 
 describe('viewport', () => {
   beforeEach(() => viewport.reset());
@@ -66,5 +66,59 @@ describe('viewport', () => {
     expect(get(viewport).panMode).toBe(true);
     viewport.setPanMode(false);
     expect(get(viewport).panMode).toBe(false);
+  });
+});
+
+describe('computeFitScale', () => {
+  it('portrait page in landscape viewport is height-limited', () => {
+    // Page 612x792pt (US Letter portrait), viewport 1600x900 minus padding.
+    const scale = computeFitScale({ width: 612, height: 792 }, { width: 1600, height: 900 }, 0);
+    expect(scale).toBeCloseTo(900 / 792, 6);
+  });
+
+  it('landscape page in portrait viewport is width-limited', () => {
+    const scale = computeFitScale({ width: 792, height: 612 }, { width: 900, height: 1600 }, 0);
+    expect(scale).toBeCloseTo(900 / 792, 6);
+  });
+
+  it('exact aspect match yields the matching ratio on both axes', () => {
+    const scale = computeFitScale({ width: 200, height: 100 }, { width: 400, height: 200 }, 0);
+    expect(scale).toBeCloseTo(2, 6);
+  });
+
+  it('respects padding by shrinking the available area', () => {
+    const noPad = computeFitScale({ width: 100, height: 100 }, { width: 200, height: 200 }, 0);
+    const withPad = computeFitScale({ width: 100, height: 100 }, { width: 200, height: 200 }, 24);
+    expect(withPad).toBeLessThan(noPad);
+  });
+
+  it('clamps to MAX_SCALE for tiny pages in huge viewports', () => {
+    const scale = computeFitScale({ width: 1, height: 1 }, { width: 10000, height: 10000 }, 0);
+    expect(scale).toBe(MAX_SCALE);
+  });
+
+  it('clamps to MIN_SCALE for huge pages in tiny viewports', () => {
+    const scale = computeFitScale({ width: 10000, height: 10000 }, { width: 100, height: 100 }, 0);
+    expect(scale).toBe(MIN_SCALE);
+  });
+
+  it('handles invalid page dims gracefully', () => {
+    expect(computeFitScale({ width: 0, height: 100 }, { width: 200, height: 200 })).toBe(1);
+  });
+});
+
+describe('viewport.fitPageToViewport', () => {
+  beforeEach(() => viewport.reset());
+
+  it('sets scale to fit and zeros the offset', () => {
+    viewport.setOffset(50, 70);
+    viewport.fitPageToViewport({ width: 200, height: 100 }, { width: 400, height: 200 });
+    const s = get(viewport);
+    expect(s.offsetX).toBe(0);
+    expect(s.offsetY).toBe(0);
+    expect(s.scale).toBeCloseTo(
+      computeFitScale({ width: 200, height: 100 }, { width: 400, height: 200 }),
+      6,
+    );
   });
 });


### PR DESCRIPTION
Closes #122.

- F5 toggles Zen instead of presenter view; presenter commands stay palette-only
- Entering Zen auto-fits current page to viewport (fit-page), exiting restores prior viewport
- New "Fit page" button next to +/- in topbar zoom group
- Schema-versioned migration for users with custom F5 binding