### PR TITLE
chore(release): v0.1.0-rc.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eldraw",
-  "version": "0.1.0-rc.11",
+  "version": "0.1.0-rc.12",
   "description": "PDF annotation tool for live math teaching",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1097,7 +1097,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "eldraw"
-version = "0.1.0-rc.11"
+version = "0.1.0-rc.12"
 dependencies = [
  "image",
  "lru",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eldraw"
-version = "0.1.0-rc.11"
+version = "0.1.0-rc.12"
 description = "PDF annotation tool for live math teaching"
 authors = ["Adam"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "eldraw",
-  "version": "0.1.0-rc.11",
+  "version": "0.1.0-rc.12",
   "identifier": "com.adamkadaban.eldraw",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Release v0.1.0-rc.12

Version bump in lockstep across `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, and `Cargo.lock`.

### Changes since rc.11

- **Ink**: stronger max stabilization (#126) — at amount=100, minCutoff 0.4 Hz / beta 1.8e-3 for much smoother strokes
- **View**: F5 now toggles Zen mode + auto-fits to screen; new fit-to-screen button (#127)
- **Ruler**: snap-only mode — ruler no longer blocks drawing; toggle between snap and passthrough (#128)
- **Sidebar**: active brush preset is highlighted (#129)
- **IPC**: sidebar ⇄ main window tool/style bridge now bidirectional (#130)
- **Session (new)**: live replay with synchronized audio recording — Phase A of #131. Record stylus sessions with audio (Opus/WebM), replay with scrubbable timeline, multiple sessions per document stored in `<pdf>.eldraw-sessions/` (#134)

### Verification

All checks green locally:

- `pnpm lint` ✅
- `pnpm test` — 611 tests across 65 files ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo fmt --check` ✅
- `cargo test` — 58 tests ✅