### PR TITLE
feat(graph): visual themes and refined styling for graph objects

### DIFF
--- a/src/lib/canvas/GraphLayer.svelte
+++ b/src/lib/canvas/GraphLayer.svelte
@@ -3,31 +3,33 @@
   import { parseExpression, parseExpressionXY } from '$lib/graph/parser';
   import { plotFunction } from '$lib/graph/plotter';
   import { marchingSquares, stitchSegments } from '$lib/graph/implicit';
-  import { niceStep, generateTicks, formatTick, cappedStep } from '$lib/graph/axes';
+  import { drawGraphFrame } from '$lib/graph/render';
+  import { resolveTheme, type GraphTheme } from '$lib/graph/theme';
+  import { settings } from '$lib/store/settings';
 
   interface Props {
     graphs: GraphObject[];
     width: number;
     height: number;
     ptToPx: number;
+    /** Override the settings-derived theme (used by the preview in settings). */
+    theme?: GraphTheme;
   }
 
-  let { graphs, width, height, ptToPx }: Props = $props();
+  let { graphs, width, height, ptToPx, theme: themeOverride }: Props = $props();
 
   let canvas: HTMLCanvasElement;
 
-  const AXIS_COLOR = '#444';
-  const GRID_MAJOR_COLOR = '#cfcfcf';
-  const GRID_MINOR_COLOR = '#ececec';
-  const LABEL_COLOR = '#555';
-  const FRAME_COLOR = '#888';
   const MAX_SAMPLES = 2048;
   const IMPLICIT_MAX_RES = 256;
-  const TARGET_MAJOR_TICKS = 8;
-  const MINOR_SUBDIVISIONS = 5;
-  const MAX_GRID_LINES_PER_AXIS = 200;
-  const LABEL_FONT = '10px system-ui, -apple-system, "Segoe UI", sans-serif';
-  const LABEL_PAD = 3;
+
+  const resolvedTheme = $derived(
+    themeOverride ??
+      resolveTheme({
+        graphTheme: $settings.graphTheme,
+        graphOverrides: $settings.graphOverrides,
+      }),
+  );
 
   function dashFor(d: 'solid' | 'dashed' | 'dotted', strokeWidth: number): number[] {
     if (d === 'dashed') return [strokeWidth * 4, strokeWidth * 3];
@@ -35,156 +37,34 @@
     return [];
   }
 
-  function drawGraph(ctx: CanvasRenderingContext2D, g: GraphObject) {
+  function drawGraph(ctx: CanvasRenderingContext2D, g: GraphObject, theme: GraphTheme) {
     const px = g.bounds.x * ptToPx;
     const py = g.bounds.y * ptToPx;
     const pw = g.bounds.w * ptToPx;
     const ph = g.bounds.h * ptToPx;
     if (pw < 2 || ph < 2) return;
 
+    const [x0, x1] = g.xRange;
+    const [y0, y1] = g.yRange;
+    if (x1 - x0 <= 0 || y1 - y0 <= 0) return;
+
+    drawGraphFrame(ctx, {
+      rect: { x: px, y: py, w: pw, h: ph },
+      xRange: g.xRange,
+      yRange: g.yRange,
+      theme,
+      gridStep: g.gridStep,
+      showAxes: g.showAxes,
+      showGrid: g.showGrid,
+    });
+
     ctx.save();
     ctx.beginPath();
     ctx.rect(px, py, pw, ph);
     ctx.clip();
 
-    ctx.fillStyle = '#ffffff';
-    ctx.fillRect(px, py, pw, ph);
-
-    const [x0, x1] = g.xRange;
-    const [y0, y1] = g.yRange;
-    const xSpan = x1 - x0;
-    const ySpan = y1 - y0;
-    if (xSpan <= 0 || ySpan <= 0) {
-      ctx.restore();
-      return;
-    }
-
-    const xToPx = (x: number) => px + ((x - x0) / xSpan) * pw;
-    const yToPx = (y: number) => py + (1 - (y - y0) / ySpan) * ph;
-
-    const userStep = Number.isFinite(g.gridStep) && g.gridStep > 0 ? g.gridStep : null;
-    const majorXStep = cappedStep(
-      xSpan,
-      userStep ?? niceStep(xSpan, TARGET_MAJOR_TICKS),
-      MAX_GRID_LINES_PER_AXIS,
-    );
-    const majorYStep = cappedStep(
-      ySpan,
-      userStep ?? niceStep(ySpan, TARGET_MAJOR_TICKS),
-      MAX_GRID_LINES_PER_AXIS,
-    );
-    const rawMinorX = majorXStep / MINOR_SUBDIVISIONS;
-    const rawMinorY = majorYStep / MINOR_SUBDIVISIONS;
-    const drawMinorX = rawMinorX > 0 && xSpan / rawMinorX <= MAX_GRID_LINES_PER_AXIS;
-    const drawMinorY = rawMinorY > 0 && ySpan / rawMinorY <= MAX_GRID_LINES_PER_AXIS;
-
-    if (g.showGrid) {
-      ctx.lineWidth = 1;
-      if (drawMinorX || drawMinorY) {
-        ctx.strokeStyle = GRID_MINOR_COLOR;
-        ctx.beginPath();
-        if (drawMinorX) {
-          for (const x of generateTicks(x0, x1, rawMinorX)) {
-            const sx = xToPx(x);
-            ctx.moveTo(sx, py);
-            ctx.lineTo(sx, py + ph);
-          }
-        }
-        if (drawMinorY) {
-          for (const y of generateTicks(y0, y1, rawMinorY)) {
-            const sy = yToPx(y);
-            ctx.moveTo(px, sy);
-            ctx.lineTo(px + pw, sy);
-          }
-        }
-        ctx.stroke();
-      }
-
-      ctx.strokeStyle = GRID_MAJOR_COLOR;
-      ctx.beginPath();
-      for (const x of generateTicks(x0, x1, majorXStep)) {
-        const sx = xToPx(x);
-        ctx.moveTo(sx, py);
-        ctx.lineTo(sx, py + ph);
-      }
-      for (const y of generateTicks(y0, y1, majorYStep)) {
-        const sy = yToPx(y);
-        ctx.moveTo(px, sy);
-        ctx.lineTo(px + pw, sy);
-      }
-      ctx.stroke();
-    }
-
-    const xAxisVisible = y0 <= 0 && y1 >= 0;
-    const yAxisVisible = x0 <= 0 && x1 >= 0;
-
-    if (g.showAxes) {
-      ctx.strokeStyle = AXIS_COLOR;
-      ctx.lineWidth = 1.25;
-      ctx.beginPath();
-      if (xAxisVisible) {
-        const axisY = yToPx(0);
-        ctx.moveTo(px, axisY);
-        ctx.lineTo(px + pw, axisY);
-      }
-      if (yAxisVisible) {
-        const axisX = xToPx(0);
-        ctx.moveTo(axisX, py);
-        ctx.lineTo(axisX, py + ph);
-      }
-      ctx.stroke();
-
-      ctx.fillStyle = LABEL_COLOR;
-      ctx.font = LABEL_FONT;
-
-      if (xAxisVisible) {
-        const axisY = yToPx(0);
-        const nearBottom = py + ph - axisY < LABEL_PAD + 12;
-        const tickLabelY = nearBottom
-          ? Math.max(axisY - LABEL_PAD, py + LABEL_PAD)
-          : Math.min(axisY + LABEL_PAD, py + ph - LABEL_PAD);
-        ctx.textAlign = 'center';
-        ctx.textBaseline = nearBottom ? 'bottom' : 'top';
-        for (const x of generateTicks(x0, x1, majorXStep)) {
-          if (yAxisVisible && Math.abs(x) < majorXStep * 1e-6) continue;
-          ctx.fillText(formatTick(x, majorXStep), xToPx(x), tickLabelY);
-        }
-        const nearTop = axisY - py < LABEL_PAD + 12;
-        const xLabelY = nearTop
-          ? Math.min(axisY + LABEL_PAD, py + ph - LABEL_PAD)
-          : Math.max(axisY - LABEL_PAD, py + LABEL_PAD);
-        ctx.textAlign = 'right';
-        ctx.textBaseline = nearTop ? 'top' : 'alphabetic';
-        ctx.fillText('x', px + pw - LABEL_PAD, xLabelY);
-      }
-
-      if (yAxisVisible) {
-        const axisX = xToPx(0);
-        const nearLeft = axisX - px < LABEL_PAD + 16;
-        const nearRight = px + pw - axisX < LABEL_PAD + 16;
-        const tickLabelX = nearLeft
-          ? Math.min(axisX + LABEL_PAD, px + pw - LABEL_PAD)
-          : Math.max(axisX - LABEL_PAD, px + LABEL_PAD);
-        ctx.textAlign = nearLeft ? 'left' : 'right';
-        ctx.textBaseline = 'middle';
-        for (const y of generateTicks(y0, y1, majorYStep)) {
-          if (xAxisVisible && Math.abs(y) < majorYStep * 1e-6) continue;
-          ctx.fillText(formatTick(y, majorYStep), tickLabelX, yToPx(y));
-        }
-        const yLabelX = nearRight
-          ? Math.max(axisX - LABEL_PAD, px + LABEL_PAD)
-          : Math.min(axisX + LABEL_PAD, px + pw - LABEL_PAD);
-        ctx.textAlign = nearRight ? 'right' : 'left';
-        ctx.textBaseline = 'top';
-        ctx.fillText('y', yLabelX, py + LABEL_PAD);
-      }
-
-      if (xAxisVisible && yAxisVisible) {
-        ctx.textAlign = 'right';
-        ctx.textBaseline = 'top';
-        ctx.fillText('0', xToPx(0) - LABEL_PAD, yToPx(0) + LABEL_PAD);
-      }
-    }
+    const xToPx = (x: number) => px + ((x - x0) / (x1 - x0)) * pw;
+    const yToPx = (y: number) => py + (1 - (y - y0) / (y1 - y0)) * ph;
 
     const samples = Math.min(MAX_SAMPLES, Math.max(64, Math.ceil(pw)));
     const implicitRes = Math.min(IMPLICIT_MAX_RES, Math.max(32, Math.ceil(pw / 4)));
@@ -237,10 +117,6 @@
     }
 
     ctx.restore();
-
-    ctx.strokeStyle = FRAME_COLOR;
-    ctx.lineWidth = 1;
-    ctx.strokeRect(px + 0.5, py + 0.5, pw - 1, ph - 1);
   }
 
   function redraw() {
@@ -248,7 +124,8 @@
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
     ctx.clearRect(0, 0, canvas.width, canvas.height);
-    for (const g of graphs) drawGraph(ctx, g);
+    const theme = resolvedTheme;
+    for (const g of graphs) drawGraph(ctx, g, theme);
   }
 
   $effect(() => {
@@ -256,6 +133,7 @@
     void width;
     void height;
     void ptToPx;
+    void resolvedTheme;
     redraw();
   });
 </script>

