### PR TITLE
fix(ruler): snap-only when non-ruler tool active (#123)

### DIFF
--- a/src/lib/canvas/RulerOverlay.svelte
+++ b/src/lib/canvas/RulerOverlay.svelte
@@ -87,6 +87,7 @@
   {height}
   role="application"
   aria-label="Ruler overlay"
+  aria-hidden={!isRulerTool}
   onpointermove={onPointerMove}
   onpointerup={onPointerUp}
   onpointercancel={onPointerUp}
@@ -105,7 +106,7 @@
       stroke="#1e88e5"
       stroke-width="1"
       role="button"
-      tabindex="0"
+      tabindex={isRulerTool ? 0 : -1}
       aria-label="Move ruler"
       onpointerdown={isRulerTool ? onBodyPointerDown : null}
     />
@@ -143,7 +144,7 @@
     stroke="#fff"
     stroke-width="1.5"
     role="slider"
-    tabindex="0"
+    tabindex={isRulerTool ? 0 : -1}
     aria-label="Rotate ruler"
     aria-valuenow={Math.round(ruler.rotation)}
     onpointerdown={isRulerTool ? onEndPointerDown : null}
@@ -162,7 +163,7 @@
       stroke="#1e88e5"
       stroke-width="1"
       role="button"
-      tabindex="0"
+      tabindex={isRulerTool ? 0 : -1}
       aria-label="Hide ruler"
       onclick={isRulerTool ? onClose : null}
       onpointerdown={isRulerTool ? onClose : null}

--- a/src/lib/canvas/RulerOverlay.svelte
+++ b/src/lib/canvas/RulerOverlay.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { overlays } from '$lib/store/overlays';
+  import { toolStore } from '$lib/store/tool';
   import { rulerEnd, rulerTicks, type Vec2 } from '$lib/geometry';
 
   interface Props {
@@ -13,6 +14,7 @@
   const ruler = $derived($overlays.ruler);
   const ticks = $derived(rulerTicks(ruler));
   const end = $derived(rulerEnd(ruler));
+  const isRulerTool = $derived($toolStore.tool === 'ruler');
 
   let svgEl: SVGSVGElement | undefined = $state();
 
@@ -94,6 +96,7 @@
   >
     <rect
       class="body"
+      class:interactive={isRulerTool}
       x="0"
       y="0"
       width={ruler.length * ptToPx}
@@ -104,7 +107,7 @@
       role="button"
       tabindex="0"
       aria-label="Move ruler"
-      onpointerdown={onBodyPointerDown}
+      onpointerdown={isRulerTool ? onBodyPointerDown : null}
     />
   </g>
 
@@ -132,6 +135,7 @@
 
   <circle
     class="end-handle"
+    class:interactive={isRulerTool}
     cx={end.x * ptToPx}
     cy={end.y * ptToPx}
     r={6}
@@ -142,7 +146,7 @@
     tabindex="0"
     aria-label="Rotate ruler"
     aria-valuenow={Math.round(ruler.rotation)}
-    onpointerdown={onEndPointerDown}
+    onpointerdown={isRulerTool ? onEndPointerDown : null}
   />
 
   <g
@@ -150,6 +154,7 @@
   >
     <circle
       class="close"
+      class:interactive={isRulerTool}
       cx={-closeOffset}
       cy={bodyHeight / 2}
       r="8"
@@ -159,9 +164,9 @@
       role="button"
       tabindex="0"
       aria-label="Hide ruler"
-      onclick={onClose}
-      onpointerdown={onClose}
-      onkeydown={onCloseKey}
+      onclick={isRulerTool ? onClose : null}
+      onpointerdown={isRulerTool ? onClose : null}
+      onkeydown={isRulerTool ? onCloseKey : null}
     />
     <line
       x1={-closeOffset - 3}
@@ -185,23 +190,23 @@
 </svg>
 
 <style>
-  /* The outer SVG covers the whole canvas so ticks/labels can render
-     anywhere. It must not swallow pointer events — only the interactive
-     children below opt back in via pointer-events: auto. See #112. */
+  /* Outer SVG covers the whole canvas so ticks/labels can render anywhere.
+     It must not swallow pointer events — only interactive children opt in
+     via .interactive (gated on the ruler tool being active). See #112, #123. */
   .ruler {
     position: absolute;
     inset: 0;
     pointer-events: none;
   }
-  .body {
+  .body.interactive {
     cursor: grab;
     pointer-events: auto;
   }
-  .end-handle {
+  .end-handle.interactive {
     cursor: grab;
     pointer-events: auto;
   }
-  .close {
+  .close.interactive {
     cursor: pointer;
     pointer-events: auto;
   }

--- a/tests/ruler-overlay.test.ts
+++ b/tests/ruler-overlay.test.ts
@@ -8,7 +8,7 @@ const source = readFileSync(
 );
 
 function styleRule(selector: string): string {
-  const re = new RegExp(`\\${selector}\\s*\\{([^}]*)\\}`);
+  const re = new RegExp(`${selector.replace(/\./g, '\\.')}\\s*\\{([^}]*)\\}`);
   const m = source.match(re);
   if (!m) throw new Error(`no rule for ${selector}`);
   return m[1];
@@ -19,14 +19,55 @@ describe('RulerOverlay pointer-events (regression for #112)', () => {
     expect(styleRule('.ruler')).toMatch(/pointer-events:\s*none/);
   });
 
-  for (const sel of ['.body', '.end-handle', '.close'] as const) {
-    it(`${sel} opts back in with pointer-events: auto`, () => {
-      expect(styleRule(sel)).toMatch(/pointer-events:\s*auto/);
-    });
-  }
-
   it('decorative close-button strokes keep pointer-events="none"', () => {
     const decorativeLines = source.match(/<line[^>]*pointer-events="none"/g) ?? [];
     expect(decorativeLines.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('RulerOverlay snap-only mode (regression for #123)', () => {
+  it('derives isRulerTool from toolStore', () => {
+    expect(source).toMatch(/toolStore/);
+    expect(source).toMatch(
+      /isRulerTool\s*=\s*\$derived\(\s*\$toolStore\.tool\s*===\s*'ruler'\s*\)/,
+    );
+  });
+
+  for (const sel of ['.body', '.end-handle', '.close'] as const) {
+    it(`${sel} only opts into pointer-events when interactive (ruler tool active)`, () => {
+      expect(styleRule(`${sel}.interactive`)).toMatch(/pointer-events:\s*auto/);
+      expect(() => styleRule(sel)).toThrow();
+    });
+  }
+
+  for (const sel of ['body', 'end-handle', 'close'] as const) {
+    it(`${sel} element gets class:interactive bound to isRulerTool`, () => {
+      const re = new RegExp(`class="${sel}"\\s+class:interactive=\\{isRulerTool\\}`);
+      expect(source).toMatch(re);
+    });
+  }
+
+  it('body pointer handler is gated on isRulerTool', () => {
+    expect(source).toMatch(/onpointerdown=\{isRulerTool \? onBodyPointerDown : null\}/);
+  });
+
+  it('end-handle pointer handler is gated on isRulerTool', () => {
+    expect(source).toMatch(/onpointerdown=\{isRulerTool \? onEndPointerDown : null\}/);
+  });
+
+  it('close button handlers are gated on isRulerTool', () => {
+    expect(source).toMatch(/onclick=\{isRulerTool \? onClose : null\}/);
+    expect(source).toMatch(/onpointerdown=\{isRulerTool \? onClose : null\}/);
+    expect(source).toMatch(/onkeydown=\{isRulerTool \? onCloseKey : null\}/);
+  });
+});
+
+describe('RulerOverlay snap math is independent of active tool', () => {
+  it('snap geometry lives in $lib/geometry/ruler, not in the overlay', async () => {
+    const ruler = await import('../src/lib/geometry/ruler');
+    expect(typeof ruler.snapPointToRuler).toBe('function');
+    expect(typeof ruler.snapStrokeToRuler).toBe('function');
+    const overlaySnapMatches = source.match(/snapPointToRuler|snapStrokeToRuler/g) ?? [];
+    expect(overlaySnapMatches.length).toBe(0);
   });
 });

--- a/tests/ruler-overlay.test.ts
+++ b/tests/ruler-overlay.test.ts
@@ -42,23 +42,38 @@ describe('RulerOverlay snap-only mode (regression for #123)', () => {
 
   for (const sel of ['body', 'end-handle', 'close'] as const) {
     it(`${sel} element gets class:interactive bound to isRulerTool`, () => {
-      const re = new RegExp(`class="${sel}"\\s+class:interactive=\\{isRulerTool\\}`);
+      const re = new RegExp(
+        `<[^>]*class="${sel}"[^>]*class:interactive=\\{\\s*isRulerTool\\s*\\}[^>]*>`,
+      );
       expect(source).toMatch(re);
     });
   }
 
   it('body pointer handler is gated on isRulerTool', () => {
-    expect(source).toMatch(/onpointerdown=\{isRulerTool \? onBodyPointerDown : null\}/);
+    expect(source).toMatch(
+      /onpointerdown\s*=\s*\{\s*isRulerTool\s*\?\s*onBodyPointerDown\s*:\s*null\s*\}/,
+    );
   });
 
   it('end-handle pointer handler is gated on isRulerTool', () => {
-    expect(source).toMatch(/onpointerdown=\{isRulerTool \? onEndPointerDown : null\}/);
+    expect(source).toMatch(
+      /onpointerdown\s*=\s*\{\s*isRulerTool\s*\?\s*onEndPointerDown\s*:\s*null\s*\}/,
+    );
   });
 
   it('close button handlers are gated on isRulerTool', () => {
-    expect(source).toMatch(/onclick=\{isRulerTool \? onClose : null\}/);
-    expect(source).toMatch(/onpointerdown=\{isRulerTool \? onClose : null\}/);
-    expect(source).toMatch(/onkeydown=\{isRulerTool \? onCloseKey : null\}/);
+    expect(source).toMatch(/onclick\s*=\s*\{\s*isRulerTool\s*\?\s*onClose\s*:\s*null\s*\}/);
+    expect(source).toMatch(/onpointerdown\s*=\s*\{\s*isRulerTool\s*\?\s*onClose\s*:\s*null\s*\}/);
+    expect(source).toMatch(/onkeydown\s*=\s*\{\s*isRulerTool\s*\?\s*onCloseKey\s*:\s*null\s*\}/);
+  });
+
+  it('outer ruler SVG is aria-hidden when the ruler tool is inactive', () => {
+    expect(source).toMatch(/aria-hidden\s*=\s*\{\s*!\s*isRulerTool\s*\}/);
+  });
+
+  it('focusable ruler elements gate tabindex on isRulerTool', () => {
+    const matches = source.match(/tabindex\s*=\s*\{\s*isRulerTool\s*\?\s*0\s*:\s*-1\s*\}/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(3);
   });
 });
 


### PR DESCRIPTION
Closes #123.

Ruler is fully interactive only when the ruler tool is active. With any other tool, body/handles/close drop `pointer-events: auto` (and their handlers go null), so the active tool's cursor and clicks pass through. Snap math is unchanged.