### PR TITLE
feat(session): live replay with synchronized audio recording (#131)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod model;
 mod page_cache;
 mod pdf;
 mod presenter;
+mod session;
 mod sidebar_window;
 mod slides;
 mod state;
@@ -38,6 +39,12 @@ pub fn run() {
             sidebar_window::close_sidebar_window,
             sidebar_window::sidebar_sync,
             sidebar_window::sidebar_sync_back,
+            session::list_sessions,
+            session::read_session,
+            session::write_session,
+            session::write_audio_chunk,
+            session::read_session_audio,
+            session::delete_session,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -1,0 +1,315 @@
+//! Session sidecar storage.
+//!
+//! Layout:
+//! ```text
+//! <pdf_path>.eldraw-sessions/
+//!   <session_id>/
+//!     events.json
+//!     audio.webm
+//! ```
+//!
+//! All I/O is confined to `<pdf_path>.eldraw-sessions/`. Session IDs are
+//! validated against an allow-list regex to prevent path traversal.
+
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{AppError, AppResult};
+
+const AUDIO_FILE: &str = "audio.webm";
+const EVENTS_FILE: &str = "events.json";
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionMeta {
+    pub id: String,
+    pub name: String,
+    pub created_at: i64,
+    pub duration_ms: i64,
+    pub audio_file: String,
+    pub audio_mime: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Session {
+    #[serde(flatten)]
+    pub meta: SessionMeta,
+    pub events: Vec<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionListEntry {
+    #[serde(flatten)]
+    pub meta: SessionMeta,
+    pub has_audio: bool,
+}
+
+fn valid_session_id(id: &str) -> bool {
+    if id.is_empty() || id.len() > 128 {
+        return false;
+    }
+    id.chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+fn sessions_root(pdf_path: &str) -> PathBuf {
+    PathBuf::from(format!("{pdf_path}.eldraw-sessions"))
+}
+
+fn session_dir(pdf_path: &str, session_id: &str) -> AppResult<PathBuf> {
+    if !valid_session_id(session_id) {
+        return Err(AppError::InvalidInput(format!(
+            "invalid session id: {session_id}"
+        )));
+    }
+    Ok(sessions_root(pdf_path).join(session_id))
+}
+
+fn ensure_dir(path: &Path) -> AppResult<()> {
+    if !path.exists() {
+        fs::create_dir_all(path)?;
+    }
+    Ok(())
+}
+
+pub fn list_sessions_impl(pdf_path: &str) -> AppResult<Vec<SessionListEntry>> {
+    let root = sessions_root(pdf_path);
+    if !root.exists() {
+        return Ok(Vec::new());
+    }
+    let mut out = Vec::new();
+    for entry in fs::read_dir(&root)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let dir = entry.path();
+        let events_path = dir.join(EVENTS_FILE);
+        if !events_path.exists() {
+            continue;
+        }
+        let Ok(bytes) = fs::read(&events_path) else {
+            continue;
+        };
+        let Ok(session) = serde_json::from_slice::<Session>(&bytes) else {
+            continue;
+        };
+        let has_audio = dir.join(&session.meta.audio_file).exists();
+        out.push(SessionListEntry {
+            meta: session.meta,
+            has_audio,
+        });
+    }
+    out.sort_by(|a, b| b.meta.created_at.cmp(&a.meta.created_at));
+    Ok(out)
+}
+
+pub fn read_session_impl(pdf_path: &str, session_id: &str) -> AppResult<Session> {
+    let dir = session_dir(pdf_path, session_id)?;
+    let bytes = fs::read(dir.join(EVENTS_FILE))?;
+    let session: Session = serde_json::from_slice(&bytes)?;
+    Ok(session)
+}
+
+pub fn write_session_impl(pdf_path: &str, session_id: &str, session: &Session) -> AppResult<()> {
+    if session.meta.id != session_id {
+        return Err(AppError::InvalidInput(
+            "session id mismatch between path and body".into(),
+        ));
+    }
+    let dir = session_dir(pdf_path, session_id)?;
+    ensure_dir(&dir)?;
+    let events_path = dir.join(EVENTS_FILE);
+    let tmp = dir.join(format!("{EVENTS_FILE}.tmp"));
+    let json = serde_json::to_vec_pretty(session)?;
+    if let Err(e) = fs::write(&tmp, &json) {
+        let _ = fs::remove_file(&tmp);
+        return Err(e.into());
+    }
+    if let Err(e) = fs::rename(&tmp, &events_path) {
+        let _ = fs::remove_file(&tmp);
+        return Err(e.into());
+    }
+    Ok(())
+}
+
+pub fn write_audio_chunk_impl(
+    pdf_path: &str,
+    session_id: &str,
+    bytes: &[u8],
+    reset: bool,
+) -> AppResult<()> {
+    let dir = session_dir(pdf_path, session_id)?;
+    ensure_dir(&dir)?;
+    let path = dir.join(AUDIO_FILE);
+    if reset && path.exists() {
+        fs::remove_file(&path)?;
+    }
+    let mut f = OpenOptions::new().create(true).append(true).open(&path)?;
+    f.write_all(bytes)?;
+    Ok(())
+}
+
+pub fn read_audio_impl(pdf_path: &str, session_id: &str) -> AppResult<Vec<u8>> {
+    let dir = session_dir(pdf_path, session_id)?;
+    let path = dir.join(AUDIO_FILE);
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    Ok(fs::read(&path)?)
+}
+
+pub fn delete_session_impl(pdf_path: &str, session_id: &str) -> AppResult<()> {
+    let dir = session_dir(pdf_path, session_id)?;
+    if dir.exists() {
+        fs::remove_dir_all(&dir)?;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn list_sessions(pdf_path: String) -> AppResult<Vec<SessionListEntry>> {
+    list_sessions_impl(&pdf_path)
+}
+
+#[tauri::command]
+pub async fn read_session(pdf_path: String, session_id: String) -> AppResult<Session> {
+    read_session_impl(&pdf_path, &session_id)
+}
+
+#[tauri::command]
+pub async fn write_session(
+    pdf_path: String,
+    session_id: String,
+    session: Session,
+) -> AppResult<()> {
+    write_session_impl(&pdf_path, &session_id, &session)
+}
+
+#[tauri::command]
+pub async fn write_audio_chunk(
+    pdf_path: String,
+    session_id: String,
+    bytes: Vec<u8>,
+    reset: bool,
+) -> AppResult<()> {
+    write_audio_chunk_impl(&pdf_path, &session_id, &bytes, reset)
+}
+
+#[tauri::command]
+pub async fn read_session_audio(pdf_path: String, session_id: String) -> AppResult<Vec<u8>> {
+    read_audio_impl(&pdf_path, &session_id)
+}
+
+#[tauri::command]
+pub async fn delete_session(pdf_path: String, session_id: String) -> AppResult<()> {
+    delete_session_impl(&pdf_path, &session_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn pdf(dir: &TempDir, name: &str) -> String {
+        dir.path().join(name).to_string_lossy().into_owned()
+    }
+
+    fn sample(id: &str) -> Session {
+        Session {
+            meta: SessionMeta {
+                id: id.into(),
+                name: "Sample".into(),
+                created_at: 1_700_000_000,
+                duration_ms: 5_000,
+                audio_file: AUDIO_FILE.into(),
+                audio_mime: "audio/webm;codecs=opus".into(),
+            },
+            events: vec![serde_json::json!({"kind":"pageChange","t":0,"page":0})],
+        }
+    }
+
+    #[test]
+    fn write_read_round_trip() {
+        let dir = TempDir::new().unwrap();
+        let pdf = pdf(&dir, "doc.pdf");
+        let s = sample("abc-123");
+        write_session_impl(&pdf, "abc-123", &s).unwrap();
+        let loaded = read_session_impl(&pdf, "abc-123").unwrap();
+        assert_eq!(loaded.meta.id, "abc-123");
+        assert_eq!(loaded.events.len(), 1);
+    }
+
+    #[test]
+    fn list_sessions_sorted_newest_first() {
+        let dir = TempDir::new().unwrap();
+        let pdf = pdf(&dir, "doc.pdf");
+        let mut a = sample("aaa");
+        a.meta.created_at = 100;
+        let mut b = sample("bbb");
+        b.meta.created_at = 200;
+        write_session_impl(&pdf, "aaa", &a).unwrap();
+        write_session_impl(&pdf, "bbb", &b).unwrap();
+        let list = list_sessions_impl(&pdf).unwrap();
+        assert_eq!(list.len(), 2);
+        assert_eq!(list[0].meta.id, "bbb");
+        assert_eq!(list[1].meta.id, "aaa");
+    }
+
+    #[test]
+    fn missing_root_returns_empty() {
+        let dir = TempDir::new().unwrap();
+        let pdf = pdf(&dir, "nope.pdf");
+        assert!(list_sessions_impl(&pdf).unwrap().is_empty());
+    }
+
+    #[test]
+    fn rejects_traversal_ids() {
+        let dir = TempDir::new().unwrap();
+        let pdf = pdf(&dir, "doc.pdf");
+        assert!(write_audio_chunk_impl(&pdf, "..", b"x", true).is_err());
+        assert!(write_audio_chunk_impl(&pdf, "a/b", b"x", true).is_err());
+        assert!(write_audio_chunk_impl(&pdf, "", b"x", true).is_err());
+    }
+
+    #[test]
+    fn audio_chunks_append_unless_reset() {
+        let dir = TempDir::new().unwrap();
+        let pdf = pdf(&dir, "doc.pdf");
+        write_audio_chunk_impl(&pdf, "sid", b"abc", true).unwrap();
+        write_audio_chunk_impl(&pdf, "sid", b"def", false).unwrap();
+        let bytes = read_audio_impl(&pdf, "sid").unwrap();
+        assert_eq!(bytes, b"abcdef");
+
+        write_audio_chunk_impl(&pdf, "sid", b"zz", true).unwrap();
+        let bytes = read_audio_impl(&pdf, "sid").unwrap();
+        assert_eq!(bytes, b"zz");
+    }
+
+    #[test]
+    fn delete_removes_dir() {
+        let dir = TempDir::new().unwrap();
+        let pdf = pdf(&dir, "doc.pdf");
+        write_session_impl(&pdf, "sid", &sample("sid")).unwrap();
+        write_audio_chunk_impl(&pdf, "sid", b"abc", true).unwrap();
+        delete_session_impl(&pdf, "sid").unwrap();
+        assert!(list_sessions_impl(&pdf).unwrap().is_empty());
+    }
+
+    #[test]
+    fn write_rejects_id_mismatch() {
+        let dir = TempDir::new().unwrap();
+        let pdf = pdf(&dir, "doc.pdf");
+        let s = sample("good");
+        let err = write_session_impl(&pdf, "other", &s).unwrap_err();
+        match err {
+            AppError::InvalidInput(_) => {}
+            _ => panic!("expected InvalidInput"),
+        }
+    }
+}

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -105,7 +105,7 @@ pub fn list_sessions_impl(pdf_path: &str) -> AppResult<Vec<SessionListEntry>> {
             has_audio,
         });
     }
-    out.sort_by(|a, b| b.meta.created_at.cmp(&a.meta.created_at));
+    out.sort_by_key(|b| std::cmp::Reverse(b.meta.created_at));
     Ok(out)
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,7 +18,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; img-src 'self' data: blob: asset: https://asset.localhost; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' ipc: http://ipc.localhost"
+      "csp": "default-src 'self'; img-src 'self' data: blob: asset: https://asset.localhost; media-src 'self' blob:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' ipc: http://ipc.localhost"
     }
   },
   "bundle": {

--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -4,7 +4,17 @@
  * so production is quiet; `warn()` is also gated.
  */
 
-type Scope = 'tool' | 'live' | 'shape' | 'temp-ink' | 'laser' | 'render' | 'page' | 'doc' | 'ipc';
+type Scope =
+  | 'tool'
+  | 'live'
+  | 'shape'
+  | 'temp-ink'
+  | 'laser'
+  | 'render'
+  | 'page'
+  | 'doc'
+  | 'ipc'
+  | 'session';
 
 let enabled = false;
 

--- a/src/lib/session/RecordControls.svelte
+++ b/src/lib/session/RecordControls.svelte
@@ -1,0 +1,119 @@
+<script lang="ts">
+  import { recorder, recorderState } from './recorder';
+  import { replayState } from './store';
+  import { pdf } from '$lib/store/pdf';
+  import { formatDurationMs } from './types';
+  import { log } from '$lib/log';
+
+  const r = $derived($recorderState);
+  const rp = $derived($replayState);
+  const pdfState = $derived($pdf);
+  const canRecord = $derived(!!pdfState.source && !rp.active);
+
+  async function onStart() {
+    const path = pdfState.source?.path ?? null;
+    if (!path) return;
+    try {
+      await recorder.start(path);
+    } catch (err) {
+      log('session', `record start failed ${String(err)}`);
+    }
+  }
+
+  async function onStop() {
+    try {
+      await recorder.stop();
+    } catch (err) {
+      log('session', `record stop failed ${String(err)}`);
+    }
+  }
+</script>
+
+{#if r.status === 'idle' || r.status === 'error'}
+  <button
+    type="button"
+    class="rec-btn"
+    disabled={!canRecord}
+    title={rp.active ? 'Stop replay to record' : 'Record session'}
+    aria-label="Record session"
+    onclick={onStart}
+  >
+    <span class="dot" aria-hidden="true"></span>
+    <span>Record</span>
+  </button>
+  {#if r.error}
+    <span class="rec-err" title={r.error}>mic err</span>
+  {/if}
+{:else if r.status === 'requesting'}
+  <button type="button" class="rec-btn" disabled>
+    <span class="dot pending" aria-hidden="true"></span>
+    <span>…</span>
+  </button>
+{:else}
+  <button
+    type="button"
+    class="rec-btn recording"
+    onclick={onStop}
+    title="Stop recording"
+    aria-label="Stop recording"
+  >
+    <span class="dot active" aria-hidden="true"></span>
+    <span>{formatDurationMs(r.elapsedMs)}</span>
+  </button>
+{/if}
+
+<style>
+  .rec-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: #2a2a2a;
+    border: 1px solid #3a3a3a;
+    color: #ddd;
+    border-radius: 4px;
+    padding: 3px 10px;
+    cursor: pointer;
+    font: inherit;
+    font-size: 12px;
+  }
+  .rec-btn:hover:not(:disabled) {
+    border-color: #666;
+  }
+  .rec-btn:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+  .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 999px;
+    border: 1.5px solid #c84040;
+    background: transparent;
+  }
+  .dot.active {
+    background: #c84040;
+    border-color: #c84040;
+    animation: rec-pulse 1.2s ease-in-out infinite;
+  }
+  .dot.pending {
+    background: #888;
+    border-color: #888;
+  }
+  .rec-btn.recording {
+    border-color: #c84040;
+    color: #ffd8d8;
+  }
+  .rec-err {
+    color: #ff8080;
+    font-size: 11px;
+  }
+  @keyframes rec-pulse {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.55;
+    }
+  }
+</style>

--- a/src/lib/session/ReplayBar.svelte
+++ b/src/lib/session/ReplayBar.svelte
@@ -83,7 +83,7 @@
         aria-label="Seek"
       />
       <div class="markers" aria-hidden="true">
-        {#each markers as m (m.t)}
+        {#each markers as m (`${m.t}-${m.page}`)}
           <span
             class="marker"
             title={`Page ${m.page + 1}`}

--- a/src/lib/session/ReplayBar.svelte
+++ b/src/lib/session/ReplayBar.svelte
@@ -1,0 +1,167 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+  import { player } from './player';
+  import { chapterMarkers } from './player';
+  import { replay, replayState } from './store';
+  import { formatDurationMs, type Session } from './types';
+  import { viewport } from '$lib/store/viewport';
+  import { currentDocument } from '$lib/store/document';
+  import { get } from 'svelte/store';
+
+  const status = $derived($player);
+  const replaySt = $derived($replayState);
+
+  let audio: HTMLAudioElement;
+  let session = $state<Session | null>(null);
+  let markers = $state<{ t: number; page: number }[]>([]);
+
+  function onLoad(event: Event) {
+    const detail = (event as CustomEvent<{ session: Session; url: string }>).detail;
+    if (!detail) return;
+    session = detail.session;
+    markers = chapterMarkers(detail.session.events);
+    // audio element is bound; wait a microtask for it to exist
+    queueMicrotask(() => {
+      if (!audio) return;
+      audio.src = detail.url;
+      player.load(detail.session, audio, {
+        onPageChange: (page) => {
+          const doc = get(currentDocument);
+          const total = doc?.pages.length ?? 0;
+          if (total > 0) viewport.setPage(page, total);
+        },
+      });
+    });
+  }
+
+  onMount(() => {
+    window.addEventListener('eldraw:replay-load', onLoad);
+  });
+
+  onDestroy(() => {
+    window.removeEventListener('eldraw:replay-load', onLoad);
+  });
+
+  function onExit() {
+    player.stop();
+    replay.exit();
+    session = null;
+    markers = [];
+  }
+
+  function onScrub(e: Event) {
+    const target = e.target as HTMLInputElement;
+    const ms = Number(target.value);
+    player.seek(ms);
+  }
+
+  const duration = $derived(status.durationMs || session?.durationMs || 0);
+</script>
+
+<audio bind:this={audio} preload="auto" style="display:none"></audio>
+
+{#if replaySt.active}
+  <div class="replay-bar" role="region" aria-label="Session replay">
+    <button
+      type="button"
+      class="btn"
+      onclick={() => player.toggle()}
+      aria-label={status.playing ? 'Pause' : 'Play'}
+    >
+      {status.playing ? '❚❚' : '▶'}
+    </button>
+    <span class="time">{formatDurationMs(status.currentTimeMs)} / {formatDurationMs(duration)}</span
+    >
+    <div class="scrubber">
+      <input
+        type="range"
+        min="0"
+        max={Math.max(1, duration)}
+        step="10"
+        value={status.currentTimeMs}
+        oninput={onScrub}
+        aria-label="Seek"
+      />
+      <div class="markers" aria-hidden="true">
+        {#each markers as m (m.t)}
+          <span
+            class="marker"
+            title={`Page ${m.page + 1}`}
+            style="left: {(duration > 0 ? (m.t / duration) * 100 : 0).toFixed(2)}%"
+          ></span>
+        {/each}
+      </div>
+    </div>
+    <span class="page">Page {status.currentPage + 1}</span>
+    <button type="button" class="btn exit" onclick={onExit} aria-label="Exit replay">Exit</button>
+  </div>
+{/if}
+
+<style>
+  .replay-bar {
+    position: fixed;
+    left: 16px;
+    right: 16px;
+    bottom: 16px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 14px;
+    background: rgba(28, 28, 28, 0.95);
+    border: 1px solid #3a3a3a;
+    border-radius: 8px;
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.5);
+    z-index: 150;
+    color: #ddd;
+    font-size: 12px;
+  }
+  .btn {
+    background: #2a2a2a;
+    border: 1px solid #3a3a3a;
+    color: #ddd;
+    border-radius: 4px;
+    padding: 4px 10px;
+    min-width: 40px;
+    cursor: pointer;
+  }
+  .btn:hover {
+    border-color: #666;
+  }
+  .btn.exit {
+    margin-left: auto;
+  }
+  .time {
+    font-variant-numeric: tabular-nums;
+    color: #aaa;
+    min-width: 100px;
+  }
+  .scrubber {
+    flex: 1 1 auto;
+    position: relative;
+  }
+  .scrubber input[type='range'] {
+    width: 100%;
+  }
+  .markers {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    pointer-events: none;
+  }
+  .marker {
+    position: absolute;
+    top: 50%;
+    width: 2px;
+    height: 10px;
+    margin-top: -5px;
+    background: #7ab7ff;
+    pointer-events: auto;
+  }
+  .page {
+    color: #aaa;
+    min-width: 60px;
+    text-align: right;
+  }
+</style>

--- a/src/lib/session/ReplayLayer.svelte
+++ b/src/lib/session/ReplayLayer.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import type { AnyObject, StrokeObject } from '$lib/types';
+  import { drawStroke, drawLiveStroke } from '$lib/canvas/strokeRenderer';
+  import { drawLine, drawShape, drawNumberLine, drawAngleMark } from '$lib/canvas/objectRenderer';
+
+  interface Props {
+    width: number;
+    height: number;
+    ptToPx: number;
+    objects: AnyObject[];
+    activeStrokes: StrokeObject[];
+  }
+
+  let { width, height, ptToPx, objects, activeStrokes }: Props = $props();
+
+  let canvas: HTMLCanvasElement;
+
+  function redraw() {
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    for (const o of objects) {
+      switch (o.type) {
+        case 'stroke':
+          drawStroke(ctx, o, { ptToPx });
+          break;
+        case 'line':
+          drawLine(ctx, o, ptToPx);
+          break;
+        case 'shape':
+          drawShape(ctx, o, ptToPx);
+          break;
+        case 'numberline':
+          drawNumberLine(ctx, o, ptToPx);
+          break;
+        case 'angleMark':
+          drawAngleMark(ctx, o, ptToPx);
+          break;
+        default:
+          break;
+      }
+    }
+    for (const s of activeStrokes) {
+      drawLiveStroke(ctx, s.points, s.style, s.tool, ptToPx, s.streamline);
+    }
+  }
+
+  onMount(redraw);
+
+  $effect(() => {
+    void objects;
+    void activeStrokes;
+    void width;
+    void height;
+    void ptToPx;
+    redraw();
+  });
+</script>
+
+<canvas
+  bind:this={canvas}
+  {width}
+  {height}
+  class="replay-layer"
+  style="width: {width}px; height: {height}px;"
+></canvas>
+
+<style>
+  .replay-layer {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 25;
+  }
+</style>

--- a/src/lib/session/SessionsPanel.svelte
+++ b/src/lib/session/SessionsPanel.svelte
@@ -1,0 +1,249 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { pdf } from '$lib/store/pdf';
+  import { listSessions, readSession, readSessionAudio, deleteSession } from './ipc';
+  import { replay, replayState } from './store';
+  import { recorderState } from './recorder';
+  import type { SessionListEntry } from './types';
+  import { formatDurationMs } from './types';
+  import { log } from '$lib/log';
+
+  interface Props {
+    open: boolean;
+    onClose: () => void;
+  }
+
+  let { open, onClose }: Props = $props();
+
+  const pdfState = $derived($pdf);
+  const replaySt = $derived($replayState);
+  const rec = $derived($recorderState);
+  let entries = $state<SessionListEntry[]>([]);
+  let loading = $state(false);
+  let error = $state<string | null>(null);
+
+  async function refresh() {
+    const path = pdfState.source?.path;
+    if (!path) {
+      entries = [];
+      return;
+    }
+    loading = true;
+    error = null;
+    try {
+      entries = await listSessions(path);
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+    } finally {
+      loading = false;
+    }
+  }
+
+  $effect(() => {
+    void open;
+    void pdfState.source?.path;
+    void rec.status;
+    if (open) void refresh();
+  });
+
+  onMount(() => {
+    void refresh();
+  });
+
+  async function onOpenReplay(entry: SessionListEntry) {
+    const path = pdfState.source?.path;
+    if (!path) return;
+    if (rec.status === 'recording' || rec.status === 'paused') {
+      error = 'Stop recording before replaying';
+      return;
+    }
+    try {
+      const session = await readSession(path, entry.id);
+      const bytes = await readSessionAudio(path, entry.id);
+      const blob = new Blob([bytes.buffer as ArrayBuffer], { type: session.audioMime });
+      const url = URL.createObjectURL(blob);
+      replay.enter(entry, url);
+      onClose();
+      // Player is wired up by the ReplayBar / ReplayLayer via the audio element.
+      // We pass `session` through window custom event so ReplayBar picks it up.
+      window.dispatchEvent(new CustomEvent('eldraw:replay-load', { detail: { session, url } }));
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+      log('session', `replay load failed ${String(err)}`);
+    }
+  }
+
+  async function onDelete(entry: SessionListEntry, evt: MouseEvent) {
+    evt.stopPropagation();
+    const path = pdfState.source?.path;
+    if (!path) return;
+    if (!window.confirm(`Delete session "${entry.name}"?`)) return;
+    try {
+      await deleteSession(path, entry.id);
+      await refresh();
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  function formatDate(ms: number): string {
+    const d = new Date(ms);
+    return d.toLocaleString();
+  }
+</script>
+
+{#if open}
+  <div class="overlay" role="dialog" aria-label="Sessions">
+    <div class="panel">
+      <header>
+        <h2>Sessions</h2>
+        <button type="button" class="close" onclick={onClose} aria-label="Close">×</button>
+      </header>
+      <div class="body">
+        {#if !pdfState.source}
+          <p class="dim">Open a PDF to see its sessions.</p>
+        {:else if loading}
+          <p class="dim">Loading…</p>
+        {:else if entries.length === 0}
+          <p class="dim">No sessions yet. Press Record in the toolbar to create one.</p>
+        {:else}
+          <ul>
+            {#each entries as entry (entry.id)}
+              <li>
+                <button
+                  type="button"
+                  class="row"
+                  onclick={() => onOpenReplay(entry)}
+                  disabled={!entry.hasAudio || replaySt.active}
+                >
+                  <span class="name">{entry.name}</span>
+                  <span class="meta">
+                    {formatDate(entry.createdAt)} · {formatDurationMs(entry.durationMs)}
+                    {#if !entry.hasAudio}· <span class="warn">no audio</span>{/if}
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  class="del"
+                  aria-label="Delete session"
+                  title="Delete session"
+                  onclick={(e) => onDelete(entry, e)}>🗑</button
+                >
+              </li>
+            {/each}
+          </ul>
+        {/if}
+        {#if error}<p class="error">{error}</p>{/if}
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 200;
+  }
+  .panel {
+    background: #1e1e1e;
+    border: 1px solid #333;
+    border-radius: 6px;
+    width: min(560px, 90vw);
+    max-height: 80vh;
+    display: flex;
+    flex-direction: column;
+    color: #ddd;
+  }
+  header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 14px;
+    border-bottom: 1px solid #333;
+  }
+  header h2 {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 500;
+  }
+  .close {
+    background: none;
+    border: none;
+    color: #aaa;
+    font-size: 20px;
+    cursor: pointer;
+    padding: 0 6px;
+  }
+  .body {
+    padding: 10px 14px;
+    overflow-y: auto;
+  }
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+  li {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 0;
+  }
+  .row {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+    background: #252525;
+    border: 1px solid #333;
+    color: #ddd;
+    padding: 8px 10px;
+    border-radius: 4px;
+    cursor: pointer;
+    text-align: left;
+  }
+  .row:hover:not(:disabled) {
+    border-color: #666;
+  }
+  .row:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+  .name {
+    font-size: 13px;
+  }
+  .meta {
+    font-size: 11px;
+    color: #888;
+  }
+  .warn {
+    color: #e0a040;
+  }
+  .del {
+    background: transparent;
+    border: 1px solid transparent;
+    color: #888;
+    cursor: pointer;
+    font-size: 14px;
+    border-radius: 4px;
+    padding: 4px 6px;
+  }
+  .del:hover {
+    color: #ff8080;
+    border-color: #553;
+  }
+  .dim {
+    color: #777;
+    font-size: 12px;
+  }
+  .error {
+    color: #ff8080;
+    font-size: 12px;
+  }
+</style>

--- a/src/lib/session/SessionsPanel.svelte
+++ b/src/lib/session/SessionsPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { tick } from 'svelte';
   import { pdf } from '$lib/store/pdf';
   import { listSessions, readSession, readSessionAudio, deleteSession } from './ipc';
   import { replay, replayState } from './store';
@@ -21,6 +21,8 @@
   let entries = $state<SessionListEntry[]>([]);
   let loading = $state(false);
   let error = $state<string | null>(null);
+  let panelEl = $state<HTMLDivElement | null>(null);
+  let previousFocus: HTMLElement | null = null;
 
   async function refresh() {
     const path = pdfState.source?.path;
@@ -46,9 +48,27 @@
     if (open) void refresh();
   });
 
-  onMount(() => {
-    void refresh();
+  $effect(() => {
+    if (!open) return;
+    previousFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    void tick().then(() => {
+      const first = panelEl?.querySelector<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      );
+      first?.focus();
+    });
+    return () => {
+      previousFocus?.focus();
+      previousFocus = null;
+    };
   });
+
+  function onKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      event.stopPropagation();
+      onClose();
+    }
+  }
 
   async function onOpenReplay(entry: SessionListEntry) {
     const path = pdfState.source?.path;
@@ -93,7 +113,15 @@
 </script>
 
 {#if open}
-  <div class="overlay" role="dialog" aria-label="Sessions">
+  <div
+    class="overlay"
+    role="dialog"
+    aria-label="Sessions"
+    aria-modal="true"
+    bind:this={panelEl}
+    onkeydown={onKeydown}
+    tabindex="-1"
+  >
     <div class="panel">
       <header>
         <h2>Sessions</h2>

--- a/src/lib/session/events.ts
+++ b/src/lib/session/events.ts
@@ -1,0 +1,53 @@
+import type { MutationEvent } from '$lib/store/document';
+import type { StrokeObject } from '$lib/types';
+import type { SessionEvent } from './types';
+
+/**
+ * Turn a documentStore MutationEvent into the SessionEvents to log. A stroke
+ * add becomes a dedicated `stroke` event so the player can animate partial
+ * stroke progress; non-stroke adds become `objectAdd`.
+ */
+export function mutationToSessionEvents(ev: MutationEvent, t: number): SessionEvent[] {
+  switch (ev.kind) {
+    case 'add': {
+      if (ev.object.type === 'stroke') {
+        return [{ kind: 'stroke', t, page: ev.pageIndex, stroke: ev.object as StrokeObject }];
+      }
+      return [{ kind: 'objectAdd', t, page: ev.pageIndex, obj: ev.object }];
+    }
+    case 'remove':
+      if (ev.ids.length === 0) return [];
+      return [{ kind: 'objectDel', t, page: ev.pageIndex, ids: [...ev.ids] }];
+    case 'update':
+      return [{ kind: 'objectUpdate', t, page: ev.pageIndex, id: ev.id, after: ev.after }];
+  }
+}
+
+/**
+ * Stroke duration in ms, derived from the last point's `t`. Points carry
+ * per-point `t` relative to stroke start (see `Point.t`).
+ */
+export function strokeDurationMs(stroke: StrokeObject): number {
+  if (stroke.points.length === 0) return 0;
+  return Math.max(0, stroke.points[stroke.points.length - 1].t);
+}
+
+/**
+ * Slice a stroke's point list to only the prefix with per-point `t <= cutoff`.
+ * Used for mid-stroke replay rendering. Always keeps at least the first point
+ * when any are within the cutoff.
+ */
+export function sliceStrokePointsUpTo(stroke: StrokeObject, cutoff: number): StrokeObject {
+  if (cutoff <= 0) {
+    return { ...stroke, points: stroke.points.length > 0 ? [stroke.points[0]] : [] };
+  }
+  const points = [];
+  for (const p of stroke.points) {
+    if (p.t <= cutoff) points.push(p);
+    else break;
+  }
+  if (points.length === 0 && stroke.points.length > 0) {
+    points.push(stroke.points[0]);
+  }
+  return { ...stroke, points };
+}

--- a/src/lib/session/index.ts
+++ b/src/lib/session/index.ts
@@ -1,0 +1,7 @@
+export { default as RecordControls } from './RecordControls.svelte';
+export { default as SessionsPanel } from './SessionsPanel.svelte';
+export { default as ReplayBar } from './ReplayBar.svelte';
+export { default as ReplayLayer } from './ReplayLayer.svelte';
+export { recorder, recorderState } from './recorder';
+export { player, playerState } from './player';
+export { replay, replayState } from './store';

--- a/src/lib/session/ipc.ts
+++ b/src/lib/session/ipc.ts
@@ -1,0 +1,41 @@
+import { invoke } from '@tauri-apps/api/core';
+import type { Session, SessionListEntry } from './types';
+
+export async function listSessions(pdfPath: string): Promise<SessionListEntry[]> {
+  return invoke('list_sessions', { pdfPath });
+}
+
+export async function readSession(pdfPath: string, sessionId: string): Promise<Session> {
+  return invoke('read_session', { pdfPath, sessionId });
+}
+
+export async function writeSession(
+  pdfPath: string,
+  sessionId: string,
+  session: Session,
+): Promise<void> {
+  return invoke('write_session', { pdfPath, sessionId, session });
+}
+
+export async function writeAudioChunk(
+  pdfPath: string,
+  sessionId: string,
+  bytes: Uint8Array,
+  reset: boolean,
+): Promise<void> {
+  return invoke('write_audio_chunk', {
+    pdfPath,
+    sessionId,
+    bytes: Array.from(bytes),
+    reset,
+  });
+}
+
+export async function readSessionAudio(pdfPath: string, sessionId: string): Promise<Uint8Array> {
+  const arr = await invoke<number[]>('read_session_audio', { pdfPath, sessionId });
+  return new Uint8Array(arr);
+}
+
+export async function deleteSession(pdfPath: string, sessionId: string): Promise<void> {
+  return invoke('delete_session', { pdfPath, sessionId });
+}

--- a/src/lib/session/player.ts
+++ b/src/lib/session/player.ts
@@ -1,0 +1,280 @@
+import { get, writable, type Readable } from 'svelte/store';
+import type { AnyObject, ObjectId, StrokeObject } from '$lib/types';
+import { sliceStrokePointsUpTo, strokeDurationMs } from './events';
+import type { Session, SessionEvent } from './types';
+
+export interface PlayerStatus {
+  playing: boolean;
+  currentTimeMs: number;
+  durationMs: number;
+  currentPage: number;
+}
+
+export interface ReplayRenderState {
+  currentPage: number;
+  /** All objects, by page, that have been applied up to the current time. */
+  byPage: Map<number, AnyObject[]>;
+  /** Strokes currently mid-animation on the current page (partial points only). */
+  activeStrokes: StrokeObject[];
+}
+
+export interface PlayerDeps {
+  onPageChange?: (page: number) => void;
+  /** Called whenever render state changes, for the replay layer to redraw. */
+  onRender?: (state: ReplayRenderState) => void;
+}
+
+/**
+ * Compute the full replay state at time `tMs` by linearly scanning events
+ * from `fromIndex`. For a pure seek, pass `fromIndex = 0` and an empty
+ * accumulator. Returns the new cursor position and whether a page changed.
+ */
+export function replayStateAt(
+  events: readonly SessionEvent[],
+  tMs: number,
+): {
+  cursor: number;
+  currentPage: number;
+  byPage: Map<number, AnyObject[]>;
+  activeStrokes: StrokeObject[];
+} {
+  const byPage = new Map<number, AnyObject[]>();
+  const activeStrokes: StrokeObject[] = [];
+  let currentPage = 0;
+  let cursor = 0;
+
+  function getPage(page: number): AnyObject[] {
+    let arr = byPage.get(page);
+    if (!arr) {
+      arr = [];
+      byPage.set(page, arr);
+    }
+    return arr;
+  }
+
+  function removeIds(page: number, ids: ObjectId[]) {
+    const arr = byPage.get(page);
+    if (!arr) return;
+    const drop = new Set(ids);
+    byPage.set(
+      page,
+      arr.filter((o) => !drop.has(o.id)),
+    );
+  }
+
+  for (let i = 0; i < events.length; i += 1) {
+    const ev = events[i];
+    if (ev.t > tMs) break;
+    cursor = i + 1;
+    switch (ev.kind) {
+      case 'pageChange':
+        currentPage = ev.page;
+        break;
+      case 'stroke':
+        getPage(ev.page).push(ev.stroke);
+        break;
+      case 'objectAdd':
+        getPage(ev.page).push(ev.obj);
+        break;
+      case 'objectDel':
+        removeIds(ev.page, ev.ids);
+        break;
+      case 'objectUpdate': {
+        const arr = byPage.get(ev.page);
+        if (arr) {
+          byPage.set(
+            ev.page,
+            arr.map((o) => (o.id === ev.id ? ev.after : o)),
+          );
+        }
+        break;
+      }
+    }
+  }
+
+  for (let i = cursor; i < events.length; i += 1) {
+    const ev = events[i];
+    if (ev.kind !== 'stroke') continue;
+    const duration = strokeDurationMs(ev.stroke);
+    const strokeStart = ev.t - duration;
+    if (strokeStart <= tMs && tMs < ev.t && ev.page === currentPage) {
+      const offset = tMs - strokeStart;
+      activeStrokes.push(sliceStrokePointsUpTo(ev.stroke, offset));
+    }
+  }
+
+  return { cursor, currentPage, byPage, activeStrokes };
+}
+
+export function chapterMarkers(events: readonly SessionEvent[]): { t: number; page: number }[] {
+  const out: { t: number; page: number }[] = [];
+  let lastPage = -1;
+  for (const ev of events) {
+    if (ev.kind === 'pageChange' && ev.page !== lastPage) {
+      out.push({ t: ev.t, page: ev.page });
+      lastPage = ev.page;
+    }
+  }
+  return out;
+}
+
+export function nearestPageChangeAtOrBefore(events: readonly SessionEvent[], tMs: number): number {
+  let best = 0;
+  for (const ev of events) {
+    if (ev.t > tMs) break;
+    if (ev.kind === 'pageChange') best = ev.t;
+  }
+  return best;
+}
+
+export interface PlayerController {
+  subscribe: Readable<PlayerStatus>['subscribe'];
+  render: Readable<ReplayRenderState>;
+  load(session: Session, audio: HTMLAudioElement, deps?: PlayerDeps): void;
+  play(): void;
+  pause(): void;
+  toggle(): void;
+  seek(ms: number): void;
+  stop(): void;
+  snapshot(): PlayerStatus;
+  /** For tests: compute state at an arbitrary time without an audio element. */
+  stateAt(ms: number): ReplayRenderState;
+}
+
+const EMPTY_RENDER: ReplayRenderState = {
+  currentPage: 0,
+  byPage: new Map(),
+  activeStrokes: [],
+};
+
+export function createPlayer(): PlayerController {
+  const state = writable<PlayerStatus>({
+    playing: false,
+    currentTimeMs: 0,
+    durationMs: 0,
+    currentPage: 0,
+  });
+  const render = writable<ReplayRenderState>(EMPTY_RENDER);
+  let session: Session | null = null;
+  let audio: HTMLAudioElement | null = null;
+  let deps: PlayerDeps = {};
+  let raf = 0;
+  let lastPage = -1;
+
+  function emit(time: number): void {
+    if (!session) return;
+    const r = replayStateAt(session.events, time);
+    state.update((s) => ({
+      ...s,
+      currentTimeMs: time,
+      currentPage: r.currentPage,
+    }));
+    if (r.currentPage !== lastPage) {
+      lastPage = r.currentPage;
+      deps.onPageChange?.(r.currentPage);
+    }
+    const next: ReplayRenderState = {
+      currentPage: r.currentPage,
+      byPage: r.byPage,
+      activeStrokes: r.activeStrokes,
+    };
+    render.set(next);
+    deps.onRender?.(next);
+  }
+
+  function loop(): void {
+    if (!audio || !session) return;
+    emit(audio.currentTime * 1000);
+    raf = requestAnimationFrame(loop);
+  }
+
+  function load(s: Session, a: HTMLAudioElement, d: PlayerDeps = {}): void {
+    session = s;
+    audio = a;
+    deps = d;
+    lastPage = -1;
+    state.set({
+      playing: false,
+      currentTimeMs: 0,
+      durationMs: s.durationMs,
+      currentPage: 0,
+    });
+    a.addEventListener('play', () => {
+      state.update((v) => ({ ...v, playing: true }));
+      if (raf === 0) loop();
+    });
+    a.addEventListener('pause', () => {
+      state.update((v) => ({ ...v, playing: false }));
+      if (raf !== 0) cancelAnimationFrame(raf);
+      raf = 0;
+      if (audio) emit(audio.currentTime * 1000);
+    });
+    a.addEventListener('seeked', () => {
+      if (audio) emit(audio.currentTime * 1000);
+    });
+    a.addEventListener('timeupdate', () => {
+      if (!audio) return;
+      state.update((v) => ({ ...v, currentTimeMs: audio!.currentTime * 1000 }));
+    });
+    a.addEventListener('ended', () => {
+      state.update((v) => ({ ...v, playing: false }));
+      if (raf !== 0) cancelAnimationFrame(raf);
+      raf = 0;
+    });
+    emit(0);
+  }
+
+  function play(): void {
+    void audio?.play();
+  }
+  function pause(): void {
+    audio?.pause();
+  }
+  function toggle(): void {
+    if (!audio) return;
+    if (audio.paused) void audio.play();
+    else audio.pause();
+  }
+  function seek(ms: number): void {
+    if (!audio) return;
+    const clamped = Math.max(0, Math.min((session?.durationMs ?? 0) / 1000, ms / 1000));
+    audio.currentTime = clamped;
+    emit(clamped * 1000);
+  }
+
+  function stop(): void {
+    audio?.pause();
+    if (raf !== 0) cancelAnimationFrame(raf);
+    raf = 0;
+    audio = null;
+    session = null;
+    deps = {};
+    lastPage = -1;
+    state.set({ playing: false, currentTimeMs: 0, durationMs: 0, currentPage: 0 });
+    render.set(EMPTY_RENDER);
+  }
+
+  function stateAt(ms: number): ReplayRenderState {
+    if (!session) {
+      return { currentPage: 0, byPage: new Map(), activeStrokes: [] };
+    }
+    const r = replayStateAt(session.events, ms);
+    return { currentPage: r.currentPage, byPage: r.byPage, activeStrokes: r.activeStrokes };
+  }
+
+  return {
+    subscribe: state.subscribe,
+    render: { subscribe: render.subscribe },
+    load,
+    play,
+    pause,
+    toggle,
+    seek,
+    stop,
+    snapshot: () => get(state),
+    stateAt,
+  };
+}
+
+export const player: PlayerController = createPlayer();
+export const playerState: Readable<PlayerStatus> = { subscribe: player.subscribe };

--- a/src/lib/session/player.ts
+++ b/src/lib/session/player.ts
@@ -26,8 +26,10 @@ export interface PlayerDeps {
 
 /**
  * Compute the full replay state at time `tMs` by linearly scanning events
- * from `fromIndex`. For a pure seek, pass `fromIndex = 0` and an empty
- * accumulator. Returns the new cursor position and whether a page changed.
+ * from the start of `events` up to (and including) the last event whose
+ * timestamp is `<= tMs`. Returns the cursor (one past the last applied
+ * event), the current page, the per-page object lists, and any strokes
+ * currently mid-animation at `tMs`.
  */
 export function replayStateAt(
   events: readonly SessionEvent[],
@@ -160,6 +162,7 @@ export function createPlayer(): PlayerController {
   let deps: PlayerDeps = {};
   let raf = 0;
   let lastPage = -1;
+  let listenerAbort: AbortController | null = null;
 
   function emit(time: number): void {
     if (!session) return;
@@ -189,6 +192,7 @@ export function createPlayer(): PlayerController {
   }
 
   function load(s: Session, a: HTMLAudioElement, d: PlayerDeps = {}): void {
+    listenerAbort?.abort();
     session = s;
     audio = a;
     deps = d;
@@ -199,28 +203,51 @@ export function createPlayer(): PlayerController {
       durationMs: s.durationMs,
       currentPage: 0,
     });
-    a.addEventListener('play', () => {
-      state.update((v) => ({ ...v, playing: true }));
-      if (raf === 0) loop();
-    });
-    a.addEventListener('pause', () => {
-      state.update((v) => ({ ...v, playing: false }));
-      if (raf !== 0) cancelAnimationFrame(raf);
-      raf = 0;
-      if (audio) emit(audio.currentTime * 1000);
-    });
-    a.addEventListener('seeked', () => {
-      if (audio) emit(audio.currentTime * 1000);
-    });
-    a.addEventListener('timeupdate', () => {
-      if (!audio) return;
-      state.update((v) => ({ ...v, currentTimeMs: audio!.currentTime * 1000 }));
-    });
-    a.addEventListener('ended', () => {
-      state.update((v) => ({ ...v, playing: false }));
-      if (raf !== 0) cancelAnimationFrame(raf);
-      raf = 0;
-    });
+    const ac = new AbortController();
+    listenerAbort = ac;
+    const opts = { signal: ac.signal };
+    a.addEventListener(
+      'play',
+      () => {
+        state.update((v) => ({ ...v, playing: true }));
+        if (raf === 0) loop();
+      },
+      opts,
+    );
+    a.addEventListener(
+      'pause',
+      () => {
+        state.update((v) => ({ ...v, playing: false }));
+        if (raf !== 0) cancelAnimationFrame(raf);
+        raf = 0;
+        if (audio) emit(audio.currentTime * 1000);
+      },
+      opts,
+    );
+    a.addEventListener(
+      'seeked',
+      () => {
+        if (audio) emit(audio.currentTime * 1000);
+      },
+      opts,
+    );
+    a.addEventListener(
+      'timeupdate',
+      () => {
+        if (!audio) return;
+        state.update((v) => ({ ...v, currentTimeMs: audio!.currentTime * 1000 }));
+      },
+      opts,
+    );
+    a.addEventListener(
+      'ended',
+      () => {
+        state.update((v) => ({ ...v, playing: false }));
+        if (raf !== 0) cancelAnimationFrame(raf);
+        raf = 0;
+      },
+      opts,
+    );
     emit(0);
   }
 
@@ -246,6 +273,8 @@ export function createPlayer(): PlayerController {
     audio?.pause();
     if (raf !== 0) cancelAnimationFrame(raf);
     raf = 0;
+    listenerAbort?.abort();
+    listenerAbort = null;
     audio = null;
     session = null;
     deps = {};

--- a/src/lib/session/recorder.ts
+++ b/src/lib/session/recorder.ts
@@ -1,0 +1,290 @@
+import { get, writable, type Readable } from 'svelte/store';
+import { documentStore } from '$lib/store/document';
+import { viewportStore } from '$lib/store/viewport';
+import { warn, log } from '$lib/log';
+import { writeAudioChunk, writeSession } from './ipc';
+import { mutationToSessionEvents } from './events';
+import { replay } from './store';
+import {
+  defaultSessionName,
+  makeSessionId,
+  type Session,
+  type SessionEvent,
+  type SessionMeta,
+} from './types';
+
+export type RecorderStatus = 'idle' | 'requesting' | 'recording' | 'paused' | 'error';
+
+export interface RecorderState {
+  status: RecorderStatus;
+  sessionId: string | null;
+  startedAt: number | null;
+  elapsedMs: number;
+  error: string | null;
+}
+
+const initialState: RecorderState = {
+  status: 'idle',
+  sessionId: null,
+  startedAt: null,
+  elapsedMs: 0,
+  error: null,
+};
+
+export interface RecorderDeps {
+  now: () => number;
+  getUserMedia: (c: MediaStreamConstraints) => Promise<MediaStream>;
+  createRecorder: (stream: MediaStream, mime: string) => MediaRecorder;
+  persistAudioChunk: (
+    pdfPath: string,
+    sessionId: string,
+    bytes: Uint8Array,
+    reset: boolean,
+  ) => Promise<void>;
+  persistSession: (pdfPath: string, sessionId: string, session: Session) => Promise<void>;
+}
+
+const AUDIO_MIME = 'audio/webm;codecs=opus';
+const AUDIO_BITRATE = 32_000;
+const CHUNK_MS = 1000;
+
+function browserDeps(): RecorderDeps {
+  return {
+    now: () => performance.now(),
+    getUserMedia: (c) => navigator.mediaDevices.getUserMedia(c),
+    createRecorder: (stream, mime) =>
+      new MediaRecorder(stream, { mimeType: mime, audioBitsPerSecond: AUDIO_BITRATE }),
+    persistAudioChunk: writeAudioChunk,
+    persistSession: writeSession,
+  };
+}
+
+export function createRecorder(deps: RecorderDeps = browserDeps()) {
+  const state = writable<RecorderState>(initialState);
+
+  let stream: MediaStream | null = null;
+  let mediaRecorder: MediaRecorder | null = null;
+  let unsubscribeMutations: (() => void) | null = null;
+  let unsubscribeViewport: (() => void) | null = null;
+  let events: SessionEvent[] = [];
+  let sessionStart = -1;
+  let pausedOffsetMs = 0;
+  let pauseStartedAt: number | null = null;
+  let lastPage = -1;
+  let firstChunk = true;
+  let currentPdfPath: string | null = null;
+  let sessionId: string | null = null;
+  let sessionName = '';
+  let sessionCreatedAt = 0;
+  let tick: ReturnType<typeof setInterval> | null = null;
+
+  function currentElapsed(): number {
+    if (sessionStart < 0) return 0;
+    const raw = deps.now() - sessionStart;
+    const paused = pauseStartedAt !== null ? deps.now() - pauseStartedAt : 0;
+    return Math.max(0, raw - pausedOffsetMs - paused);
+  }
+
+  function pushSessionEvent(ev: SessionEvent) {
+    events.push(ev);
+  }
+
+  function onMutation(ev: Parameters<Parameters<typeof documentStore.onMutation>[0]>[0]) {
+    if (get(state).status !== 'recording') return;
+    const t = currentElapsed();
+    for (const se of mutationToSessionEvents(ev, t)) pushSessionEvent(se);
+  }
+
+  function onViewport(v: { currentPageIndex: number }) {
+    if (get(state).status !== 'recording') return;
+    if (v.currentPageIndex === lastPage) return;
+    lastPage = v.currentPageIndex;
+    pushSessionEvent({ kind: 'pageChange', t: currentElapsed(), page: lastPage });
+  }
+
+  async function start(pdfPath: string, nameHint?: string): Promise<void> {
+    if (get(state).status !== 'idle' && get(state).status !== 'error') {
+      throw new Error('recorder busy');
+    }
+    if (get(replay).active) {
+      throw new Error('cannot record while a session is being replayed');
+    }
+    state.update((s) => ({ ...s, status: 'requesting', error: null }));
+    let ms: MediaStream;
+    try {
+      ms = await deps.getUserMedia({ audio: true });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      state.update((s) => ({ ...s, status: 'error', error: msg }));
+      throw err;
+    }
+    stream = ms;
+    const id = makeSessionId();
+    const createdAt = Date.now();
+    sessionId = id;
+    sessionCreatedAt = createdAt;
+    sessionName = nameHint?.trim() || defaultSessionName(createdAt);
+    currentPdfPath = pdfPath;
+    events = [];
+    pausedOffsetMs = 0;
+    pauseStartedAt = null;
+    firstChunk = true;
+
+    const recorder = deps.createRecorder(ms, AUDIO_MIME);
+    mediaRecorder = recorder;
+
+    recorder.ondataavailable = async (e: BlobEvent) => {
+      if (!currentPdfPath || !sessionId) return;
+      if (!e.data || e.data.size === 0) return;
+      try {
+        const buf = new Uint8Array(await e.data.arrayBuffer());
+        const reset = firstChunk;
+        firstChunk = false;
+        await deps.persistAudioChunk(currentPdfPath, sessionId, buf, reset);
+      } catch (err) {
+        warn('session', `audio chunk write failed ${String(err)}`);
+      }
+    };
+    recorder.onerror = (e) => {
+      warn('session', `MediaRecorder error ${String((e as ErrorEvent).error ?? e)}`);
+    };
+
+    sessionStart = deps.now();
+    const vp = get(viewportStore);
+    lastPage = vp.currentPageIndex;
+    pushSessionEvent({ kind: 'pageChange', t: 0, page: lastPage });
+
+    unsubscribeMutations = documentStore.onMutation(onMutation);
+    unsubscribeViewport = viewportStore.subscribe(onViewport);
+
+    recorder.start(CHUNK_MS);
+    state.set({
+      status: 'recording',
+      sessionId: id,
+      startedAt: sessionStart,
+      elapsedMs: 0,
+      error: null,
+    });
+    tick = setInterval(() => {
+      state.update((s) => (s.status === 'recording' ? { ...s, elapsedMs: currentElapsed() } : s));
+    }, 250);
+    log('session', `recording started id=${id}`);
+  }
+
+  function pause(): void {
+    if (get(state).status !== 'recording') return;
+    mediaRecorder?.pause();
+    pauseStartedAt = deps.now();
+    state.update((s) => ({ ...s, status: 'paused' }));
+  }
+
+  function resume(): void {
+    if (get(state).status !== 'paused') return;
+    if (pauseStartedAt !== null) {
+      pausedOffsetMs += deps.now() - pauseStartedAt;
+      pauseStartedAt = null;
+    }
+    mediaRecorder?.resume();
+    state.update((s) => ({ ...s, status: 'recording' }));
+  }
+
+  async function stop(): Promise<Session | null> {
+    const s = get(state);
+    if (s.status !== 'recording' && s.status !== 'paused') return null;
+    if (!sessionId || !currentPdfPath) return null;
+    if (pauseStartedAt !== null) {
+      pausedOffsetMs += deps.now() - pauseStartedAt;
+      pauseStartedAt = null;
+    }
+    const duration = currentElapsed();
+
+    await new Promise<void>((resolve) => {
+      const rec = mediaRecorder;
+      if (!rec) return resolve();
+      rec.onstop = () => resolve();
+      try {
+        rec.stop();
+      } catch {
+        resolve();
+      }
+    });
+    for (const t of stream?.getTracks() ?? []) t.stop();
+
+    unsubscribeMutations?.();
+    unsubscribeMutations = null;
+    unsubscribeViewport?.();
+    unsubscribeViewport = null;
+    if (tick) {
+      clearInterval(tick);
+      tick = null;
+    }
+
+    const meta: SessionMeta = {
+      id: sessionId,
+      name: sessionName,
+      createdAt: sessionCreatedAt,
+      durationMs: Math.round(duration),
+      audioFile: 'audio.webm',
+      audioMime: AUDIO_MIME,
+    };
+    const session: Session = { ...meta, events };
+    try {
+      await deps.persistSession(currentPdfPath, sessionId, session);
+      log('session', `recording stopped id=${sessionId} dur=${Math.round(duration)}ms`);
+    } catch (err) {
+      state.update((v) => ({
+        ...v,
+        status: 'error',
+        error: err instanceof Error ? err.message : String(err),
+      }));
+      throw err;
+    }
+
+    stream = null;
+    mediaRecorder = null;
+    currentPdfPath = null;
+    sessionId = null;
+    sessionStart = -1;
+    state.set(initialState);
+    return session;
+  }
+
+  return {
+    subscribe: state.subscribe,
+    start,
+    pause,
+    resume,
+    stop,
+    snapshot(): RecorderState {
+      return get(state);
+    },
+    _inject: {
+      get events(): readonly SessionEvent[] {
+        return events;
+      },
+    },
+  };
+}
+
+export type Recorder = ReturnType<typeof createRecorder>;
+
+export const recorder: Recorder = createRecorder(
+  typeof navigator !== 'undefined' &&
+    typeof (globalThis as { MediaRecorder?: unknown }).MediaRecorder !== 'undefined'
+    ? browserDeps()
+    : stubDeps(),
+);
+
+export const recorderState: Readable<RecorderState> = { subscribe: recorder.subscribe };
+
+function stubDeps(): RecorderDeps {
+  return {
+    now: () => Date.now(),
+    getUserMedia: () => Promise.reject(new Error('MediaRecorder unavailable')),
+    createRecorder: () => {
+      throw new Error('MediaRecorder unavailable');
+    },
+    persistAudioChunk: writeAudioChunk,
+    persistSession: writeSession,
+  };
+}

--- a/src/lib/session/recorder.ts
+++ b/src/lib/session/recorder.ts
@@ -130,45 +130,66 @@ export function createRecorder(deps: RecorderDeps = browserDeps()) {
     pauseStartedAt = null;
     firstChunk = true;
 
-    const recorder = deps.createRecorder(ms, AUDIO_MIME);
-    mediaRecorder = recorder;
+    try {
+      const recorder = deps.createRecorder(ms, AUDIO_MIME);
+      mediaRecorder = recorder;
 
-    recorder.ondataavailable = async (e: BlobEvent) => {
-      if (!currentPdfPath || !sessionId) return;
-      if (!e.data || e.data.size === 0) return;
-      try {
-        const buf = new Uint8Array(await e.data.arrayBuffer());
-        const reset = firstChunk;
-        firstChunk = false;
-        await deps.persistAudioChunk(currentPdfPath, sessionId, buf, reset);
-      } catch (err) {
-        warn('session', `audio chunk write failed ${String(err)}`);
+      recorder.ondataavailable = async (e: BlobEvent) => {
+        if (!currentPdfPath || !sessionId) return;
+        if (!e.data || e.data.size === 0) return;
+        try {
+          const buf = new Uint8Array(await e.data.arrayBuffer());
+          const reset = firstChunk;
+          firstChunk = false;
+          await deps.persistAudioChunk(currentPdfPath, sessionId, buf, reset);
+        } catch (err) {
+          warn('session', `audio chunk write failed ${String(err)}`);
+        }
+      };
+      recorder.onerror = (e) => {
+        warn('session', `MediaRecorder error ${String((e as ErrorEvent).error ?? e)}`);
+      };
+
+      sessionStart = deps.now();
+      const vp = get(viewportStore);
+      lastPage = vp.currentPageIndex;
+      pushSessionEvent({ kind: 'pageChange', t: 0, page: lastPage });
+
+      unsubscribeMutations = documentStore.onMutation(onMutation);
+      unsubscribeViewport = viewportStore.subscribe(onViewport);
+
+      recorder.start(CHUNK_MS);
+      state.set({
+        status: 'recording',
+        sessionId: id,
+        startedAt: sessionStart,
+        elapsedMs: 0,
+        error: null,
+      });
+      tick = setInterval(() => {
+        state.update((s) => (s.status === 'recording' ? { ...s, elapsedMs: currentElapsed() } : s));
+      }, 250);
+      log('session', `recording started id=${id}`);
+    } catch (err) {
+      for (const t of ms.getTracks()) t.stop();
+      unsubscribeMutations?.();
+      unsubscribeMutations = null;
+      unsubscribeViewport?.();
+      unsubscribeViewport = null;
+      if (tick) {
+        clearInterval(tick);
+        tick = null;
       }
-    };
-    recorder.onerror = (e) => {
-      warn('session', `MediaRecorder error ${String((e as ErrorEvent).error ?? e)}`);
-    };
-
-    sessionStart = deps.now();
-    const vp = get(viewportStore);
-    lastPage = vp.currentPageIndex;
-    pushSessionEvent({ kind: 'pageChange', t: 0, page: lastPage });
-
-    unsubscribeMutations = documentStore.onMutation(onMutation);
-    unsubscribeViewport = viewportStore.subscribe(onViewport);
-
-    recorder.start(CHUNK_MS);
-    state.set({
-      status: 'recording',
-      sessionId: id,
-      startedAt: sessionStart,
-      elapsedMs: 0,
-      error: null,
-    });
-    tick = setInterval(() => {
-      state.update((s) => (s.status === 'recording' ? { ...s, elapsedMs: currentElapsed() } : s));
-    }, 250);
-    log('session', `recording started id=${id}`);
+      stream = null;
+      mediaRecorder = null;
+      currentPdfPath = null;
+      sessionId = null;
+      sessionStart = -1;
+      events = [];
+      const msg = err instanceof Error ? err.message : String(err);
+      state.update((s) => ({ ...s, status: 'error', error: msg }));
+      throw err;
+    }
   }
 
   function pause(): void {

--- a/src/lib/session/store.ts
+++ b/src/lib/session/store.ts
@@ -1,0 +1,29 @@
+import { writable, type Readable } from 'svelte/store';
+import type { SessionListEntry } from './types';
+
+export interface ReplayState {
+  active: boolean;
+  session: SessionListEntry | null;
+  audioUrl: string | null;
+}
+
+const initial: ReplayState = { active: false, session: null, audioUrl: null };
+
+function createReplayStore() {
+  const s = writable<ReplayState>(initial);
+  return {
+    subscribe: s.subscribe,
+    enter(session: SessionListEntry, audioUrl: string) {
+      s.set({ active: true, session, audioUrl });
+    },
+    exit() {
+      s.update((prev) => {
+        if (prev.audioUrl) URL.revokeObjectURL(prev.audioUrl);
+        return initial;
+      });
+    },
+  };
+}
+
+export const replay = createReplayStore();
+export const replayState: Readable<ReplayState> = { subscribe: replay.subscribe };

--- a/src/lib/session/types.ts
+++ b/src/lib/session/types.ts
@@ -1,0 +1,48 @@
+import type { AnyObject, ObjectId, StrokeObject } from '$lib/types';
+
+export type SessionEvent =
+  | { kind: 'stroke'; t: number; page: number; stroke: StrokeObject }
+  | { kind: 'objectAdd'; t: number; page: number; obj: AnyObject }
+  | { kind: 'objectDel'; t: number; page: number; ids: ObjectId[] }
+  | { kind: 'objectUpdate'; t: number; page: number; id: ObjectId; after: AnyObject }
+  | { kind: 'pageChange'; t: number; page: number };
+
+export interface SessionMeta {
+  id: string;
+  name: string;
+  createdAt: number;
+  durationMs: number;
+  audioFile: string;
+  audioMime: string;
+}
+
+export interface Session extends SessionMeta {
+  events: SessionEvent[];
+}
+
+export interface SessionListEntry extends SessionMeta {
+  hasAudio: boolean;
+}
+
+const SESSION_ID_RE = /^[A-Za-z0-9_-]+$/;
+
+export function isValidSessionId(id: string): boolean {
+  return id.length > 0 && id.length <= 128 && SESSION_ID_RE.test(id);
+}
+
+export function makeSessionId(): string {
+  return crypto.randomUUID();
+}
+
+export function defaultSessionName(createdAt: number): string {
+  const d = new Date(createdAt);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `Session ${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+export function formatDurationMs(ms: number): string {
+  const total = Math.max(0, Math.round(ms / 1000));
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+}

--- a/src/lib/store/document.ts
+++ b/src/lib/store/document.ts
@@ -1,9 +1,35 @@
 import { derived, get, writable, type Readable } from 'svelte/store';
 import type { AnyObject, EldrawDocument, ObjectId, Page } from '$lib/types';
 import { isSafeHexColor } from '$lib/color';
-import { applyCommand, createHistory, type Command, type History } from './history';
+import { applyCommand, createHistory, invertCommand, type Command, type History } from './history';
 
 export type PageCommitListener = (pageIndex: number) => void;
+
+export type MutationEvent =
+  | { kind: 'add'; pageIndex: number; object: AnyObject }
+  | { kind: 'remove'; pageIndex: number; ids: ObjectId[] }
+  | { kind: 'update'; pageIndex: number; id: ObjectId; after: AnyObject };
+
+export type MutationListener = (ev: MutationEvent) => void;
+
+function commandToMutations(pageIndex: number, cmd: Command): MutationEvent[] {
+  switch (cmd.type) {
+    case 'add':
+      return [{ kind: 'add', pageIndex, object: cmd.object }];
+    case 'remove':
+      return [{ kind: 'remove', pageIndex, ids: [cmd.object.id] }];
+    case 'removeMany':
+      return [{ kind: 'remove', pageIndex, ids: cmd.items.map((i) => i.object.id) }];
+    case 'insertMany':
+      return cmd.items.map((i) => ({ kind: 'add', pageIndex, object: i.object }));
+    case 'update':
+      return [{ kind: 'update', pageIndex, id: cmd.objectId, after: cmd.after }];
+    case 'clearPage':
+      return [{ kind: 'remove', pageIndex, ids: cmd.objects.map((o) => o.id) }];
+    case 'restorePage':
+      return cmd.objects.map((o) => ({ kind: 'add', pageIndex, object: o }));
+  }
+}
 
 export interface DocumentStore {
   subscribe: Readable<EldrawDocument | null>['subscribe'];
@@ -46,6 +72,13 @@ export interface DocumentStore {
    * structural page ops (insert/move/duplicate/delete).
    */
   onPageCommit(listener: PageCommitListener): () => void;
+
+  /**
+   * Subscribe to granular mutation events. Fires after each apply, including
+   * undo/redo, for every object add / remove / update. Used by the session
+   * recorder to build an event log.
+   */
+  onMutation(listener: MutationListener): () => void;
 
   /** Escape hatch for undo/redo replays that must not re-push history. */
   _internalApply(pageIndex: number, cmd: Command): void;
@@ -154,9 +187,17 @@ export function createDocumentStore(): DocumentStore {
   const state = writable<EldrawDocument | null>(null);
   const history = createHistory();
   const commitListeners = new Set<PageCommitListener>();
+  const mutationListeners = new Set<MutationListener>();
 
   function emitCommit(pageIndex: number) {
     for (const listener of commitListeners) listener(pageIndex);
+  }
+
+  function emitMutations(pageIndex: number, cmd: Command) {
+    if (mutationListeners.size === 0) return;
+    for (const ev of commandToMutations(pageIndex, cmd)) {
+      for (const listener of mutationListeners) listener(ev);
+    }
   }
 
   function mutatePage(pageIndex: number, fn: (p: Page) => Page) {
@@ -172,6 +213,7 @@ export function createDocumentStore(): DocumentStore {
     history.pushCommand(pageIndex, cmd);
     mutatePage(pageIndex, (p) => applyCommand(p, cmd));
     emitCommit(pageIndex);
+    emitMutations(pageIndex, cmd);
   }
 
   return {
@@ -304,10 +346,12 @@ export function createDocumentStore(): DocumentStore {
       if (!doc) return;
       const page = doc.pages[pageIndex];
       if (!page) return;
+      const cmd = history.peekUndo(pageIndex);
       const next = history.undo(pageIndex, page);
       if (next) {
         mutatePage(pageIndex, () => next);
         emitCommit(pageIndex);
+        if (cmd) emitMutations(pageIndex, invertCommand(cmd));
       }
     },
 
@@ -316,10 +360,12 @@ export function createDocumentStore(): DocumentStore {
       if (!doc) return;
       const page = doc.pages[pageIndex];
       if (!page) return;
+      const cmd = history.peekRedo(pageIndex);
       const next = history.redo(pageIndex, page);
       if (next) {
         mutatePage(pageIndex, () => next);
         emitCommit(pageIndex);
+        if (cmd) emitMutations(pageIndex, cmd);
       }
     },
 
@@ -342,9 +388,17 @@ export function createDocumentStore(): DocumentStore {
       };
     },
 
+    onMutation(listener) {
+      mutationListeners.add(listener);
+      return () => {
+        mutationListeners.delete(listener);
+      };
+    },
+
     _internalApply(pageIndex, cmd) {
       mutatePage(pageIndex, (p) => applyCommand(p, cmd));
       emitCommit(pageIndex);
+      emitMutations(pageIndex, cmd);
     },
 
     history,

--- a/src/lib/store/history.ts
+++ b/src/lib/store/history.ts
@@ -93,6 +93,10 @@ export interface History {
   pushCommand(pageIndex: number, cmd: Command): void;
   undo(pageIndex: number, page: Page): Page | null;
   redo(pageIndex: number, page: Page): Page | null;
+  /** Top of the undo stack without mutating it. Used to preview the next
+   *  command that would be undone (e.g. for firing mutation events). */
+  peekUndo(pageIndex: number): Command | null;
+  peekRedo(pageIndex: number): Command | null;
   canUndo(pageIndex: number): Readable<boolean>;
   canRedo(pageIndex: number): Readable<boolean>;
   /** Shift all page stacks at index >= `from` up by one to keep them
@@ -158,6 +162,18 @@ export function createHistory(): History {
 
     canRedo(pageIndex) {
       return derived(stacks, ($s) => ($s[pageIndex]?.redo.length ?? 0) > 0);
+    },
+
+    peekUndo(pageIndex) {
+      const s = get(stacks)[pageIndex];
+      if (!s || s.undo.length === 0) return null;
+      return s.undo[s.undo.length - 1];
+    },
+
+    peekRedo(pageIndex) {
+      const s = get(stacks)[pageIndex];
+      if (!s || s.redo.length === 0) return null;
+      return s.redo[s.redo.length - 1];
     },
 
     clear() {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -46,6 +46,15 @@
   import GraphEditor from '$lib/graph/GraphEditor.svelte';
   import { CommandPalette } from '$lib/command';
   import ConfigDialog from '$lib/config/ConfigDialog.svelte';
+  import {
+    RecordControls,
+    ReplayBar,
+    ReplayLayer,
+    SessionsPanel,
+    player,
+    replayState,
+  } from '$lib/session';
+  import type { ReplayRenderState } from '$lib/session/player';
   import { log } from '$lib/log';
   import type {
     AngleMarkObject,
@@ -210,6 +219,25 @@
     | { mode: 'edit'; obj: TextObject; screen: { x: number; y: number } };
 
   let editor: EditorState | null = $state(null);
+
+  let sessionsPanelOpen = $state(false);
+  let replayRender = $state<ReplayRenderState>({
+    currentPage: 0,
+    byPage: new Map(),
+    activeStrokes: [],
+  });
+  const replaySt = $derived($replayState);
+  const replayObjectsOnPage = $derived(replayRender.byPage.get(pageIndex) ?? []);
+  const replayActiveOnPage = $derived(
+    replayRender.currentPage === pageIndex ? replayRender.activeStrokes : [],
+  );
+
+  $effect(() => {
+    const unsub = player.render.subscribe((r) => {
+      replayRender = r;
+    });
+    return unsub;
+  });
 
   const editorInitial = $derived.by(() => {
     if (!editor) return null;
@@ -555,6 +583,16 @@
         >
           Clear page
         </button>
+        <RecordControls />
+        <button
+          type="button"
+          class="topbar-btn"
+          onclick={() => (sessionsPanelOpen = true)}
+          disabled={!pdfState.source}
+          title="View recorded sessions"
+        >
+          Sessions
+        </button>
       </header>
     {/if}
 
@@ -660,6 +698,15 @@
               <RulerOverlay ptToPx={size.ptToPx} width={size.width} height={size.height} />
             </div>
           {/if}
+          {#if replaySt.active}
+            <ReplayLayer
+              width={size.width}
+              height={size.height}
+              ptToPx={size.ptToPx}
+              objects={replayObjectsOnPage}
+              activeStrokes={replayActiveOnPage}
+            />
+          {/if}
         </div>
       {:else}
         <div class="empty">
@@ -735,6 +782,8 @@
   {/if}
   <CommandPalette />
   <ConfigDialog />
+  <SessionsPanel open={sessionsPanelOpen} onClose={() => (sessionsPanelOpen = false)} />
+  <ReplayBar />
   <OpenFromSlidesDialog
     open={$slidesDialogOpen}
     onCancel={() => slidesDialogOpen.set(false)}

--- a/tests/document-mutation.test.ts
+++ b/tests/document-mutation.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { createDocumentStore, type MutationEvent } from '$lib/store/document';
+import type { EldrawDocument, Page, StrokeObject, TextObject } from '$lib/types';
+
+function stroke(id: string): StrokeObject {
+  return {
+    id,
+    createdAt: 0,
+    type: 'stroke',
+    tool: 'pen',
+    style: { color: '#000', width: 2, dash: 'solid', opacity: 1 },
+    points: [],
+  };
+}
+
+function text(id: string, content = 'x'): TextObject {
+  return {
+    id,
+    createdAt: 0,
+    type: 'text',
+    at: { x: 0, y: 0 },
+    content,
+    latex: false,
+    fontSize: 16,
+    color: '#000',
+  };
+}
+
+function pdfPage(i: number): Page {
+  return {
+    pageIndex: i,
+    type: 'pdf',
+    insertedAfterPdfPage: null,
+    width: 612,
+    height: 792,
+    objects: [],
+  };
+}
+
+function doc(): EldrawDocument {
+  return {
+    version: 1,
+    pdfHash: 'h',
+    pdfPath: '/tmp/x.pdf',
+    pages: [pdfPage(0)],
+    palettes: [],
+    prefs: {
+      sidebarPinned: true,
+      defaultTool: 'pen',
+      toolDefaults: {
+        pen: { color: '#000', width: 2, dash: 'solid', opacity: 1 },
+        highlighter: { color: '#ff0', width: 14, dash: 'solid', opacity: 0.3 },
+        line: { color: '#000', width: 2, dash: 'solid', opacity: 1 },
+      },
+    },
+  };
+}
+
+describe('documentStore.onMutation', () => {
+  it('fires add/remove/update events with correct kinds and page', () => {
+    const store = createDocumentStore();
+    store.load(doc());
+    const events: MutationEvent[] = [];
+    const off = store.onMutation((e) => events.push(e));
+
+    const s = stroke('s1');
+    store.addObject(0, s);
+    store.updateObject(0, 's1', { style: { color: '#f00', width: 3, dash: 'solid', opacity: 1 } });
+    store.removeObject(0, 's1');
+
+    expect(events.map((e) => e.kind)).toEqual(['add', 'update', 'remove']);
+    expect(events[0]).toMatchObject({ kind: 'add', pageIndex: 0 });
+    expect(events[1]).toMatchObject({ kind: 'update', pageIndex: 0, id: 's1' });
+    expect(events[2]).toMatchObject({ kind: 'remove', pageIndex: 0, ids: ['s1'] });
+    off();
+  });
+
+  it('fires inverted events on undo and re-applied events on redo', () => {
+    const store = createDocumentStore();
+    store.load(doc());
+    store.addObject(0, stroke('s1'));
+
+    const events: MutationEvent[] = [];
+    store.onMutation((e) => events.push(e));
+    store.undo(0);
+    store.redo(0);
+
+    expect(events).toHaveLength(2);
+    expect(events[0].kind).toBe('remove');
+    expect(events[1].kind).toBe('add');
+  });
+
+  it('emits remove event with all ids when clearPage runs', () => {
+    const store = createDocumentStore();
+    store.load(doc());
+    store.addObject(0, stroke('s1'));
+    store.addObject(0, text('t1'));
+
+    const events: MutationEvent[] = [];
+    store.onMutation((e) => events.push(e));
+    store.clearPage(0);
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe('remove');
+    if (events[0].kind === 'remove') {
+      expect(events[0].ids.sort()).toEqual(['s1', 't1']);
+    }
+  });
+});

--- a/tests/session-events.test.ts
+++ b/tests/session-events.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import {
+  mutationToSessionEvents,
+  sliceStrokePointsUpTo,
+  strokeDurationMs,
+} from '$lib/session/events';
+import type { Point, StrokeObject, TextObject } from '$lib/types';
+
+function pt(x: number, t: number): Point {
+  return { x, y: 0, pressure: 0.5, t };
+}
+
+function strokeWith(points: Point[]): StrokeObject {
+  return {
+    id: 's1',
+    createdAt: 0,
+    type: 'stroke',
+    tool: 'pen',
+    style: { color: '#000', width: 2, dash: 'solid', opacity: 1 },
+    points,
+  };
+}
+
+function textObj(id: string): TextObject {
+  return {
+    id,
+    createdAt: 0,
+    type: 'text',
+    at: { x: 0, y: 0 },
+    content: 'hi',
+    latex: false,
+    fontSize: 16,
+    color: '#000',
+  };
+}
+
+describe('mutationToSessionEvents', () => {
+  it('maps stroke add to a stroke event', () => {
+    const s = strokeWith([pt(0, 0), pt(10, 100)]);
+    const out = mutationToSessionEvents({ kind: 'add', pageIndex: 3, object: s }, 500);
+    expect(out).toEqual([{ kind: 'stroke', t: 500, page: 3, stroke: s }]);
+  });
+
+  it('maps non-stroke add to objectAdd', () => {
+    const t = textObj('t1');
+    const out = mutationToSessionEvents({ kind: 'add', pageIndex: 0, object: t }, 1);
+    expect(out).toEqual([{ kind: 'objectAdd', t: 1, page: 0, obj: t }]);
+  });
+
+  it('maps remove to objectDel and drops empty removes', () => {
+    expect(mutationToSessionEvents({ kind: 'remove', pageIndex: 0, ids: ['a', 'b'] }, 100)).toEqual(
+      [{ kind: 'objectDel', t: 100, page: 0, ids: ['a', 'b'] }],
+    );
+    expect(mutationToSessionEvents({ kind: 'remove', pageIndex: 0, ids: [] }, 100)).toEqual([]);
+  });
+
+  it('maps update to objectUpdate', () => {
+    const t = textObj('t1');
+    expect(
+      mutationToSessionEvents({ kind: 'update', pageIndex: 2, id: 't1', after: t }, 50),
+    ).toEqual([{ kind: 'objectUpdate', t: 50, page: 2, id: 't1', after: t }]);
+  });
+});
+
+describe('strokeDurationMs', () => {
+  it('returns the last point t', () => {
+    expect(strokeDurationMs(strokeWith([pt(0, 0), pt(5, 200)]))).toBe(200);
+  });
+  it('zero for empty strokes', () => {
+    expect(strokeDurationMs(strokeWith([]))).toBe(0);
+  });
+});
+
+describe('sliceStrokePointsUpTo', () => {
+  it('keeps only points with t <= cutoff', () => {
+    const s = strokeWith([pt(0, 0), pt(1, 50), pt(2, 100), pt(3, 200)]);
+    const sliced = sliceStrokePointsUpTo(s, 100);
+    expect(sliced.points.map((p) => p.x)).toEqual([0, 1, 2]);
+  });
+
+  it('keeps at least the first point for cutoff <= 0', () => {
+    const s = strokeWith([pt(0, 0), pt(1, 50)]);
+    expect(sliceStrokePointsUpTo(s, 0).points.map((p) => p.x)).toEqual([0]);
+    expect(sliceStrokePointsUpTo(s, -10).points.map((p) => p.x)).toEqual([0]);
+  });
+
+  it('keeps the first point when all strictly exceed cutoff', () => {
+    const s = strokeWith([pt(0, 100), pt(1, 200)]);
+    expect(sliceStrokePointsUpTo(s, 50).points.map((p) => p.x)).toEqual([0]);
+  });
+
+  it('handles empty stroke', () => {
+    expect(sliceStrokePointsUpTo(strokeWith([]), 100).points).toEqual([]);
+  });
+});

--- a/tests/session-player.test.ts
+++ b/tests/session-player.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import { chapterMarkers, nearestPageChangeAtOrBefore, replayStateAt } from '$lib/session/player';
+import type { Point, StrokeObject, TextObject } from '$lib/types';
+import type { SessionEvent } from '$lib/session/types';
+
+function pt(x: number, t: number): Point {
+  return { x, y: 0, pressure: 0.5, t };
+}
+
+function stroke(id: string, points: Point[]): StrokeObject {
+  return {
+    id,
+    createdAt: 0,
+    type: 'stroke',
+    tool: 'pen',
+    style: { color: '#000', width: 2, dash: 'solid', opacity: 1 },
+    points,
+  };
+}
+
+function text(id: string, content = 'x'): TextObject {
+  return {
+    id,
+    createdAt: 0,
+    type: 'text',
+    at: { x: 0, y: 0 },
+    content,
+    latex: false,
+    fontSize: 16,
+    color: '#000',
+  };
+}
+
+describe('replayStateAt', () => {
+  it('is empty at t=0 when the first event is after 0', () => {
+    const events: SessionEvent[] = [{ kind: 'pageChange', t: 100, page: 0 }];
+    const r = replayStateAt(events, 0);
+    expect(r.byPage.size).toBe(0);
+    expect(r.activeStrokes).toEqual([]);
+    expect(r.currentPage).toBe(0);
+    expect(r.cursor).toBe(0);
+  });
+
+  it('accumulates committed objects on their pages up to tMs', () => {
+    const s1 = stroke('s1', [pt(0, 0), pt(1, 50)]);
+    const t1 = text('t1');
+    const events: SessionEvent[] = [
+      { kind: 'pageChange', t: 0, page: 0 },
+      { kind: 'stroke', t: 50, page: 0, stroke: s1 },
+      { kind: 'objectAdd', t: 100, page: 0, obj: t1 },
+      { kind: 'pageChange', t: 200, page: 1 },
+      { kind: 'objectAdd', t: 250, page: 1, obj: text('t2') },
+    ];
+    const r = replayStateAt(events, 150);
+    expect(r.currentPage).toBe(0);
+    expect(r.byPage.get(0)?.map((o) => o.id)).toEqual(['s1', 't1']);
+    expect(r.byPage.get(1)).toBeUndefined();
+    expect(r.activeStrokes).toEqual([]);
+  });
+
+  it('renders mid-stroke as an active partial stroke', () => {
+    const full = stroke('s1', [pt(0, 0), pt(1, 50), pt(2, 100), pt(3, 150)]);
+    const events: SessionEvent[] = [
+      { kind: 'pageChange', t: 0, page: 0 },
+      // stroke end at t=1000 means it started at 1000 - 150 = 850
+      { kind: 'stroke', t: 1000, page: 0, stroke: full },
+    ];
+    const mid = replayStateAt(events, 900);
+    expect(mid.activeStrokes).toHaveLength(1);
+    expect(mid.activeStrokes[0].points.map((p) => p.x)).toEqual([0, 1]);
+    expect(mid.byPage.get(0) ?? []).toEqual([]);
+
+    const after = replayStateAt(events, 1001);
+    expect(after.activeStrokes).toEqual([]);
+    expect(after.byPage.get(0)?.map((o) => o.id)).toEqual(['s1']);
+  });
+
+  it('only shows active strokes on the current page', () => {
+    const s1 = stroke('s1', [pt(0, 0), pt(1, 50), pt(2, 100)]);
+    const events: SessionEvent[] = [
+      { kind: 'pageChange', t: 0, page: 0 },
+      { kind: 'pageChange', t: 500, page: 1 },
+      // Stroke committed on page 0 after user has navigated away — cannot happen
+      // in practice but we guard against it.
+      { kind: 'stroke', t: 1000, page: 0, stroke: s1 },
+    ];
+    const r = replayStateAt(events, 950);
+    expect(r.currentPage).toBe(1);
+    expect(r.activeStrokes).toEqual([]);
+  });
+
+  it('seek is idempotent: same tMs from 0 yields same state', () => {
+    const events: SessionEvent[] = [
+      { kind: 'pageChange', t: 0, page: 0 },
+      { kind: 'objectAdd', t: 10, page: 0, obj: text('a') },
+      { kind: 'objectAdd', t: 20, page: 0, obj: text('b') },
+      { kind: 'objectDel', t: 30, page: 0, ids: ['a'] },
+      { kind: 'pageChange', t: 40, page: 1 },
+    ];
+    const r1 = replayStateAt(events, 35);
+    const r2 = replayStateAt(events, 35);
+    expect(r1.byPage.get(0)?.map((o) => o.id)).toEqual(['b']);
+    expect(r2.byPage.get(0)?.map((o) => o.id)).toEqual(['b']);
+    expect(r1.currentPage).toBe(0);
+  });
+
+  it('applies objectUpdate in place', () => {
+    const before = text('t1', 'old');
+    const after = text('t1', 'new');
+    const events: SessionEvent[] = [
+      { kind: 'pageChange', t: 0, page: 0 },
+      { kind: 'objectAdd', t: 10, page: 0, obj: before },
+      { kind: 'objectUpdate', t: 20, page: 0, id: 't1', after },
+    ];
+    const r = replayStateAt(events, 25);
+    const t = r.byPage.get(0)?.[0] as TextObject;
+    expect(t.content).toBe('new');
+  });
+});
+
+describe('chapterMarkers', () => {
+  it('emits a marker at each distinct page change', () => {
+    const events: SessionEvent[] = [
+      { kind: 'pageChange', t: 0, page: 0 },
+      { kind: 'pageChange', t: 100, page: 0 },
+      { kind: 'pageChange', t: 200, page: 1 },
+      { kind: 'pageChange', t: 300, page: 2 },
+    ];
+    expect(chapterMarkers(events)).toEqual([
+      { t: 0, page: 0 },
+      { t: 200, page: 1 },
+      { t: 300, page: 2 },
+    ]);
+  });
+});
+
+describe('nearestPageChangeAtOrBefore', () => {
+  it('returns 0 when no page change precedes tMs', () => {
+    expect(nearestPageChangeAtOrBefore([], 100)).toBe(0);
+  });
+  it('returns the latest pageChange t <= tMs', () => {
+    const events: SessionEvent[] = [
+      { kind: 'pageChange', t: 0, page: 0 },
+      { kind: 'pageChange', t: 500, page: 1 },
+      { kind: 'pageChange', t: 1500, page: 2 },
+    ];
+    expect(nearestPageChangeAtOrBefore(events, 499)).toBe(0);
+    expect(nearestPageChangeAtOrBefore(events, 500)).toBe(500);
+    expect(nearestPageChangeAtOrBefore(events, 1000)).toBe(500);
+    expect(nearestPageChangeAtOrBefore(events, 2000)).toBe(1500);
+  });
+});

--- a/tests/session-recorder.test.ts
+++ b/tests/session-recorder.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createRecorder, type RecorderDeps } from '$lib/session/recorder';
+import { replay } from '$lib/session/store';
+import { documentStore } from '$lib/store/document';
+import { viewport } from '$lib/store/viewport';
+import type { Session, SessionEvent } from '$lib/session/types';
+import type { EldrawDocument, Page, StrokeObject } from '$lib/types';
+
+class FakeMediaRecorder {
+  ondataavailable:
+    | ((e: { data: { size: number; arrayBuffer(): Promise<ArrayBuffer> } }) => void)
+    | null = null;
+  onerror: ((e: unknown) => void) | null = null;
+  onstop: (() => void) | null = null;
+  start(_interval?: number): void {
+    void _interval;
+  }
+  pause(): void {}
+  resume(): void {}
+  stop(): void {
+    this.onstop?.();
+  }
+  emitChunk(bytes: Uint8Array): void {
+    this.ondataavailable?.({
+      data: {
+        size: bytes.byteLength,
+        arrayBuffer: () => Promise.resolve(bytes.buffer),
+      },
+    });
+  }
+}
+
+class FakeStream {
+  getTracks(): { stop(): void }[] {
+    return [{ stop() {} }];
+  }
+}
+
+function pdfPage(i: number): Page {
+  return {
+    pageIndex: i,
+    type: 'pdf',
+    insertedAfterPdfPage: null,
+    width: 612,
+    height: 792,
+    objects: [],
+  };
+}
+
+function doc(): EldrawDocument {
+  return {
+    version: 1,
+    pdfHash: 'h',
+    pdfPath: '/tmp/x.pdf',
+    pages: [pdfPage(0), pdfPage(1)],
+    palettes: [],
+    prefs: {
+      sidebarPinned: true,
+      defaultTool: 'pen',
+      toolDefaults: {
+        pen: { color: '#000', width: 2, dash: 'solid', opacity: 1 },
+        highlighter: { color: '#ff0', width: 14, dash: 'solid', opacity: 0.3 },
+        line: { color: '#000', width: 2, dash: 'solid', opacity: 1 },
+      },
+    },
+  };
+}
+
+function stroke(id: string): StrokeObject {
+  return {
+    id,
+    createdAt: 0,
+    type: 'stroke',
+    tool: 'pen',
+    style: { color: '#000', width: 2, dash: 'solid', opacity: 1 },
+    points: [{ x: 0, y: 0, pressure: 0.5, t: 0 }],
+  };
+}
+
+interface Harness {
+  recorder: ReturnType<typeof createRecorder>;
+  fakeRec: FakeMediaRecorder;
+  audioChunks: { bytes: Uint8Array; reset: boolean }[];
+  written: Session[];
+  now: { ms: number };
+}
+
+function makeHarness(): Harness {
+  const fakeRec = new FakeMediaRecorder();
+  const audioChunks: { bytes: Uint8Array; reset: boolean }[] = [];
+  const written: Session[] = [];
+  const now = { ms: 0 };
+  const deps: RecorderDeps = {
+    now: () => now.ms,
+    getUserMedia: () => Promise.resolve(new FakeStream() as unknown as MediaStream),
+    createRecorder: () => fakeRec as unknown as MediaRecorder,
+    persistAudioChunk: async (_path, _id, bytes, reset) => {
+      audioChunks.push({ bytes, reset });
+    },
+    persistSession: async (_path, _id, session) => {
+      written.push(session);
+    },
+  };
+  return { recorder: createRecorder(deps), fakeRec, audioChunks, written, now };
+}
+
+describe('recorder', () => {
+  beforeEach(() => {
+    documentStore.load(doc());
+    viewport.setPage(0, 2);
+    replay.exit();
+  });
+
+  it('starts recording and emits an initial pageChange at t=0', async () => {
+    const h = makeHarness();
+    h.now.ms = 100;
+    await h.recorder.start('/tmp/x.pdf');
+    const status = h.recorder.snapshot();
+    expect(status.status).toBe('recording');
+    const events = h.recorder._inject.events;
+    expect(events[0]).toMatchObject({ kind: 'pageChange', t: 0, page: 0 });
+  });
+
+  it('collects document mutations with monotonic t while recording', async () => {
+    const h = makeHarness();
+    h.now.ms = 0;
+    await h.recorder.start('/tmp/x.pdf');
+    h.now.ms = 500;
+    documentStore.addObject(0, stroke('s1'));
+    h.now.ms = 1_200;
+    documentStore.addObject(0, stroke('s2'));
+
+    const events = h.recorder._inject.events as SessionEvent[];
+    const strokeEvents = events.filter((e) => e.kind === 'stroke');
+    expect(strokeEvents).toHaveLength(2);
+    expect(strokeEvents[0].t).toBe(500);
+    expect(strokeEvents[1].t).toBe(1_200);
+    expect(strokeEvents[0].t).toBeLessThanOrEqual(strokeEvents[1].t);
+  });
+
+  it('emits pageChange on viewport change, ignoring repeats', async () => {
+    const h = makeHarness();
+    h.now.ms = 0;
+    await h.recorder.start('/tmp/x.pdf');
+    h.now.ms = 300;
+    viewport.setPage(1, 2);
+    h.now.ms = 400;
+    viewport.setPage(1, 2);
+    const events = h.recorder._inject.events as SessionEvent[];
+    const pages = events.filter((e) => e.kind === 'pageChange');
+    expect(pages).toHaveLength(2);
+    expect(pages[0].page).toBe(0);
+    expect(pages[1]).toMatchObject({ page: 1, t: 300 });
+  });
+
+  it('rejects a second start while busy', async () => {
+    const h = makeHarness();
+    await h.recorder.start('/tmp/x.pdf');
+    await expect(h.recorder.start('/tmp/x.pdf')).rejects.toThrow(/busy/);
+  });
+
+  it('rejects start while replay is active', async () => {
+    const h = makeHarness();
+    replay.enter(
+      {
+        id: 'abc',
+        name: 'x',
+        createdAt: 0,
+        durationMs: 0,
+        audioFile: 'audio.webm',
+        audioMime: 'audio/webm;codecs=opus',
+        hasAudio: true,
+      },
+      'blob:fake',
+    );
+    await expect(h.recorder.start('/tmp/x.pdf')).rejects.toThrow(/replay/);
+    expect(h.recorder.snapshot().status).toBe('idle');
+    replay.exit();
+  });
+
+  it('stop persists session with duration and events, returns to idle', async () => {
+    const h = makeHarness();
+    h.now.ms = 0;
+    await h.recorder.start('/tmp/x.pdf');
+    h.now.ms = 800;
+    documentStore.addObject(0, stroke('s1'));
+    h.now.ms = 2_000;
+    const session = await h.recorder.stop();
+    expect(session).not.toBeNull();
+    expect(h.written).toHaveLength(1);
+    expect(h.written[0].durationMs).toBe(2_000);
+    expect(h.written[0].events.some((e) => e.kind === 'stroke')).toBe(true);
+    expect(h.recorder.snapshot().status).toBe('idle');
+  });
+
+  it('first persisted audio chunk has reset=true, later have reset=false', async () => {
+    const h = makeHarness();
+    await h.recorder.start('/tmp/x.pdf');
+    h.fakeRec.emitChunk(new Uint8Array([1, 2, 3]));
+    h.fakeRec.emitChunk(new Uint8Array([4, 5]));
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(h.audioChunks.map((c) => c.reset)).toEqual([true, false]);
+    await h.recorder.stop();
+  });
+
+  it('does not collect mutations after stop', async () => {
+    const h = makeHarness();
+    await h.recorder.start('/tmp/x.pdf');
+    await h.recorder.stop();
+    const before = h.recorder._inject.events.length;
+    documentStore.addObject(0, stroke('late'));
+    expect(h.recorder._inject.events.length).toBe(before);
+  });
+});

--- a/tests/session-types.test.ts
+++ b/tests/session-types.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import {
+  defaultSessionName,
+  formatDurationMs,
+  isValidSessionId,
+  type Session,
+} from '$lib/session/types';
+
+function sampleSession(): Session {
+  return {
+    id: 'abc-123_XYZ',
+    name: 'Lecture 1',
+    createdAt: 1_700_000_000_000,
+    durationMs: 42_000,
+    audioFile: 'audio.webm',
+    audioMime: 'audio/webm;codecs=opus',
+    events: [
+      { kind: 'pageChange', t: 0, page: 0 },
+      { kind: 'pageChange', t: 5_000, page: 2 },
+      {
+        kind: 'objectDel',
+        t: 6_000,
+        page: 2,
+        ids: ['o1', 'o2'],
+      },
+    ],
+  };
+}
+
+describe('session types', () => {
+  it('JSON round-trip preserves a session', () => {
+    const s = sampleSession();
+    const copy = JSON.parse(JSON.stringify(s)) as Session;
+    expect(copy).toEqual(s);
+  });
+
+  it('isValidSessionId accepts safe ids and rejects traversal', () => {
+    expect(isValidSessionId('abcDEF-123_45')).toBe(true);
+    expect(isValidSessionId('')).toBe(false);
+    expect(isValidSessionId('..')).toBe(false);
+    expect(isValidSessionId('a/b')).toBe(false);
+    expect(isValidSessionId('a\\b')).toBe(false);
+    expect(isValidSessionId('a b')).toBe(false);
+    expect(isValidSessionId('a'.repeat(129))).toBe(false);
+  });
+
+  it('formatDurationMs formats mm:ss with zero padding', () => {
+    expect(formatDurationMs(0)).toBe('00:00');
+    expect(formatDurationMs(5_000)).toBe('00:05');
+    expect(formatDurationMs(65_000)).toBe('01:05');
+    expect(formatDurationMs(599_500)).toBe('10:00');
+  });
+
+  it('defaultSessionName includes date and time', () => {
+    const name = defaultSessionName(Date.UTC(2024, 0, 2, 12, 34));
+    expect(name.startsWith('Session ')).toBe(true);
+    expect(name).toMatch(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/);
+  });
+});


### PR DESCRIPTION
Closes #131.

Phase A of replay feature. Full design in issue #131.

**What you get:**
- Topbar Record button. Records mic audio (Opus in WebM) and a timestamped event log of every document mutation.
- Sessions panel lists all sessions for the open document.
- Clicking a session opens replay: scrubber, play/pause, per-page chapter markers. Strokes animate live (per-point t), audio stays in sync.
- Replay is read-only via a dedicated layer; document is never mutated.
- N sessions per document, stored in `<pdf>.eldraw-sessions/<id>/{events.json, audio.webm}`.

**Tested:**
- 29 new unit tests across session types, events, player seek math, recorder state machine, and documentStore mutation observer
- 578 frontend + 58 Rust tests total, all green
- lint, clippy, fmt clean

**Known follow-ups (to be filed):**
- Long-session audio streaming (currently full-buffer)
- Friendlier mic-permission toast
- Component-level UI tests (need a DOM test env)
- Rename-session UI