--- a/src/lib/graph/render.ts
+++ b/src/lib/graph/render.ts
@@ -1,0 +1,371 @@
+/**
+ * Canvas rendering of axes/grid/labels for a graph object. Split out from
+ * `GraphLayer.svelte` so the settings preview can reuse the exact same
+ * styling rules.
+ *
+ * Inputs are pure data (`GraphTheme` + rectangle + ranges). The function
+ * mutates the supplied 2D context but restores its state on exit.
+ */
+
+import { generateTicks, formatTick, cappedStep, niceStep } from './axes';
+import type { GraphTheme } from './theme';
+
+export interface GraphRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface DrawFrameOptions {
+  rect: GraphRect;
+  xRange: [number, number];
+  yRange: [number, number];
+  theme: GraphTheme;
+  /** Explicit grid step in graph units. `null`/`0` ⇒ derive from range. */
+  gridStep?: number | null;
+  showAxes: boolean;
+  showGrid: boolean;
+}
+
+const TARGET_MAJOR_TICKS = 8;
+const MAX_GRID_LINES_PER_AXIS = 200;
+const LABEL_PAD = 3;
+const ARROW_LEN = 8;
+const ARROW_HALF = 3.5;
+
+export function snapLine(v: number, width: number): number {
+  const integral = Math.round(width);
+  if (Math.abs(width - integral) < 0.05 && integral % 2 === 1) {
+    return Math.round(v) + 0.5;
+  }
+  return Math.round(v);
+}
+
+function withAlpha(ctx: CanvasRenderingContext2D, a: number, body: () => void): void {
+  if (a >= 1) {
+    body();
+    return;
+  }
+  const prev = ctx.globalAlpha;
+  ctx.globalAlpha = prev * a;
+  body();
+  ctx.globalAlpha = prev;
+}
+
+function axisLabelFontFamily(theme: GraphTheme): string {
+  if (theme.axisLabelStyle === 'italic-serif') {
+    return '"Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif';
+  }
+  return theme.labelFontFamily;
+}
+
+function axisLabelFont(theme: GraphTheme): string {
+  const size = Math.max(10, theme.labelFontSize + 1);
+  return `italic ${size}px ${axisLabelFontFamily(theme)}`;
+}
+
+function tickLabelFont(theme: GraphTheme): string {
+  return `${theme.labelFontSize}px ${theme.labelFontFamily}`;
+}
+
+export interface StepPair {
+  majorXStep: number;
+  majorYStep: number;
+  minorXStep: number;
+  minorYStep: number;
+  drawMinorX: boolean;
+  drawMinorY: boolean;
+}
+
+export function computeSteps(
+  xRange: [number, number],
+  yRange: [number, number],
+  theme: GraphTheme,
+  gridStep?: number | null,
+): StepPair {
+  const xSpan = xRange[1] - xRange[0];
+  const ySpan = yRange[1] - yRange[0];
+  const user =
+    Number.isFinite(gridStep ?? NaN) && (gridStep ?? 0) > 0 ? (gridStep as number) : null;
+  const majorXStep = cappedStep(
+    xSpan,
+    user ?? niceStep(xSpan, TARGET_MAJOR_TICKS),
+    MAX_GRID_LINES_PER_AXIS,
+  );
+  const majorYStep = cappedStep(
+    ySpan,
+    user ?? niceStep(ySpan, TARGET_MAJOR_TICKS),
+    MAX_GRID_LINES_PER_AXIS,
+  );
+  const subs = Math.max(1, Math.floor(theme.gridMinor.subdivisions || 1));
+  const minorXStep = majorXStep / subs;
+  const minorYStep = majorYStep / subs;
+  const drawMinorX =
+    theme.gridMinor.enabled && minorXStep > 0 && xSpan / minorXStep <= MAX_GRID_LINES_PER_AXIS;
+  const drawMinorY =
+    theme.gridMinor.enabled && minorYStep > 0 && ySpan / minorYStep <= MAX_GRID_LINES_PER_AXIS;
+  return { majorXStep, majorYStep, minorXStep, minorYStep, drawMinorX, drawMinorY };
+}
+
+export function drawGraphFrame(ctx: CanvasRenderingContext2D, opts: DrawFrameOptions): void {
+  const { rect, xRange, yRange, theme, gridStep, showAxes, showGrid } = opts;
+  const { x: px, y: py, w: pw, h: ph } = rect;
+  if (pw < 2 || ph < 2) return;
+
+  const [x0, x1] = xRange;
+  const [y0, y1] = yRange;
+  const xSpan = x1 - x0;
+  const ySpan = y1 - y0;
+  if (xSpan <= 0 || ySpan <= 0) return;
+
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(px, py, pw, ph);
+  ctx.clip();
+
+  if (theme.backgroundEnabled) {
+    ctx.fillStyle = theme.background;
+    ctx.fillRect(px, py, pw, ph);
+  }
+
+  const xToPx = (x: number) => px + ((x - x0) / xSpan) * pw;
+  const yToPx = (y: number) => py + (1 - (y - y0) / ySpan) * ph;
+
+  const steps = computeSteps(xRange, yRange, theme, gridStep);
+  const { majorXStep, majorYStep, minorXStep, minorYStep, drawMinorX, drawMinorY } = steps;
+
+  if (showGrid && theme.gridMinor.enabled && (drawMinorX || drawMinorY)) {
+    const minor = theme.gridMinor;
+    withAlpha(ctx, minor.opacity, () => {
+      ctx.lineWidth = minor.width;
+      ctx.strokeStyle = minor.color;
+      ctx.beginPath();
+      if (drawMinorX) {
+        for (const x of generateTicks(x0, x1, minorXStep)) {
+          const sx = snapLine(xToPx(x), minor.width);
+          ctx.moveTo(sx, py);
+          ctx.lineTo(sx, py + ph);
+        }
+      }
+      if (drawMinorY) {
+        for (const y of generateTicks(y0, y1, minorYStep)) {
+          const sy = snapLine(yToPx(y), minor.width);
+          ctx.moveTo(px, sy);
+          ctx.lineTo(px + pw, sy);
+        }
+      }
+      ctx.stroke();
+    });
+  }
+
+  if (showGrid && theme.gridMajor.enabled) {
+    const major = theme.gridMajor;
+    withAlpha(ctx, major.opacity, () => {
+      ctx.lineWidth = major.width;
+      ctx.strokeStyle = major.color;
+      ctx.beginPath();
+      for (const x of generateTicks(x0, x1, majorXStep)) {
+        const sx = snapLine(xToPx(x), major.width);
+        ctx.moveTo(sx, py);
+        ctx.lineTo(sx, py + ph);
+      }
+      for (const y of generateTicks(y0, y1, majorYStep)) {
+        const sy = snapLine(yToPx(y), major.width);
+        ctx.moveTo(px, sy);
+        ctx.lineTo(px + pw, sy);
+      }
+      ctx.stroke();
+    });
+  }
+
+  const xAxisVisible = y0 <= 0 && y1 >= 0;
+  const yAxisVisible = x0 <= 0 && x1 >= 0;
+
+  if (showAxes) {
+    ctx.strokeStyle = theme.axisColor;
+    ctx.lineWidth = theme.axisWidth;
+    ctx.beginPath();
+    if (xAxisVisible) {
+      const axisY = snapLine(yToPx(0), theme.axisWidth);
+      ctx.moveTo(px, axisY);
+      ctx.lineTo(px + pw, axisY);
+    }
+    if (yAxisVisible) {
+      const axisX = snapLine(xToPx(0), theme.axisWidth);
+      ctx.moveTo(axisX, py);
+      ctx.lineTo(axisX, py + ph);
+    }
+    ctx.stroke();
+
+    if (theme.axisArrowheads) {
+      ctx.fillStyle = theme.axisColor;
+      if (xAxisVisible) {
+        const axisY = yToPx(0);
+        drawArrowhead(ctx, px + pw, axisY, 1, 0);
+        drawArrowhead(ctx, px, axisY, -1, 0);
+      }
+      if (yAxisVisible) {
+        const axisX = xToPx(0);
+        drawArrowhead(ctx, axisX, py, 0, -1);
+        drawArrowhead(ctx, axisX, py + ph, 0, 1);
+      }
+    }
+
+    if (theme.tickLength > 0) {
+      ctx.strokeStyle = theme.axisColor;
+      ctx.lineWidth = theme.axisWidth;
+      ctx.beginPath();
+      const half = theme.tickLength / 2;
+      if (xAxisVisible) {
+        const axisY = yToPx(0);
+        for (const x of generateTicks(x0, x1, majorXStep)) {
+          if (yAxisVisible && Math.abs(x) < majorXStep * 1e-6) continue;
+          const sx = snapLine(xToPx(x), theme.axisWidth);
+          ctx.moveTo(sx, axisY - half);
+          ctx.lineTo(sx, axisY + half);
+        }
+      }
+      if (yAxisVisible) {
+        const axisX = xToPx(0);
+        for (const y of generateTicks(y0, y1, majorYStep)) {
+          if (xAxisVisible && Math.abs(y) < majorYStep * 1e-6) continue;
+          const sy = snapLine(yToPx(y), theme.axisWidth);
+          ctx.moveTo(axisX - half, sy);
+          ctx.lineTo(axisX + half, sy);
+        }
+      }
+      ctx.stroke();
+    }
+
+    drawTickAndAxisLabels(ctx, {
+      rect,
+      xRange,
+      yRange,
+      theme,
+      steps,
+      xAxisVisible,
+      yAxisVisible,
+      xToPx,
+      yToPx,
+    });
+  }
+
+  ctx.restore();
+
+  if (theme.frameEnabled) {
+    ctx.strokeStyle = theme.frameColor;
+    ctx.lineWidth = 1;
+    ctx.strokeRect(px + 0.5, py + 0.5, pw - 1, ph - 1);
+  }
+}
+
+function drawArrowhead(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  dirX: number,
+  dirY: number,
+): void {
+  const tipX = x;
+  const tipY = y;
+  const baseX = tipX - dirX * ARROW_LEN;
+  const baseY = tipY - dirY * ARROW_LEN;
+  // Perpendicular vector (rotate direction 90°).
+  const perpX = -dirY;
+  const perpY = dirX;
+  ctx.beginPath();
+  ctx.moveTo(tipX, tipY);
+  ctx.lineTo(baseX + perpX * ARROW_HALF, baseY + perpY * ARROW_HALF);
+  ctx.lineTo(baseX - perpX * ARROW_HALF, baseY - perpY * ARROW_HALF);
+  ctx.closePath();
+  ctx.fill();
+}
+
+interface LabelContext {
+  rect: GraphRect;
+  xRange: [number, number];
+  yRange: [number, number];
+  theme: GraphTheme;
+  steps: StepPair;
+  xAxisVisible: boolean;
+  yAxisVisible: boolean;
+  xToPx: (x: number) => number;
+  yToPx: (y: number) => number;
+}
+
+function drawTickAndAxisLabels(ctx: CanvasRenderingContext2D, lc: LabelContext): void {
+  const { rect, xRange, yRange, theme, steps, xAxisVisible, yAxisVisible, xToPx, yToPx } = lc;
+  const { x: px, y: py, w: pw, h: ph } = rect;
+  const { majorXStep, majorYStep } = steps;
+  const [x0, x1] = xRange;
+  const [y0, y1] = yRange;
+
+  ctx.fillStyle = theme.labelColor;
+  ctx.font = tickLabelFont(theme);
+
+  if (xAxisVisible) {
+    const axisY = yToPx(0);
+    const nearBottom = py + ph - axisY < LABEL_PAD + theme.labelFontSize + 2;
+    const tickLabelY = nearBottom
+      ? Math.max(axisY - LABEL_PAD - Math.max(0, theme.tickLength / 2), py + LABEL_PAD)
+      : Math.min(
+          axisY + LABEL_PAD + Math.max(0, theme.tickLength / 2),
+          py + ph - LABEL_PAD - theme.labelFontSize,
+        );
+    ctx.textAlign = 'center';
+    ctx.textBaseline = nearBottom ? 'bottom' : 'top';
+    for (const x of generateTicks(x0, x1, majorXStep)) {
+      if (yAxisVisible && Math.abs(x) < majorXStep * 1e-6) continue;
+      ctx.fillText(formatTick(x, majorXStep), xToPx(x), tickLabelY);
+    }
+  }
+
+  if (yAxisVisible) {
+    const axisX = xToPx(0);
+    const nearLeft = axisX - px < LABEL_PAD + 16;
+    const tickLabelX = nearLeft
+      ? Math.min(axisX + LABEL_PAD + Math.max(0, theme.tickLength / 2), px + pw - LABEL_PAD)
+      : Math.max(axisX - LABEL_PAD - Math.max(0, theme.tickLength / 2), px + LABEL_PAD);
+    ctx.textAlign = nearLeft ? 'left' : 'right';
+    ctx.textBaseline = 'middle';
+    for (const y of generateTicks(y0, y1, majorYStep)) {
+      if (xAxisVisible && Math.abs(y) < majorYStep * 1e-6) continue;
+      ctx.fillText(formatTick(y, majorYStep), tickLabelX, yToPx(y));
+    }
+  }
+
+  if (theme.axisLabelStyle !== 'none') {
+    ctx.font = axisLabelFont(theme);
+    ctx.fillStyle = theme.labelColor;
+    if (xAxisVisible) {
+      const axisY = yToPx(0);
+      const nearTop = axisY - py < LABEL_PAD + 14;
+      const xLabelY = nearTop
+        ? Math.min(axisY + LABEL_PAD, py + ph - LABEL_PAD)
+        : Math.max(axisY - LABEL_PAD, py + LABEL_PAD);
+      ctx.textAlign = 'right';
+      ctx.textBaseline = nearTop ? 'top' : 'alphabetic';
+      ctx.fillText('x', px + pw - LABEL_PAD - (theme.axisArrowheads ? ARROW_LEN : 0), xLabelY);
+    }
+    if (yAxisVisible) {
+      const axisX = xToPx(0);
+      const nearRight = px + pw - axisX < LABEL_PAD + 16;
+      const yLabelX = nearRight
+        ? Math.max(axisX - LABEL_PAD, px + LABEL_PAD)
+        : Math.min(axisX + LABEL_PAD, px + pw - LABEL_PAD);
+      ctx.textAlign = nearRight ? 'right' : 'left';
+      ctx.textBaseline = 'top';
+      ctx.fillText('y', yLabelX, py + LABEL_PAD + (theme.axisArrowheads ? ARROW_LEN : 0));
+    }
+  }
+
+  if (xAxisVisible && yAxisVisible && theme.originLabel !== 'none') {
+    ctx.font = tickLabelFont(theme);
+    ctx.fillStyle = theme.labelColor;
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'top';
+    const label = theme.originLabel === 'coords' ? '(0, 0)' : 'O';
+    ctx.fillText(label, xToPx(0) - LABEL_PAD, yToPx(0) + LABEL_PAD);
+  }
+}

