### PR TITLE
feat(sidebar): highlight active color/dash/preset (#124)

### DIFF
--- a/src/lib/sidebar/ColorPalette.svelte
+++ b/src/lib/sidebar/ColorPalette.svelte
@@ -43,9 +43,11 @@
             type="button"
             class="swatch"
             class:active={color === activeColor}
+            data-selected={color === activeColor ? 'true' : undefined}
             style="background: {color}"
             title={color}
             aria-label={`${palette.name} ${color}`}
+            aria-pressed={color === activeColor}
             oncontextmenu={(e) => onContext(e, palette.id, color)}
             onclick={() => select(color)}
           ></button>
@@ -91,8 +93,14 @@
     transform: scale(1.08);
   }
   .swatch.active {
-    outline: 2px solid #7ab7ff;
-    outline-offset: 1px;
+    border-color: #ffffff;
+    box-shadow:
+      0 0 0 2px #7ab7ff,
+      0 0 0 4px #ffffff;
+    transform: scale(1.05);
+  }
+  .swatch.active:hover {
+    transform: scale(1.12);
   }
   .add {
     width: 22px;

--- a/src/lib/sidebar/DashStyleToggle.svelte
+++ b/src/lib/sidebar/DashStyleToggle.svelte
@@ -38,6 +38,7 @@
         type="button"
         class="option"
         class:active={style === value}
+        data-selected={style === value ? 'true' : undefined}
         title={style}
         aria-pressed={style === value}
         onclick={() => select(style)}
@@ -114,5 +115,6 @@
     border-color: #7ab7ff;
     color: #fff;
     background: #2a3847;
+    box-shadow: 0 0 0 2px rgba(122, 183, 255, 0.35);
   }
 </style>

--- a/src/lib/sidebar/Sidebar.svelte
+++ b/src/lib/sidebar/Sidebar.svelte
@@ -442,6 +442,7 @@
       <ToolPresets
         presets={sidebarState.presets}
         activeTool={sidebarState.activeTool}
+        activeStyle={style}
         onApply={onApplyPreset}
         onCapture={onCapturePreset}
         onRemove={onRemovePreset}

--- a/src/lib/sidebar/ToolPresets.svelte
+++ b/src/lib/sidebar/ToolPresets.svelte
@@ -1,16 +1,17 @@
 <script lang="ts">
-  import type { ToolKind, ToolPreset } from '$lib/types';
+  import type { StrokeStyle, ToolKind, ToolPreset } from '$lib/types';
   import { MAX_PRESETS, canPresetTool } from '$lib/store/sidebar';
 
   interface Props {
     presets: ToolPreset[];
     activeTool: ToolKind;
+    activeStyle?: StrokeStyle;
     onApply?: (id: string) => void;
     onCapture?: () => void;
     onRemove?: (id: string) => void;
   }
 