--- a/src/lib/graph/render.ts
+++ b/src/lib/graph/render.ts
@@ -254,9 +254,11 @@ export function drawGraphFrame(ctx: CanvasRenderingContext2D, opts: DrawFrameOpt
   ctx.restore();
 
   if (theme.frameEnabled) {
+    ctx.save();
     ctx.strokeStyle = theme.frameColor;
     ctx.lineWidth = 1;
     ctx.strokeRect(px + 0.5, py + 0.5, pw - 1, ph - 1);
+    ctx.restore();
   }
 }
 

--- a/src/lib/graph/theme.ts
+++ b/src/lib/graph/theme.ts
@@ -1,0 +1,257 @@
+/**
+ * Graph visual themes — types, built-in presets, and resolution helpers.
+ *
+ * A `GraphTheme` is plain data consumed by `GraphLayer` and the preview in
+ * settings. Presets live in `GRAPH_THEME_PRESETS`; user tuning is expressed
+ * as a deep-partial `GraphThemeOverrides` and merged on top via
+ * {@link resolveTheme}.
+ */
+
+export type GraphPresetName = 'classic' | 'textbook' | 'blueprint' | 'minimal' | 'graphPaper';
+
+export type OriginLabelMode = 'none' | 'letter' | 'coords';
+export type AxisLabelStyle = 'italic-serif' | 'italic-sans' | 'none';
+
+export interface GridStrokeTheme {
+  enabled: boolean;
+  color: string;
+  width: number;
+  opacity: number;
+}
+
+export interface MinorGridTheme extends GridStrokeTheme {
+  /** Minor divisions per major cell (default 5 ⇒ `majorStep / 5`). */
+  subdivisions: number;
+}
+
+export interface GraphTheme {
+  background: string;
+  backgroundEnabled: boolean;
+  frameColor: string;
+  frameEnabled: boolean;
+
+  axisColor: string;
+  axisWidth: number;
+  axisArrowheads: boolean;
+
+  /** Length in px of tick marks drawn on the axis itself. `0` disables them. */
+  tickLength: number;
+
+  gridMajor: GridStrokeTheme;
+  gridMinor: MinorGridTheme;
+
+  labelColor: string;
+  labelFontFamily: string;
+  labelFontSize: number;
+
+  axisLabelStyle: AxisLabelStyle;
+  originLabel: OriginLabelMode;
+
+  curveDefaultWidth: number;
+}
+
+export type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K];
+};
+
+export type GraphThemeOverrides = DeepPartial<GraphTheme>;
+
+const SANS = 'system-ui, -apple-system, "Segoe UI", sans-serif';
+const SERIF = '"Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif';
+
+const classic: GraphTheme = {
+  background: '#ffffff',
+  backgroundEnabled: true,
+  frameColor: '#888888',
+  frameEnabled: true,
+
+  axisColor: '#3a3a3a',
+  axisWidth: 1.25,
+  axisArrowheads: false,
+  tickLength: 0,
+
+  gridMajor: { enabled: true, color: '#cfcfcf', width: 1, opacity: 1 },
+  gridMinor: { enabled: true, color: '#ececec', width: 1, opacity: 1, subdivisions: 5 },
+
+  labelColor: '#555555',
+  labelFontFamily: SANS,
+  labelFontSize: 10,
+
+  axisLabelStyle: 'italic-serif',
+  originLabel: 'none',
+  curveDefaultWidth: 2,
+};
+
+const textbook: GraphTheme = {
+  background: '#ffffff',
+  backgroundEnabled: true,
+  frameColor: '#000000',
+  frameEnabled: false,
+
+  axisColor: '#111111',
+  axisWidth: 1.5,
+  axisArrowheads: true,
+  tickLength: 4,
+
+  gridMajor: { enabled: true, color: '#d6d6d6', width: 1, opacity: 1 },
+  gridMinor: { enabled: false, color: '#ebebeb', width: 1, opacity: 1, subdivisions: 5 },
+
+  labelColor: '#111111',
+  labelFontFamily: SERIF,
+  labelFontSize: 11,
+
+  axisLabelStyle: 'italic-serif',
+  originLabel: 'letter',
+  curveDefaultWidth: 2,
+};
+
+const blueprint: GraphTheme = {
+  background: '#0d2340',
+  backgroundEnabled: true,
+  frameColor: '#2b4a74',
+  frameEnabled: true,
+
+  axisColor: '#f2f6fb',
+  axisWidth: 1.25,
+  axisArrowheads: true,
+  tickLength: 4,
+
+  gridMajor: { enabled: true, color: '#6fb6d9', width: 1, opacity: 0.45 },
+  gridMinor: { enabled: true, color: '#6fb6d9', width: 1, opacity: 0.18, subdivisions: 5 },
+
+  labelColor: '#e9f1fb',
+  labelFontFamily: SANS,
+  labelFontSize: 10,
+
+  axisLabelStyle: 'italic-serif',
+  originLabel: 'letter',
+  curveDefaultWidth: 2.25,
+};
+
+const minimal: GraphTheme = {
+  background: '#ffffff',
+  backgroundEnabled: false,
+  frameColor: '#000000',
+  frameEnabled: false,
+
+  axisColor: '#222222',
+  axisWidth: 1,
+  axisArrowheads: false,
+  tickLength: 4,
+
+  gridMajor: { enabled: false, color: '#e5e5e5', width: 1, opacity: 1 },
+  gridMinor: { enabled: false, color: '#f1f1f1', width: 1, opacity: 1, subdivisions: 5 },
+
+  labelColor: '#333333',
+  labelFontFamily: SANS,
+  labelFontSize: 10,
+
+  axisLabelStyle: 'italic-serif',
+  originLabel: 'none',
+  curveDefaultWidth: 2,
+};
+
+const graphPaper: GraphTheme = {
+  background: '#fff6e6',
+  backgroundEnabled: true,
+  frameColor: '#d8bc8a',
+  frameEnabled: true,
+
+  axisColor: '#a23b1f',
+  axisWidth: 1.25,
+  axisArrowheads: false,
+  tickLength: 0,
+
+  gridMajor: { enabled: true, color: '#d97a4d', width: 1, opacity: 0.55 },
+  gridMinor: { enabled: true, color: '#d97a4d', width: 1, opacity: 0.22, subdivisions: 5 },
+
+  labelColor: '#6b4226',
+  labelFontFamily: SERIF,
+  labelFontSize: 10,
+
+  axisLabelStyle: 'italic-serif',
+  originLabel: 'none',
+  curveDefaultWidth: 2,
+};
+
+export const GRAPH_THEME_PRESETS: Readonly<Record<GraphPresetName, GraphTheme>> = Object.freeze({
+  classic,
+  textbook,
+  blueprint,
+  minimal,
+  graphPaper,
+});
+
+export const GRAPH_PRESET_ORDER: readonly GraphPresetName[] = [
+  'classic',
+  'textbook',
+  'blueprint',
+  'minimal',
+  'graphPaper',
+];
+
+export const GRAPH_PRESET_LABELS: Readonly<Record<GraphPresetName, string>> = {
+  classic: 'Classic',
+  textbook: 'Textbook',
+  blueprint: 'Blueprint',
+  minimal: 'Minimal',
+  graphPaper: 'Graph paper',
+};
+
+export const DEFAULT_GRAPH_PRESET: GraphPresetName = 'classic';
+
+export interface AppearanceThemeInput {
+  graphTheme?: GraphPresetName;
+  graphOverrides?: GraphThemeOverrides;
+}
+
+/**
+ * Clone a preset and deep-merge `overrides` on top. Overrides that are
+ * `undefined` or not plain objects are ignored — the preset value wins.
+ */
+export function resolveTheme(appearance: AppearanceThemeInput | undefined | null): GraphTheme {
+  const name = appearance?.graphTheme;
+  const base =
+    name && name in GRAPH_THEME_PRESETS
+      ? GRAPH_THEME_PRESETS[name]
+      : GRAPH_THEME_PRESETS[DEFAULT_GRAPH_PRESET];
+  const overrides = appearance?.graphOverrides;
+  return mergeTheme(base, overrides);
+}
+
+export function mergeTheme(base: GraphTheme, overrides?: GraphThemeOverrides | null): GraphTheme {
+  const merged = cloneTheme(base);
+  if (!overrides || typeof overrides !== 'object') return merged;
+  mergeInto(merged as unknown as Record<string, unknown>, overrides as Record<string, unknown>);
+  return merged;
+}
+
+function cloneTheme(t: GraphTheme): GraphTheme {
+  return {
+    ...t,
+    gridMajor: { ...t.gridMajor },
+    gridMinor: { ...t.gridMinor },
+  };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function mergeInto(target: Record<string, unknown>, patch: Record<string, unknown>): void {
+  for (const key of Object.keys(patch)) {
+    const incoming = patch[key];
+    if (incoming === undefined) continue;
+    const current = target[key];
+    if (isPlainObject(current) && isPlainObject(incoming)) {
+      mergeInto(current, incoming);
+    } else {
+      target[key] = incoming;
+    }
+  }
+}
+
+/** Does this value look like a valid preset name? */
+export function isGraphPresetName(v: unknown): v is GraphPresetName {
+  return typeof v === 'string' && v in GRAPH_THEME_PRESETS;
+}

--- a/src/lib/graph/theme.ts
+++ b/src/lib/graph/theme.ts
@@ -212,7 +212,7 @@ export interface AppearanceThemeInput {
 export function resolveTheme(appearance: AppearanceThemeInput | undefined | null): GraphTheme {
   const name = appearance?.graphTheme;
   const base =
-    name && name in GRAPH_THEME_PRESETS
+    name && Object.hasOwn(GRAPH_THEME_PRESETS, name)
       ? GRAPH_THEME_PRESETS[name]
       : GRAPH_THEME_PRESETS[DEFAULT_GRAPH_PRESET];
   const overrides = appearance?.graphOverrides;
@@ -240,18 +240,21 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 
 function mergeInto(target: Record<string, unknown>, patch: Record<string, unknown>): void {
   for (const key of Object.keys(patch)) {
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;
     const incoming = patch[key];
     if (incoming === undefined) continue;
     const current = target[key];
-    if (isPlainObject(current) && isPlainObject(incoming)) {
-      mergeInto(current, incoming);
-    } else {
-      target[key] = incoming;
+    if (isPlainObject(current)) {
+      if (isPlainObject(incoming)) {
+        mergeInto(current, incoming);
+      }
+      continue;
     }
+    target[key] = incoming;
   }
 }
 
 /** Does this value look like a valid preset name? */
 export function isGraphPresetName(v: unknown): v is GraphPresetName {
-  return typeof v === 'string' && v in GRAPH_THEME_PRESETS;
+  return typeof v === 'string' && Object.hasOwn(GRAPH_THEME_PRESETS, v);
 }

--- a/src/lib/settings/AppearanceSettings.svelte
+++ b/src/lib/settings/AppearanceSettings.svelte
@@ -1,0 +1,107 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import GraphStyleSection from './GraphStyleSection.svelte';
+
+  interface Props {
+    onClose?: () => void;
+  }
+
+  let { onClose }: Props = $props();
+  let dialog: HTMLDivElement | null = $state(null);
+
+  function onKeyDown(event: KeyboardEvent): void {
+    event.stopPropagation();
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      onClose?.();
+    }
+  }
+
+  onMount(() => {
+    dialog?.focus();
+  });
+</script>
+
+<button
+  type="button"
+  class="backdrop"
+  aria-label="Close appearance settings"
+  onclick={() => onClose?.()}
+></button>
+
+<div
+  class="dialog"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="appearance-title"
+  bind:this={dialog}
+  tabindex="-1"
+  onkeydown={onKeyDown}
+>
+  <header class="dialog-header">
+    <h2 id="appearance-title">Appearance</h2>
+    <button type="button" class="close" onclick={() => onClose?.()} aria-label="Close"> ✕ </button>
+  </header>
+  <div class="body">
+    <GraphStyleSection />
+  </div>
+</div>
+
+<style>
+  .backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    z-index: 1000;
+    border: 0;
+    padding: 0;
+  }
+  .dialog {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: min(520px, 90vw);
+    max-height: 85vh;
+    display: flex;
+    flex-direction: column;
+    background: #1b1b1b;
+    color: #ddd;
+    border: 1px solid #333;
+    border-radius: 8px;
+    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.6);
+    z-index: 1001;
+  }
+  .dialog:focus {
+    outline: none;
+  }
+  .dialog-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 14px;
+    border-bottom: 1px solid #2a2a2a;
+  }
+  .dialog-header h2 {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+  }
+  .close {
+    background: transparent;
+    color: #ddd;
+    border: 1px solid #333;
+    border-radius: 4px;
+    padding: 2px 8px;
+    cursor: pointer;
+    font: inherit;
+  }
+  .close:hover {
+    border-color: #666;
+  }
+  .body {
+    padding: 14px;
+    overflow-y: auto;
+  }
+</style>