-  let { presets, activeTool, onApply, onCapture, onRemove }: Props = $props();
+  let { presets, activeTool, activeStyle, onApply, onCapture, onRemove }: Props = $props();
 
   const ICON: Record<string, string> = {
     pen: '✏️',
@@ -25,6 +26,17 @@
 
   function dashTitle(dash: string): string {
     return dash === 'solid' ? '' : ` ${dash}`;
+  }
+
+  function isPresetActive(preset: ToolPreset): boolean {
+    if (!activeStyle) return false;
+    if (preset.tool !== activeTool) return false;
+    return (
+      preset.style.color === activeStyle.color &&
+      preset.style.width === activeStyle.width &&
+      preset.style.dash === activeStyle.dash &&
+      Math.abs(preset.style.opacity - activeStyle.opacity) < 1e-6
+    );
   }
 </script>
 
@@ -49,10 +61,14 @@
   {:else}
     <div class="grid" role="list">
       {#each presets as preset, i (preset.id)}
+        {@const active = isPresetActive(preset)}
         <div class="slot" role="listitem">
           <button
             type="button"
             class="chip"
+            class:active
+            data-selected={active ? 'true' : undefined}
+            aria-pressed={active}
             title={`${preset.tool} ${preset.style.width}px${dashTitle(preset.style.dash)} — Ctrl+${i + 1}`}
             onclick={() => onApply?.(preset.id)}
           >
@@ -151,6 +167,12 @@
   }
   .chip:hover {
     border-color: #7ab7ff;
+  }
+  .chip.active {
+    border-color: #7ab7ff;
+    background: #2a3847;
+    color: #fff;
+    box-shadow: 0 0 0 2px rgba(122, 183, 255, 0.35);
   }
   .dot {
     display: inline-block;

--- a/tests/sidebar-preset-highlight.test.ts
+++ b/tests/sidebar-preset-highlight.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { render } from 'svelte/server';
+import ColorPalette from '$lib/sidebar/ColorPalette.svelte';
+import DashStyleToggle from '$lib/sidebar/DashStyleToggle.svelte';
+import ToolPresets from '$lib/sidebar/ToolPresets.svelte';
+import type { ColorPalette as Palette, ToolPreset } from '$lib/types';
+
+function activeButtons(html: string): string[] {
+  const re = /<button\b[^>]*aria-pressed="true"[^>]*>/g;
+  return html.match(re) ?? [];
+}
+
+describe('sidebar preset highlight', () => {
+  it('marks the swatch matching activeColor as selected', () => {
+    const palettes: Palette[] = [
+      { id: 'presets', name: 'Presets', colors: ['#ff0000', '#00ff00', '#0000ff'] },
+    ];
+    const { body } = render(ColorPalette, {
+      props: { palettes, activeColor: '#00ff00' },
+    });
+
+    const pressed = activeButtons(body);
+    expect(pressed).toHaveLength(1);
+    expect(pressed[0]).toContain('background: #00ff00');
+    expect(pressed[0]).toMatch(/class="swatch[^"]*\bactive\b/);
+    expect(body).toContain('data-selected="true"');
+  });
+
+  it('marks the dash option matching the value as selected', () => {
+    const { body } = render(DashStyleToggle, { props: { value: 'dashed' } });
+    const pressed = activeButtons(body);
+    expect(pressed).toHaveLength(1);
+    expect(pressed[0]).toMatch(/class="option[^"]*\bactive\b/);
+    expect(pressed[0]).toContain('title="dashed"');
+  });
+
+  it('marks the preset chip whose tool + style matches the active style', () => {
+    const presets: ToolPreset[] = [
+      {
+        id: 'a',
+        tool: 'pen',
+        style: { color: '#ff0000', width: 3, dash: 'solid', opacity: 1 },
+      },
+      {
+        id: 'b',
+        tool: 'pen',
+        style: { color: '#00ff00', width: 5, dash: 'dashed', opacity: 1 },
+      },
+      {
+        id: 'c',
+        tool: 'highlighter',
+        style: { color: '#00ff00', width: 5, dash: 'dashed', opacity: 1 },
+      },
+    ];
+    const { body } = render(ToolPresets, {
+      props: {
+        presets,
+        activeTool: 'pen',
+        activeStyle: { color: '#00ff00', width: 5, dash: 'dashed', opacity: 1 },
+      },
+    });
+    const pressed = activeButtons(body);
+    expect(pressed).toHaveLength(1);
+    expect(pressed[0]).toMatch(/class="chip[^"]*\bactive\b/);
+  });
+
+  it('marks no preset chip when no style matches', () => {
+    const presets: ToolPreset[] = [
+      {
+        id: 'a',
+        tool: 'pen',
+        style: { color: '#ff0000', width: 3, dash: 'solid', opacity: 1 },
+      },
+    ];
+    const { body } = render(ToolPresets, {
+      props: {
+        presets,
+        activeTool: 'pen',
+        activeStyle: { color: '#000000', width: 3, dash: 'solid', opacity: 1 },
+      },
+    });
+    expect(activeButtons(body)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #124.

Color swatches, dash buttons, and tool preset chips now show a clear selected state (high-contrast ring / blue accent border + glow) and expose `aria-pressed="true"` for accessibility. State derives from `toolStore`/`sidebar`, so palette and shortcut changes also update the highlight.