--- a/src/lib/settings/GraphStyleSection.svelte
+++ b/src/lib/settings/GraphStyleSection.svelte
@@ -1,0 +1,493 @@
+<script lang="ts">
+  import { settings } from '$lib/store/settings';
+  import {
+    GRAPH_PRESET_LABELS,
+    GRAPH_PRESET_ORDER,
+    GRAPH_THEME_PRESETS,
+    resolveTheme,
+    type GraphPresetName,
+    type GraphTheme,
+    type GraphThemeOverrides,
+  } from '$lib/graph/theme';
+  import { drawGraphFrame } from '$lib/graph/render';
+  import { parseExpression } from '$lib/graph/parser';
+  import { plotFunction } from '$lib/graph/plotter';
+
+  const PREVIEW_W = 280;
+  const PREVIEW_H = 180;
+  const PREVIEW_DEMO_EXPRS: Array<{ expr: string; color: string; width: number }> = [
+    { expr: 'sin(x)', color: '#d94d4d', width: 2 },
+    { expr: '0.5*x', color: '#2e6fcf', width: 2 },
+  ];
+
+  let canvas: HTMLCanvasElement | null = $state(null);
+  let knobsOpen = $state(false);
+
+  const presetName = $derived<GraphPresetName>($settings.graphTheme);
+  const overrides = $derived<GraphThemeOverrides>($settings.graphOverrides ?? {});
+  const theme = $derived<GraphTheme>(
+    resolveTheme({ graphTheme: presetName, graphOverrides: overrides }),
+  );
+
+  function setPreset(name: GraphPresetName): void {
+    settings.setGraphTheme(name);
+  }
+
+  function resetOverrides(): void {
+    settings.resetGraphOverrides();
+  }
+
+  function updateOverride(patch: GraphThemeOverrides): void {
+    const next: GraphThemeOverrides = deepMerge(overrides, patch);
+    settings.setGraphOverrides(next);
+  }
+
+  function deepMerge(a: GraphThemeOverrides, b: GraphThemeOverrides): GraphThemeOverrides {
+    const out: Record<string, unknown> = { ...(a as Record<string, unknown>) };
+    for (const k of Object.keys(b)) {
+      const incoming = (b as Record<string, unknown>)[k];
+      const current = out[k];
+      if (
+        incoming &&
+        typeof incoming === 'object' &&
+        !Array.isArray(incoming) &&
+        current &&
+        typeof current === 'object' &&
+        !Array.isArray(current)
+      ) {
+        out[k] = deepMerge(current as GraphThemeOverrides, incoming as GraphThemeOverrides);
+      } else {
+        out[k] = incoming;
+      }
+    }
+    return out as GraphThemeOverrides;
+  }
+
+  function drawPreview(): void {
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const dpr = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
+    canvas.width = Math.round(PREVIEW_W * dpr);
+    canvas.height = Math.round(PREVIEW_H * dpr);
+    canvas.style.width = `${PREVIEW_W}px`;
+    canvas.style.height = `${PREVIEW_H}px`;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, PREVIEW_W, PREVIEW_H);
+
+    const rect = { x: 0, y: 0, w: PREVIEW_W, h: PREVIEW_H };
+    const xRange: [number, number] = [-6, 6];
+    const yRange: [number, number] = [-3.5, 3.5];
+
+    drawGraphFrame(ctx, {
+      rect,
+      xRange,
+      yRange,
+      theme,
+      gridStep: 0,
+      showAxes: true,
+      showGrid: true,
+    });
+
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(rect.x, rect.y, rect.w, rect.h);
+    ctx.clip();
+    ctx.lineJoin = 'round';
+    ctx.lineCap = 'round';
+
+    const xToPx = (x: number) => ((x - xRange[0]) / (xRange[1] - xRange[0])) * rect.w;
+    const yToPx = (y: number) => (1 - (y - yRange[0]) / (yRange[1] - yRange[0])) * rect.h;
+
+    for (const demo of PREVIEW_DEMO_EXPRS) {
+      const parsed = parseExpression(demo.expr);
+      if (!parsed.ok) continue;
+      ctx.strokeStyle = demo.color;
+      ctx.lineWidth = Math.max(theme.curveDefaultWidth, demo.width);
+      const segments = plotFunction(parsed.fn, { xRange, yRange, samples: 400 });
+      for (const seg of segments) {
+        if (seg.length < 2) continue;
+        ctx.beginPath();
+        ctx.moveTo(xToPx(seg[0].x), yToPx(seg[0].y));
+        for (let i = 1; i < seg.length; i += 1) {
+          ctx.lineTo(xToPx(seg[i].x), yToPx(seg[i].y));
+        }
+        ctx.stroke();
+      }
+    }
+    ctx.restore();
+  }
+
+  $effect(() => {
+    void theme;
+    void presetName;
+    drawPreview();
+  });
+
+  function onColor(key: 'axisColor' | 'labelColor' | 'background', value: string): void {
+    updateOverride({ [key]: value });
+  }
+
+  function onNumber(path: string[], value: number): void {
+    if (!Number.isFinite(value)) return;
+    const patch: Record<string, unknown> = {};
+    let cursor = patch;
+    for (let i = 0; i < path.length - 1; i += 1) {
+      const next: Record<string, unknown> = {};
+      cursor[path[i]] = next;
+      cursor = next;
+    }
+    cursor[path[path.length - 1]] = value;
+    updateOverride(patch as GraphThemeOverrides);
+  }
+
+  function onToggle(path: string[], value: boolean): void {
+    const patch: Record<string, unknown> = {};
+    let cursor = patch;
+    for (let i = 0; i < path.length - 1; i += 1) {
+      const next: Record<string, unknown> = {};
+      cursor[path[i]] = next;
+      cursor = next;
+    }
+    cursor[path[path.length - 1]] = value;
+    updateOverride(patch as GraphThemeOverrides);
+  }
+
+  function onOrigin(value: 'none' | 'letter' | 'coords'): void {
+    updateOverride({ originLabel: value });
+  }
+</script>
+
+<section class="graph-style" aria-label="Graph style">
+  <h3>Graph style</h3>
+
+  <div class="presets" role="radiogroup" aria-label="Graph preset">
+    {#each GRAPH_PRESET_ORDER as name (name)}
+      <button
+        type="button"
+        role="radio"
+        aria-checked={presetName === name}
+        class="preset"
+        class:active={presetName === name}
+        onclick={() => setPreset(name)}
+      >
+        <span
+          class="swatch"
+          aria-hidden="true"
+          style="background: {GRAPH_THEME_PRESETS[name]
+            .background}; border-color: {GRAPH_THEME_PRESETS[name]
+            .frameColor}; color: {GRAPH_THEME_PRESETS[name].axisColor};"
+        >
+          {#each [0.25, 0.5, 0.75] as y (y)}
+            <span
+              class="swatch-line"
+              style="top: {y * 100}%; background: {GRAPH_THEME_PRESETS[name].gridMajor
+                .color}; opacity: {GRAPH_THEME_PRESETS[name].gridMajor.enabled
+                ? GRAPH_THEME_PRESETS[name].gridMajor.opacity
+                : 0};"
+            ></span>
+          {/each}
+        </span>
+        <span class="preset-label">{GRAPH_PRESET_LABELS[name]}</span>
+      </button>
+    {/each}
+  </div>
+
+  <div class="preview-wrap">
+    <canvas bind:this={canvas} aria-label="Graph style preview" data-testid="graph-preview"
+    ></canvas>
+  </div>
+
+  <button
+    type="button"
+    class="knobs-toggle"
+    aria-expanded={knobsOpen}
+    onclick={() => (knobsOpen = !knobsOpen)}
+  >
+    {knobsOpen ? '▾' : '▸'} Tuning
+  </button>
+
+  {#if knobsOpen}
+    <div class="knobs">
+      <label>
+        <span>Axis color</span>
+        <input
+          type="color"
+          value={theme.axisColor}
+          oninput={(e) => onColor('axisColor', (e.currentTarget as HTMLInputElement).value)}
+        />
+      </label>
+      <label>
+        <span>Axis width</span>
+        <input
+          type="range"
+          min="0.5"
+          max="3"
+          step="0.25"
+          value={theme.axisWidth}
+          oninput={(e) =>
+            onNumber(['axisWidth'], Number((e.currentTarget as HTMLInputElement).value))}
+        />
+        <output>{theme.axisWidth.toFixed(2)}</output>
+      </label>
+      <label class="checkbox">
+        <input
+          type="checkbox"
+          checked={theme.axisArrowheads}
+          onchange={(e) =>
+            onToggle(['axisArrowheads'], (e.currentTarget as HTMLInputElement).checked)}
+        />
+        <span>Axis arrowheads</span>
+      </label>
+
+      <label>
+        <span>Major grid color</span>
+        <input
+          type="color"
+          value={theme.gridMajor.color}
+          oninput={(e) =>
+            updateOverride({
+              gridMajor: { color: (e.currentTarget as HTMLInputElement).value },
+            })}
+        />
+      </label>
+      <label>
+        <span>Major grid opacity</span>
+        <input
+          type="range"
+          min="0"
+          max="1"
+          step="0.05"
+          value={theme.gridMajor.opacity}
+          oninput={(e) =>
+            onNumber(['gridMajor', 'opacity'], Number((e.currentTarget as HTMLInputElement).value))}
+        />
+        <output>{theme.gridMajor.opacity.toFixed(2)}</output>
+      </label>
+      <label class="checkbox">
+        <input
+          type="checkbox"
+          checked={theme.gridMinor.enabled}
+          onchange={(e) =>
+            onToggle(['gridMinor', 'enabled'], (e.currentTarget as HTMLInputElement).checked)}
+        />
+        <span>Minor grid</span>
+      </label>
+      <label>
+        <span>Minor subdivisions</span>
+        <input
+          type="number"
+          min="2"
+          max="10"
+          step="1"
+          value={theme.gridMinor.subdivisions}
+          oninput={(e) =>
+            onNumber(
+              ['gridMinor', 'subdivisions'],
+              Number((e.currentTarget as HTMLInputElement).value),
+            )}
+        />
+      </label>
+
+      <label>
+        <span>Background</span>
+        <input
+          type="color"
+          value={theme.background}
+          oninput={(e) => onColor('background', (e.currentTarget as HTMLInputElement).value)}
+        />
+      </label>
+      <label class="checkbox">
+        <input
+          type="checkbox"
+          checked={theme.backgroundEnabled}
+          onchange={(e) =>
+            onToggle(['backgroundEnabled'], (e.currentTarget as HTMLInputElement).checked)}
+        />
+        <span>Fill background</span>
+      </label>
+
+      <label>
+        <span>Label color</span>
+        <input
+          type="color"
+          value={theme.labelColor}
+          oninput={(e) => onColor('labelColor', (e.currentTarget as HTMLInputElement).value)}
+        />
+      </label>
+      <label>
+        <span>Label size</span>
+        <input
+          type="number"
+          min="7"
+          max="20"
+          step="1"
+          value={theme.labelFontSize}
+          oninput={(e) =>
+            onNumber(['labelFontSize'], Number((e.currentTarget as HTMLInputElement).value))}
+        />
+      </label>
+
+      <label>
+        <span>Origin label</span>
+        <select
+          value={theme.originLabel}
+          onchange={(e) =>
+            onOrigin((e.currentTarget as HTMLSelectElement).value as 'none' | 'letter' | 'coords')}
+        >
+          <option value="none">None</option>
+          <option value="letter">O</option>
+          <option value="coords">(0, 0)</option>
+        </select>
+      </label>
+
+      <label>
+        <span>Default curve width</span>
+        <input
+          type="range"
+          min="1"
+          max="4"
+          step="0.25"
+          value={theme.curveDefaultWidth}
+          oninput={(e) =>
+            onNumber(['curveDefaultWidth'], Number((e.currentTarget as HTMLInputElement).value))}
+        />
+        <output>{theme.curveDefaultWidth.toFixed(2)}</output>
+      </label>
+
+      <div class="knobs-actions">
+        <button type="button" class="reset" onclick={resetOverrides}>
+          Reset to {GRAPH_PRESET_LABELS[presetName]}
+        </button>
+      </div>
+    </div>
+  {/if}
+</section>
+
+<style>
+  .graph-style {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  h3 {
+    margin: 0;
+    font-size: 13px;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+  }
+  .presets {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(96px, 1fr));
+    gap: 8px;
+  }
+  .preset {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 6px;
+    background: #1e1e1e;
+    border: 1px solid #333;
+    border-radius: 6px;
+    cursor: pointer;
+    color: #ddd;
+    font-size: 12px;
+    text-align: left;
+  }
+  .preset.active {
+    border-color: #7ab7ff;
+    background: #253246;
+  }
+  .swatch {
+    position: relative;
+    height: 40px;
+    border-radius: 4px;
+    border: 1px solid;
+    overflow: hidden;
+  }
+  .swatch-line {
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: 1px;
+  }
+  .preset-label {
+    font-size: 12px;
+  }
+  .preview-wrap {
+    display: flex;
+    justify-content: center;
+    padding: 6px;
+    background: #111;
+    border: 1px solid #2a2a2a;
+    border-radius: 6px;
+  }
+  .knobs-toggle {
+    align-self: flex-start;
+    background: transparent;
+    border: none;
+    color: #ddd;
+    font: inherit;
+    cursor: pointer;
+    padding: 2px 4px;
+  }
+  .knobs {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px 14px;
+    padding: 8px;
+    background: #1a1a1a;
+    border: 1px solid #2a2a2a;
+    border-radius: 6px;
+  }
+  .knobs label {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 12px;
+    color: #ccc;
+  }
+  .knobs label.checkbox {
+    flex-direction: row;
+    align-items: center;
+    gap: 6px;
+  }
+  .knobs input[type='color'] {
+    width: 100%;
+    height: 24px;
+    padding: 0;
+    border: 1px solid #333;
+    background: #111;
+  }
+  .knobs input[type='number'],
+  .knobs select {
+    background: #111;
+    color: #ddd;
+    border: 1px solid #333;
+    border-radius: 4px;
+    padding: 3px 6px;
+    font: inherit;
+  }
+  .knobs output {
+    font-variant-numeric: tabular-nums;
+    font-size: 11px;
+    color: #999;
+  }
+  .knobs-actions {
+    grid-column: 1 / -1;
+    display: flex;
+    justify-content: flex-end;
+  }
+  .reset {
+    background: #2a2a2a;
+    color: #ddd;
+    border: 1px solid #444;
+    border-radius: 4px;
+    padding: 4px 10px;
+    font: inherit;
+    cursor: pointer;
+  }
+  .reset:hover {
+    border-color: #666;
+  }
+</style>

--- a/src/lib/settings/GraphStyleSection.svelte
+++ b/src/lib/settings/GraphStyleSection.svelte
@@ -19,6 +19,10 @@
     { expr: 'sin(x)', color: '#d94d4d', width: 2 },
     { expr: '0.5*x', color: '#2e6fcf', width: 2 },
   ];
+  const PREVIEW_COMPILED = PREVIEW_DEMO_EXPRS.map((d) => ({
+    ...d,
+    parsed: parseExpression(d.expr),
+  }));
 
   let canvas: HTMLCanvasElement | null = $state(null);
   let knobsOpen = $state(false);
@@ -99,12 +103,11 @@
     const xToPx = (x: number) => ((x - xRange[0]) / (xRange[1] - xRange[0])) * rect.w;
     const yToPx = (y: number) => (1 - (y - yRange[0]) / (yRange[1] - yRange[0])) * rect.h;
 
-    for (const demo of PREVIEW_DEMO_EXPRS) {
-      const parsed = parseExpression(demo.expr);
-      if (!parsed.ok) continue;
+    for (const demo of PREVIEW_COMPILED) {
+      if (!demo.parsed.ok) continue;
       ctx.strokeStyle = demo.color;
       ctx.lineWidth = Math.max(theme.curveDefaultWidth, demo.width);
-      const segments = plotFunction(parsed.fn, { xRange, yRange, samples: 400 });
+      const segments = plotFunction(demo.parsed.fn, { xRange, yRange, samples: 400 });
       for (const seg of segments) {
         if (seg.length < 2) continue;
         ctx.beginPath();

--- a/src/lib/sidebar/Sidebar.svelte
+++ b/src/lib/sidebar/Sidebar.svelte
@@ -7,6 +7,7 @@
   import DashStyleToggle from './DashStyleToggle.svelte';
   import ToolPresets from './ToolPresets.svelte';
   import ShortcutsEditor from '$lib/settings/ShortcutsEditor.svelte';
+  import AppearanceSettings from '$lib/settings/AppearanceSettings.svelte';
   import { applySnap, clampToViewport, detectSnapEdge, type SnapEdge } from './snap';
 
   interface Props {
@@ -121,6 +122,7 @@
   }
 
   let shortcutsOpen = $state(false);
+  let appearanceOpen = $state(false);
 
   function onCapturePreset() {
     sidebar.capturePreset();
@@ -346,6 +348,15 @@
     <button
       type="button"
       class="pin"
+      aria-label="Appearance settings"
+      title="Appearance"
+      onclick={() => (appearanceOpen = true)}
+    >
+      <span aria-hidden="true">🎨</span>
+    </button>
+    <button
+      type="button"
+      class="pin"
       aria-label="Shortcuts settings"
       title="Customize keyboard shortcuts"
       onclick={() => (shortcutsOpen = true)}
@@ -505,6 +516,10 @@
 
 {#if shortcutsOpen}
   <ShortcutsEditor onClose={() => (shortcutsOpen = false)} />
+{/if}
+
+{#if appearanceOpen}
+  <AppearanceSettings onClose={() => (appearanceOpen = false)} />
 {/if}
 
 <style>

--- a/src/lib/store/settings.ts
+++ b/src/lib/store/settings.ts
@@ -1,30 +1,51 @@
 import { get, writable, type Readable } from 'svelte/store';
+import {
+  DEFAULT_GRAPH_PRESET,
+  isGraphPresetName,
+  type GraphPresetName,
+  type GraphThemeOverrides,
+} from '$lib/graph/theme';
 
 export type ReloadBehavior = 'keep' | 'discard';
 
 export interface Settings {
   reloadBehavior: ReloadBehavior;
+  graphTheme: GraphPresetName;
+  graphOverrides: GraphThemeOverrides;
 }
 
-const DEFAULTS: Settings = { reloadBehavior: 'keep' };
+const DEFAULTS: Settings = {
+  reloadBehavior: 'keep',
+  graphTheme: DEFAULT_GRAPH_PRESET,
+  graphOverrides: {},
+};
 const STORAGE_KEY = 'eldraw.settings.v1';
 
 function loadPersisted(): Settings {
-  if (typeof localStorage === 'undefined') return { ...DEFAULTS };
+  if (typeof localStorage === 'undefined') return cloneDefaults();
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return { ...DEFAULTS };
+    if (!raw) return cloneDefaults();
     const parsed: unknown = JSON.parse(raw);
-    if (!parsed || typeof parsed !== 'object') return { ...DEFAULTS };
+    if (!parsed || typeof parsed !== 'object') return cloneDefaults();
     const p = parsed as Record<string, unknown>;
     const reloadBehavior =
       p.reloadBehavior === 'keep' || p.reloadBehavior === 'discard'
         ? p.reloadBehavior
         : DEFAULTS.reloadBehavior;
-    return { reloadBehavior };
+    const graphTheme = isGraphPresetName(p.graphTheme) ? p.graphTheme : DEFAULTS.graphTheme;
+    const graphOverrides =
+      p.graphOverrides && typeof p.graphOverrides === 'object' && !Array.isArray(p.graphOverrides)
+        ? (p.graphOverrides as GraphThemeOverrides)
+        : {};
+    return { reloadBehavior, graphTheme, graphOverrides };
   } catch {
-    return { ...DEFAULTS };
+    return cloneDefaults();
   }
+}
+
+function cloneDefaults(): Settings {
+  return { ...DEFAULTS, graphOverrides: {} };
 }
 
 function persist(s: Settings): void {
@@ -40,6 +61,9 @@ const internal = writable<Settings>(loadPersisted());
 
 export const settings: Readable<Settings> & {
   setReloadBehavior: (b: ReloadBehavior) => void;
+  setGraphTheme: (name: GraphPresetName) => void;
+  setGraphOverrides: (overrides: GraphThemeOverrides) => void;
+  resetGraphOverrides: () => void;
   snapshot: () => Settings;
   reset: () => void;
 } = {
@@ -51,11 +75,32 @@ export const settings: Readable<Settings> & {
       return next;
     });
   },
+  setGraphTheme(name) {
+    internal.update((s) => {
+      const next = { ...s, graphTheme: name };
+      persist(next);
+      return next;
+    });
+  },
+  setGraphOverrides(overrides) {
+    internal.update((s) => {
+      const next = { ...s, graphOverrides: overrides };
+      persist(next);
+      return next;
+    });
+  },
+  resetGraphOverrides() {
+    internal.update((s) => {
+      const next = { ...s, graphOverrides: {} };
+      persist(next);
+      return next;
+    });
+  },
   snapshot() {
     return get(internal);
   },
   reset() {
-    internal.set({ ...DEFAULTS });
+    internal.set(cloneDefaults());
     if (typeof localStorage !== 'undefined') {
       try {
         localStorage.removeItem(STORAGE_KEY);

--- a/tests/graph-render.test.ts
+++ b/tests/graph-render.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect } from 'vitest';
+import { computeSteps, drawGraphFrame, snapLine } from '$lib/graph/render';
+import { GRAPH_THEME_PRESETS, resolveTheme } from '$lib/graph/theme';
+
+describe('snapLine', () => {
+  it('adds a 0.5 offset for 1-px strokes', () => {
+    expect(snapLine(10.3, 1)).toBe(10.5);
+    expect(snapLine(10.8, 1)).toBe(11.5);
+    expect(snapLine(10, 1)).toBe(10.5);
+  });
+
+  it('rounds to integer for 2-px strokes', () => {
+    expect(snapLine(10.3, 2)).toBe(10);
+    expect(snapLine(10.8, 2)).toBe(11);
+  });
+});
+
+describe('computeSteps', () => {
+  it('returns 1/2/5 × 10^n steps for standard ranges', () => {
+    const theme = resolveTheme({ graphTheme: 'classic' });
+    const s = computeSteps([-10, 10], [-10, 10], theme, 0);
+    for (const step of [s.majorXStep, s.majorYStep]) {
+      const exp = Math.floor(Math.log10(step));
+      const m = Math.round(step / 10 ** exp);
+      expect([1, 2, 5]).toContain(m);
+    }
+  });
+
+  it('respects the minor subdivision count from the theme', () => {
+    const theme = resolveTheme({
+      graphTheme: 'classic',
+      graphOverrides: { gridMinor: { subdivisions: 4 } },
+    });
+    const s = computeSteps([-10, 10], [-10, 10], theme, 0);
+    expect(s.minorXStep * 4).toBeCloseTo(s.majorXStep);
+  });
+
+  it('disables minor grid drawing when the theme turns it off', () => {
+    const theme = resolveTheme({ graphTheme: 'minimal' });
+    const s = computeSteps([-10, 10], [-10, 10], theme, 0);
+    expect(s.drawMinorX).toBe(false);
+    expect(s.drawMinorY).toBe(false);
+  });
+
+  it('uses the user gridStep when provided', () => {
+    const theme = resolveTheme({ graphTheme: 'classic' });
+    const s = computeSteps([0, 10], [0, 10], theme, 2);
+    expect(s.majorXStep).toBe(2);
+    expect(s.majorYStep).toBe(2);
+  });
+});
+
+interface FakeCtxRec {
+  type: string;
+  [k: string]: unknown;
+}
+
+function createFakeCtx(): {
+  ctx: CanvasRenderingContext2D;
+  calls: FakeCtxRec[];
+  texts: Array<{ text: string; x: number; y: number; align: string; baseline: string }>;
+} {
+  const calls: FakeCtxRec[] = [];
+  const texts: Array<{ text: string; x: number; y: number; align: string; baseline: string }> = [];
+  const state: Record<string, unknown> = {
+    fillStyle: '#000',
+    strokeStyle: '#000',
+    lineWidth: 1,
+    textAlign: 'start',
+    textBaseline: 'alphabetic',
+    font: '10px sans',
+    globalAlpha: 1,
+  };
+  const ctx = new Proxy(state, {
+    get(target, prop: string) {
+      if (prop === 'save' || prop === 'restore') {
+        return () => calls.push({ type: prop });
+      }
+      if (prop === 'beginPath' || prop === 'closePath' || prop === 'stroke' || prop === 'fill') {
+        return () => calls.push({ type: prop });
+      }
+      if (prop === 'moveTo' || prop === 'lineTo') {
+        return (x: number, y: number) => calls.push({ type: prop as string, x, y });
+      }
+      if (prop === 'rect' || prop === 'fillRect' || prop === 'strokeRect') {
+        return (x: number, y: number, w: number, h: number) =>
+          calls.push({ type: prop as string, x, y, w, h });
+      }
+      if (prop === 'clip') return () => calls.push({ type: 'clip' });
+      if (prop === 'setLineDash') return () => undefined;
+      if (prop === 'fillText') {
+        return (text: string, x: number, y: number) => {
+          texts.push({
+            text,
+            x,
+            y,
+            align: String(target.textAlign),
+            baseline: String(target.textBaseline),
+          });
+        };
+      }
+      return target[prop];
+    },
+    set(target, prop: string, value) {
+      target[prop] = value;
+      return true;
+    },
+  }) as unknown as CanvasRenderingContext2D;
+  return { ctx, calls, texts };
+}
+
+describe('drawGraphFrame zero suppression', () => {
+  it('does not emit a tick label for 0 when both axes meet inside the frame', () => {
+    const theme = resolveTheme({ graphTheme: 'classic' });
+    const { ctx, texts } = createFakeCtx();
+    drawGraphFrame(ctx, {
+      rect: { x: 0, y: 0, w: 200, h: 200 },
+      xRange: [-5, 5],
+      yRange: [-5, 5],
+      theme,
+      gridStep: 1,
+      showAxes: true,
+      showGrid: true,
+    });
+    const tickLabels = texts.filter((t) => t.text !== 'x' && t.text !== 'y');
+    // Tick labels only: should not include '0'.
+    expect(tickLabels.some((t) => t.text === '0')).toBe(false);
+    expect(tickLabels.some((t) => t.text === '3')).toBe(true);
+  });
+
+  it('labels non-zero ticks when only the x-axis is visible', () => {
+    const theme = resolveTheme({ graphTheme: 'classic' });
+    const { ctx, texts } = createFakeCtx();
+    drawGraphFrame(ctx, {
+      rect: { x: 0, y: 0, w: 200, h: 200 },
+      xRange: [2, 8],
+      yRange: [-5, 5],
+      theme,
+      gridStep: 1,
+      showAxes: true,
+      showGrid: true,
+    });
+    // y-axis not in xRange; x-axis at y=0 is visible. Tick labels on x show 3..7.
+    expect(texts.some((t) => t.text === '3')).toBe(true);
+    expect(texts.some((t) => t.text === '7')).toBe(true);
+  });
+
+  it('shows an origin label when the theme requests one', () => {
+    const theme = resolveTheme({
+      graphTheme: 'classic',
+      graphOverrides: { originLabel: 'coords' },
+    });
+    const { ctx, texts } = createFakeCtx();
+    drawGraphFrame(ctx, {
+      rect: { x: 0, y: 0, w: 200, h: 200 },
+      xRange: [-5, 5],
+      yRange: [-5, 5],
+      theme,
+      gridStep: 1,
+      showAxes: true,
+      showGrid: true,
+    });
+    expect(texts.some((t) => t.text === '(0, 0)')).toBe(true);
+  });
+
+  it('renders italic axis labels x and y when enabled', () => {
+    const theme = resolveTheme({ graphTheme: 'textbook' });
+    const { ctx, texts } = createFakeCtx();
+    drawGraphFrame(ctx, {
+      rect: { x: 0, y: 0, w: 200, h: 200 },
+      xRange: [-5, 5],
+      yRange: [-5, 5],
+      theme,
+      gridStep: 1,
+      showAxes: true,
+      showGrid: true,
+    });
+    expect(texts.some((t) => t.text === 'x')).toBe(true);
+    expect(texts.some((t) => t.text === 'y')).toBe(true);
+  });
+});
+
+describe('theme changes affect drawn output', () => {
+  it('switching a theme changes the stroke colors painted', () => {
+    const lightTheme = GRAPH_THEME_PRESETS.classic;
+    const darkTheme = GRAPH_THEME_PRESETS.blueprint;
+    const a = createFakeCtx();
+    const b = createFakeCtx();
+    for (const [ctx, theme] of [
+      [a.ctx, lightTheme],
+      [b.ctx, darkTheme],
+    ] as const) {
+      drawGraphFrame(ctx, {
+        rect: { x: 0, y: 0, w: 200, h: 200 },
+        xRange: [-5, 5],
+        yRange: [-5, 5],
+        theme,
+        gridStep: 1,
+        showAxes: true,
+        showGrid: true,
+      });
+    }
+    // The fake ctx proxy records final mutations on its state, so we can inspect
+    // strokeStyle / fillStyle by reading the last value set during the call.
+    const aState = a.ctx as unknown as Record<string, unknown>;
+    const bState = b.ctx as unknown as Record<string, unknown>;
+    expect(aState.strokeStyle).not.toBe(bState.strokeStyle);
+  });
+});

--- a/tests/graph-theme.test.ts
+++ b/tests/graph-theme.test.ts
@@ -109,4 +109,42 @@ describe('isGraphPresetName', () => {
     expect(isGraphPresetName(42)).toBe(false);
     expect(isGraphPresetName(null)).toBe(false);
   });
+  it('rejects inherited Object.prototype properties', () => {
+    expect(isGraphPresetName('toString')).toBe(false);
+    expect(isGraphPresetName('__proto__')).toBe(false);
+    expect(isGraphPresetName('hasOwnProperty')).toBe(false);
+  });
+  it('falls back to default when preset name is an inherited property', () => {
+    const t = resolveTheme({
+      // @ts-expect-error — exercising the runtime guard
+      graphTheme: 'toString',
+    });
+    expect(t).toEqual(GRAPH_THEME_PRESETS[DEFAULT_GRAPH_PRESET]);
+  });
+});
+
+describe('mergeTheme hardening', () => {
+  it('does not null-stomp nested plain-object fields', () => {
+    const t = resolveTheme({
+      graphTheme: 'classic',
+      // @ts-expect-error — gridMinor is required to be an object; exercising runtime guard
+      graphOverrides: { gridMinor: null },
+    });
+    expect(t.gridMinor).toEqual(GRAPH_THEME_PRESETS.classic.gridMinor);
+    expect(t.gridMinor.subdivisions).toBe(GRAPH_THEME_PRESETS.classic.gridMinor.subdivisions);
+  });
+
+  it('does not pollute Object.prototype via __proto__ key', () => {
+    const before = (Object.prototype as Record<string, unknown>).polluted;
+    const payload = JSON.parse('{"__proto__": {"polluted": true}}') as Record<string, unknown>;
+    mergeTheme(GRAPH_THEME_PRESETS.classic, payload as never);
+    expect((Object.prototype as Record<string, unknown>).polluted).toBe(before);
+  });
+
+  it('ignores constructor and prototype keys', () => {
+    const payload = { constructor: { bad: true }, prototype: { bad: true } };
+    const t = mergeTheme(GRAPH_THEME_PRESETS.classic, payload as never);
+    expect((t as unknown as Record<string, unknown>).constructor).toBe(Object);
+    expect((t as unknown as Record<string, unknown>).prototype).toBeUndefined();
+  });
 });

--- a/tests/graph-theme.test.ts
+++ b/tests/graph-theme.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_GRAPH_PRESET,
+  GRAPH_PRESET_ORDER,
+  GRAPH_THEME_PRESETS,
+  isGraphPresetName,
+  mergeTheme,
+  resolveTheme,
+} from '$lib/graph/theme';
+
+describe('graph theme presets', () => {
+  it('exposes the five named presets with distinct backgrounds', () => {
+    expect(GRAPH_PRESET_ORDER).toEqual([
+      'classic',
+      'textbook',
+      'blueprint',
+      'minimal',
+      'graphPaper',
+    ]);
+    const backgrounds = GRAPH_PRESET_ORDER.map((n) => GRAPH_THEME_PRESETS[n].background);
+    expect(new Set(backgrounds).size).toBeGreaterThanOrEqual(3);
+  });
+
+  it('blueprint uses a dark background with light labels', () => {
+    const t = GRAPH_THEME_PRESETS.blueprint;
+    expect(t.background).toBe('#0d2340');
+    expect(t.labelColor.toLowerCase()).not.toBe('#000000');
+  });
+
+  it('minimal disables both grid layers', () => {
+    const t = GRAPH_THEME_PRESETS.minimal;
+    expect(t.gridMajor.enabled).toBe(false);
+    expect(t.gridMinor.enabled).toBe(false);
+  });
+
+  it('textbook turns on arrowheads', () => {
+    expect(GRAPH_THEME_PRESETS.textbook.axisArrowheads).toBe(true);
+  });
+});
+
+describe('resolveTheme', () => {
+  it('returns the default preset when nothing is specified', () => {
+    const t = resolveTheme(undefined);
+    expect(t).toEqual(GRAPH_THEME_PRESETS[DEFAULT_GRAPH_PRESET]);
+  });
+
+  it('returns the named preset when no overrides are supplied', () => {
+    const t = resolveTheme({ graphTheme: 'blueprint' });
+    expect(t).toEqual(GRAPH_THEME_PRESETS.blueprint);
+  });
+
+  it('falls back to the default for unknown preset names', () => {
+    const t = resolveTheme({
+      // @ts-expect-error — exercising the runtime fallback
+      graphTheme: 'not-a-preset',
+    });
+    expect(t).toEqual(GRAPH_THEME_PRESETS[DEFAULT_GRAPH_PRESET]);
+  });
+
+  it('overrides scalar fields while leaving siblings untouched', () => {
+    const t = resolveTheme({
+      graphTheme: 'classic',
+      graphOverrides: { axisColor: '#ff0000' },
+    });
+    expect(t.axisColor).toBe('#ff0000');
+    expect(t.labelColor).toBe(GRAPH_THEME_PRESETS.classic.labelColor);
+  });
+
+  it('deep-merges nested grid overrides', () => {
+    const t = resolveTheme({
+      graphTheme: 'classic',
+      graphOverrides: { gridMajor: { color: '#112233', opacity: 0.5 } },
+    });
+    expect(t.gridMajor.color).toBe('#112233');
+    expect(t.gridMajor.opacity).toBe(0.5);
+    expect(t.gridMajor.enabled).toBe(GRAPH_THEME_PRESETS.classic.gridMajor.enabled);
+    expect(t.gridMajor.width).toBe(GRAPH_THEME_PRESETS.classic.gridMajor.width);
+  });
+
+  it('is immutable with respect to the preset table', () => {
+    const t = resolveTheme({ graphTheme: 'classic' });
+    t.gridMajor.color = '#000000';
+    expect(GRAPH_THEME_PRESETS.classic.gridMajor.color).not.toBe('#000000');
+  });
+
+  it('ignores undefined fields in overrides', () => {
+    const t = resolveTheme({
+      graphTheme: 'classic',
+      graphOverrides: { axisColor: undefined, gridMajor: { opacity: undefined } },
+    });
+    expect(t.axisColor).toBe(GRAPH_THEME_PRESETS.classic.axisColor);
+    expect(t.gridMajor.opacity).toBe(GRAPH_THEME_PRESETS.classic.gridMajor.opacity);
+  });
+
+  it('ignores non-object overrides', () => {
+    const t = mergeTheme(GRAPH_THEME_PRESETS.classic, null);
+    expect(t).toEqual(GRAPH_THEME_PRESETS.classic);
+  });
+});
+
+describe('isGraphPresetName', () => {
+  it('accepts known preset names', () => {
+    for (const name of GRAPH_PRESET_ORDER) {
+      expect(isGraphPresetName(name)).toBe(true);
+    }
+  });
+  it('rejects everything else', () => {
+    expect(isGraphPresetName('unknown')).toBe(false);
+    expect(isGraphPresetName(42)).toBe(false);
+    expect(isGraphPresetName(null)).toBe(false);
+  });
+});

--- a/tests/settings-store.test.ts
+++ b/tests/settings-store.test.ts
@@ -57,4 +57,36 @@ describe('settings store', () => {
     const { settings } = await import('$lib/store/settings');
     expect(settings.snapshot().reloadBehavior).toBe('keep');
   });
+
+  it('defaults graphTheme to classic and graphOverrides to {}', async () => {
+    const { settings } = await import('$lib/store/settings');
+    const snap = settings.snapshot();
+    expect(snap.graphTheme).toBe('classic');
+    expect(snap.graphOverrides).toEqual({});
+  });
+
+  it('migrates a legacy settings blob without graphTheme to classic', async () => {
+    stub.store.set('eldraw.settings.v1', JSON.stringify({ reloadBehavior: 'discard' }));
+    const { settings } = await import('$lib/store/settings');
+    expect(settings.snapshot().graphTheme).toBe('classic');
+    expect(settings.snapshot().reloadBehavior).toBe('discard');
+  });
+
+  it('persists graphTheme and graphOverrides', async () => {
+    const { settings } = await import('$lib/store/settings');
+    settings.setGraphTheme('blueprint');
+    settings.setGraphOverrides({ axisColor: '#ff0000' });
+    const raw = stub.store.get('eldraw.settings.v1') ?? '';
+    expect(raw).toContain('blueprint');
+    expect(raw).toContain('ff0000');
+  });
+
+  it('rejects an unknown graphTheme on load', async () => {
+    stub.store.set(
+      'eldraw.settings.v1',
+      JSON.stringify({ reloadBehavior: 'keep', graphTheme: 'nope' }),
+    );
+    const { settings } = await import('$lib/store/settings');
+    expect(settings.snapshot().graphTheme).toBe('classic');
+  });
 });


### PR DESCRIPTION
Closes #139.

## Summary

Introduces five named visual themes for graph objects, a deep-partial override layer, a new **Appearance** settings dialog with a live mini-graph preview, and a pile of rendering polish on top of the existing axes math.

## Presets

Each preset ships with a deliberate color hierarchy: axes > major grid > minor grid > labels.

- **Classic** — white background, soft grey major/minor grid (`#cfcfcf` / `#ececec`), dark-grey axes (`#3a3a3a`, 1.25 px), italic serif `x`/`y` labels at axis ends. The existing look, tightened up.
- **Textbook** — white background, black axes (`#111`, 1.5 px) with arrowheads and tick marks, serif tick labels, single light-grey major grid (`#d6d6d6`, minor off). Origin labeled `O`. Reads like a printed textbook figure.
- **Blueprint** — dark navy background (`#0d2340`), cyan grid (`#6fb6d9` at 0.45 major / 0.18 minor alpha), white axes and tick labels, arrowheads, origin `O`. High contrast for dim classrooms.
- **Minimal** — no background fill, no grid at all, thin `#222` axes with short tick marks and small labels. Clean focus on the curve.
- **Graph paper** — warm paper background (`#fff6e6`), red-orange grid (`#d97a4d`) at 0.55 / 0.22 alpha, dark red axes, serif labels in warm brown. Feels like hand-ruled paper.

## Rendering upgrades

All driven by the resolved theme object, so the live preview reflects the exact output of `GraphLayer`.

- Subpixel-snapped grid/axis/tick strokes (0.5 px offset for odd widths).
- Minor grid sampled at `majorStep / theme.gridMinor.subdivisions` (default 5), with a per-axis line-count cap.
- Italic `x` / `y` axis-end labels with a serif option; avoids the arrowhead when one is drawn.
- Zero suppression where the axes meet; optional origin label (`O` or `(0, 0)`).
- Optional axis arrowheads and tick marks, respecting theme weights.
- Alpha-aware grid rendering so preset opacity is honoured.
- Tick label placement pushes off the axis when near the frame, accounting for tick length.

## New code

- `src/lib/graph/theme.ts` — `GraphTheme` type, `GRAPH_THEME_PRESETS`, `resolveTheme(appearance)` with deep-partial merge.
- `src/lib/graph/render.ts` — `drawGraphFrame(ctx, ...)` pure renderer shared by `GraphLayer` and the settings preview; plus `computeSteps` and `snapLine` helpers.
- `src/lib/settings/GraphStyleSection.svelte` — preset picker (swatch + label), collapsible tuning knobs (axis color/width/arrowheads, grid color/opacity/subdivisions, background, label color/size, origin label, curve width), and a 280×180 live preview canvas.
- `src/lib/settings/AppearanceSettings.svelte` — modal dialog wrapper hosting the graph style section.
- `settings` store gains `graphTheme` + `graphOverrides`, with migration: existing blobs default to `classic`.
- New palette button in the sidebar opens the Appearance dialog.

`axes.ts` pure math functions are unchanged; `GraphEditor.svelte` is unchanged (per-graph override UI is tracked as a follow-up).

## Tests

- `tests/graph-theme.test.ts` — preset distinctness, `resolveTheme` merge behaviour (preset preserved when no override, overrides win when set, deep-partial nested merge, undefined / non-object overrides ignored, preset table immutability).
- `tests/graph-render.test.ts` — `snapLine` subpixel offsets, `computeSteps` 1/2/5 × 10ⁿ invariant, minor subdivision honours theme, minor grid off for minimal, user `gridStep` override, zero-suppression at origin, origin-label rendering, axis `x`/`y` labels emitted, theme switch changes painted strokes.
- Settings store tests extended with `graphTheme`/`graphOverrides` defaults, migration and persistence.

## Checks (local)

- `pnpm lint` ✓ (prettier, eslint, svelte-check all clean)
- `pnpm test` ✓ (640 tests passing, 67 files)
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings` ✓
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check` ✓

## Follow-ups (not in this PR, per the issue's non-goals)

- Per-graph theme override UI in `GraphEditor.svelte`.
- Custom user-defined themes saved alongside presets.