### PR TITLE
feat(ink): straight-edge mode — Shift-hold snaps stroke to a straight line

### DIFF
--- a/src/lib/canvas/CanvasStack.svelte
+++ b/src/lib/canvas/CanvasStack.svelte
@@ -32,6 +32,7 @@
     penStabilization?: number;
     highlighterStabilization?: number;
     tempInkStabilization?: number;
+    straightEdgeSnapStep?: number;
     rulerSnap?: RulerState | null;
     rulerSnapThresholdPx?: number;
     overlay?: Snippet;
@@ -55,6 +56,7 @@
     penStabilization,
     highlighterStabilization,
     tempInkStabilization,
+    straightEdgeSnapStep,
     rulerSnap = null,
     rulerSnapThresholdPx,
     overlay,
@@ -87,7 +89,9 @@
       {rulerSnapThresholdPx}
       {penStabilization}
       {highlighterStabilization}
+      {straightEdgeSnapStep}
       {oncommit}
+      oncommitline={oncommitobject}
       {onerase}
       {ongraph}
     />

--- a/src/lib/canvas/LiveLayer.svelte
+++ b/src/lib/canvas/LiveLayer.svelte
@@ -12,6 +12,7 @@
   import { createOneEuroFilter, stabilizationToConfig, type OneEuroFilter } from './stabilizer';
   import {
     buildStraightEdgeLine,
+    buildStraightEdgeStroke,
     decideStraightEdgeCommit,
     straightEdgeEndpoint,
     DEFAULT_STRAIGHT_EDGE_SNAP_STEP,
@@ -425,6 +426,16 @@
         );
         log('live', `commit straight-edge ${currentTool} tool`);
         oncommitline?.(line);
+      } else if (decision.kind === 'stroke') {
+        const stroke = buildStraightEdgeStroke(
+          crypto.randomUUID(),
+          Date.now(),
+          decision.from,
+          decision.to,
+          currentStyle,
+        );
+        log('live', `commit straight-edge ${currentTool} tool`);
+        oncommit?.(stroke);
       } else {
         const snapped = rulerSnap
           ? snapStrokeToRuler(points, rulerSnap, rulerSnapThresholdPx / ptToPx)

--- a/src/lib/canvas/LiveLayer.svelte
+++ b/src/lib/canvas/LiveLayer.svelte
@@ -1,14 +1,21 @@
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte';
-  import type { Point, StrokeObject, StrokeStyle, ToolKind } from '$lib/types';
+  import type { LineObject, Point, StrokeObject, StrokeStyle, ToolKind } from '$lib/types';
   import { toolStore } from '$lib/store/tool';
   import { strokeFromInput } from '$lib/tools/pen';
   import { drawLiveStroke } from './strokeRenderer';
+  import { drawLine } from './objectRenderer';
   import { cursorForTool } from './cursors';
   import { log } from '$lib/log';
   import { snapPointToRuler, snapStrokeToRuler, type RulerState } from '$lib/geometry/ruler';
   import { createRafBatcher, type Batcher } from './inkBatch';
   import { createOneEuroFilter, stabilizationToConfig, type OneEuroFilter } from './stabilizer';
+  import {
+    buildStraightEdgeLine,
+    decideStraightEdgeCommit,
+    straightEdgeEndpoint,
+    DEFAULT_STRAIGHT_EDGE_SNAP_STEP,
+  } from '$lib/tools/straightEdge';
 
   interface Props {
     width: number;
@@ -18,7 +25,9 @@
     rulerSnapThresholdPx?: number;
     penStabilization?: number;
     highlighterStabilization?: number;
+    straightEdgeSnapStep?: number;
     oncommit?: (stroke: StrokeObject) => void;
+    oncommitline?: (line: LineObject) => void;
     onerase?: (samples: { x: number; y: number }[]) => void;
     ongraph?: (bounds: { x: number; y: number; w: number; h: number }) => void;
   }
@@ -31,7 +40,9 @@
     rulerSnapThresholdPx = 12,
     penStabilization = 0,
     highlighterStabilization = 0,
+    straightEdgeSnapStep = DEFAULT_STRAIGHT_EDGE_SNAP_STEP,
     oncommit,
+    oncommitline,
     onerase,
     ongraph,
   }: Props = $props();
@@ -48,6 +59,8 @@
   let startTime = 0;
   let points: Point[] = [];
   let predictedTail: Point[] = [];
+  let shiftHeld = false;
+  let altHeld = false;
   let currentTool: ToolKind = $state('pen');
   let currentStyle: StrokeStyle = {
     color: '#000',
@@ -111,6 +124,8 @@
     predictedTail = [];
     graphStart = null;
     graphEnd = null;
+    shiftHeld = false;
+    altHeld = false;
     stabilizer = null;
     batcher?.cancel();
     clear();
@@ -154,18 +169,55 @@
     return { ...p, x: out.x, y: out.y };
   }
 
+  function straightEdgeActive(): boolean {
+    if (!shiftHeld) return false;
+    if (rulerSnap) return false;
+    if (currentTool !== 'pen' && currentTool !== 'highlighter') return false;
+    return points.length > 0;
+  }
+
+  function drawStraightPreview(c: CanvasRenderingContext2D) {
+    const first = points[0];
+    const last = points[points.length - 1];
+    const to = straightEdgeEndpoint({
+      start: { x: first.x, y: first.y },
+      current: { x: last.x, y: last.y },
+      snapStepDeg: straightEdgeSnapStep,
+      bypassSnap: altHeld,
+    });
+    const preview: LineObject = {
+      id: 'live-straight',
+      createdAt: 0,
+      type: 'line',
+      style: currentStyle,
+      from: { x: first.x, y: first.y },
+      to,
+      arrow: { start: false, end: false },
+    };
+    drawLine(c, preview, ptToPx);
+  }
+
   function redrawLive() {
     const c = ensureCtx();
     if (!c) return;
     clear();
     if (currentTool === 'highlighter') {
-      c.globalCompositeOperation = 'multiply';
-      const tail = points.concat(predictedTail);
-      drawLiveStroke(c, tail, currentStyle, 'highlighter', ptToPx);
+      if (straightEdgeActive()) {
+        c.globalCompositeOperation = 'multiply';
+        drawStraightPreview(c);
+      } else {
+        c.globalCompositeOperation = 'multiply';
+        const tail = points.concat(predictedTail);
+        drawLiveStroke(c, tail, currentStyle, 'highlighter', ptToPx);
+      }
     } else if (currentTool === 'pen') {
       c.globalCompositeOperation = 'source-over';
-      const tail = points.concat(predictedTail);
-      drawLiveStroke(c, tail, currentStyle, 'pen', ptToPx);
+      if (straightEdgeActive()) {
+        drawStraightPreview(c);
+      } else {
+        const tail = points.concat(predictedTail);
+        drawLiveStroke(c, tail, currentStyle, 'pen', ptToPx);
+      }
     } else if (currentTool === 'graph' && graphStart && graphEnd) {
       drawGraphRect(c);
     }
@@ -255,6 +307,8 @@
     activePointerId = e.pointerId;
     startTime = e.timeStamp;
     predictedTail = [];
+    shiftHeld = e.shiftKey;
+    altHeld = e.altKey;
 
     if (currentTool === 'eraser') {
       const p = toPoint(e);
@@ -279,6 +333,8 @@
 
   function handleMoveLike(e: PointerEvent) {
     if (activePointerId !== e.pointerId) return;
+    shiftHeld = e.shiftKey;
+    altHeld = e.altKey;
     const rect = canvas.getBoundingClientRect();
     if (currentTool === 'eraser') {
       const coalesced = typeof e.getCoalescedEvents === 'function' ? e.getCoalescedEvents() : [];
@@ -332,6 +388,8 @@
 
   function finish(e: PointerEvent, commit: boolean) {
     if (activePointerId !== e.pointerId) return;
+    shiftHeld = e.shiftKey;
+    altHeld = e.altKey;
     try {
       canvas.releasePointerCapture(e.pointerId);
     } catch {
@@ -345,12 +403,36 @@
     predictedTail = [];
 
     if (commit && (currentTool === 'pen' || currentTool === 'highlighter') && points.length > 0) {
-      const snapped = rulerSnap
-        ? snapStrokeToRuler(points, rulerSnap, rulerSnapThresholdPx / ptToPx)
-        : points;
-      const stroke = strokeFromInput(snapped, currentStyle, currentTool);
-      log('live', `commit ${currentTool} points=${snapped.length}`);
-      oncommit?.(stroke);
+      const first = points[0];
+      const last = points[points.length - 1];
+      const decision = decideStraightEdgeCommit({
+        shiftAtPointerUp: shiftHeld,
+        altAtPointerUp: altHeld,
+        rulerActive: rulerSnap !== null,
+        tool: currentTool,
+        first: { x: first.x, y: first.y },
+        last: { x: last.x, y: last.y },
+        style: currentStyle,
+        snapStepDeg: straightEdgeSnapStep,
+      });
+      if (decision.kind === 'line') {
+        const line = buildStraightEdgeLine(
+          crypto.randomUUID(),
+          Date.now(),
+          decision.from,
+          decision.to,
+          currentStyle,
+        );
+        log('live', `commit straight-edge ${currentTool} tool`);
+        oncommitline?.(line);
+      } else {
+        const snapped = rulerSnap
+          ? snapStrokeToRuler(points, rulerSnap, rulerSnapThresholdPx / ptToPx)
+          : points;
+        const stroke = strokeFromInput(snapped, currentStyle, currentTool);
+        log('live', `commit ${currentTool} points=${snapped.length}`);
+        oncommit?.(stroke);
+      }
     }
     if (commit && currentTool === 'graph' && graphStart && graphEnd) {
       const x = Math.min(graphStart.x, graphEnd.x);
@@ -364,6 +446,8 @@
     points = [];
     graphStart = null;
     graphEnd = null;
+    shiftHeld = false;
+    altHeld = false;
     stabilizer = null;
     clear();
   }

--- a/src/lib/sidebar/Sidebar.svelte
+++ b/src/lib/sidebar/Sidebar.svelte
@@ -97,6 +97,15 @@
     if (Number.isFinite(v)) sidebar.setSmoothing(tool, v);
   }
 
+  const showStraightEdgeSnap = $derived(
+    sidebarState.activeTool === 'pen' || sidebarState.activeTool === 'highlighter',
+  );
+
+  function onStraightEdgeSnapStep(e: Event) {
+    const v = Number((e.target as HTMLInputElement).value);
+    if (Number.isFinite(v)) sidebar.setStraightEdgeSnapStep(v);
+  }
+
   function onColor(color: string) {
     onStyleChange?.({ ...style, color });
   }
@@ -435,6 +444,25 @@
           />
           <span class="value">{smoothing}%</span>
         </div>
+      </section>
+    {/if}
+
+    {#if showStraightEdgeSnap}
+      <section class="section straight-edge" aria-label="Straight-edge snap">
+        <h3 class="section-title">Straight-edge snap</h3>
+        <div class="row">
+          <input
+            type="range"
+            min="1"
+            max="90"
+            step="1"
+            value={sidebarState.straightEdgeSnapStep}
+            oninput={onStraightEdgeSnapStep}
+            aria-label="Straight-edge snap step in degrees"
+          />
+          <span class="value">{sidebarState.straightEdgeSnapStep}°</span>
+        </div>
+        <p class="hint">Hold Shift to snap; Alt to bypass.</p>
       </section>
     {/if}
 
@@ -779,6 +807,25 @@
     min-width: 36px;
     text-align: right;
     font-variant-numeric: tabular-nums;
+  }
+  .straight-edge .row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .straight-edge input[type='range'] {
+    flex: 1;
+    min-width: 0;
+  }
+  .straight-edge .value {
+    min-width: 36px;
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+  .straight-edge .hint {
+    margin: 0;
+    font-size: 10px;
+    color: #888;
   }
   input[type='number'] {
     background: #1b1b1b;

--- a/src/lib/store/sidebar.ts
+++ b/src/lib/store/sidebar.ts
@@ -1,8 +1,10 @@
 import { derived, get, writable, type Readable } from 'svelte/store';
 import type { ColorPalette, DashStyle, StrokeStyle, ToolKind, ToolPreset } from '$lib/types';
 import { clampFadeMs, DEFAULT_TEMP_INK_FADE_MS } from '$lib/tools/tempInk';
+import { DEFAULT_STRAIGHT_EDGE_SNAP_STEP } from '$lib/tools/straightEdge';
 import type { SnapEdge } from '$lib/sidebar/snap';
 
+export { DEFAULT_STRAIGHT_EDGE_SNAP_STEP };
 export type { SnapEdge };
 
 export type StyledTool = 'pen' | 'highlighter' | 'line';
@@ -15,7 +17,6 @@ export const DEFAULT_SMOOTHING_PEN = 50;
 export const DEFAULT_SMOOTHING_HIGHLIGHTER = 50;
 export const DEFAULT_SMOOTHING_TEMP_INK = 30;
 
-export const DEFAULT_STRAIGHT_EDGE_SNAP_STEP = 15;
 export const MIN_STRAIGHT_EDGE_SNAP_STEP = 1;
 export const MAX_STRAIGHT_EDGE_SNAP_STEP = 90;
 

--- a/src/lib/store/sidebar.ts
+++ b/src/lib/store/sidebar.ts
@@ -15,6 +15,10 @@ export const DEFAULT_SMOOTHING_PEN = 50;
 export const DEFAULT_SMOOTHING_HIGHLIGHTER = 50;
 export const DEFAULT_SMOOTHING_TEMP_INK = 30;
 
+export const DEFAULT_STRAIGHT_EDGE_SNAP_STEP = 15;
+export const MIN_STRAIGHT_EDGE_SNAP_STEP = 1;
+export const MAX_STRAIGHT_EDGE_SNAP_STEP = 90;
+
 export interface LaserStyle {
   color: string;
   radius: number;
@@ -58,6 +62,7 @@ export interface SidebarState {
   smoothingPen: number;
   smoothingHighlighter: number;
   smoothingTempInk: number;
+  straightEdgeSnapStep: number;
   presets: ToolPreset[];
   floatingPos: { x: number; y: number } | null;
   hidden: boolean;
@@ -93,6 +98,7 @@ function initialState(): SidebarState {
     smoothingPen: DEFAULT_SMOOTHING_PEN,
     smoothingHighlighter: DEFAULT_SMOOTHING_HIGHLIGHTER,
     smoothingTempInk: DEFAULT_SMOOTHING_TEMP_INK,
+    straightEdgeSnapStep: DEFAULT_STRAIGHT_EDGE_SNAP_STEP,
     presets: [],
     floatingPos: null,
     hidden: false,
@@ -300,6 +306,16 @@ function createSidebarStore() {
         if (snapshot.smoothingTempInk !== undefined && Number.isFinite(snapshot.smoothingTempInk)) {
           next.smoothingTempInk = clamp(snapshot.smoothingTempInk, 0, 100);
         }
+        if (
+          snapshot.straightEdgeSnapStep !== undefined &&
+          Number.isFinite(snapshot.straightEdgeSnapStep)
+        ) {
+          next.straightEdgeSnapStep = clamp(
+            snapshot.straightEdgeSnapStep,
+            MIN_STRAIGHT_EDGE_SNAP_STEP,
+            MAX_STRAIGHT_EDGE_SNAP_STEP,
+          );
+        }
         if (snapshot.presets !== undefined) next.presets = snapshot.presets;
         if (typeof snapshot.hidden === 'boolean') next.hidden = snapshot.hidden;
         if (typeof snapshot.minimized === 'boolean') next.minimized = snapshot.minimized;
@@ -356,6 +372,13 @@ function createSidebarStore() {
       });
     },
 
+    setStraightEdgeSnapStep(value: number) {
+      const clamped = clamp(value, MIN_STRAIGHT_EDGE_SNAP_STEP, MAX_STRAIGHT_EDGE_SNAP_STEP);
+      update((s) =>
+        s.straightEdgeSnapStep === clamped ? s : { ...s, straightEdgeSnapStep: clamped },
+      );
+    },
+
     capturePreset(): ToolPreset | null {
       const s = get(store);
       const key = styleKeyFor(s.activeTool);
@@ -403,6 +426,7 @@ const PRESETS_STORAGE_KEY = 'eldraw.presets.v1';
 const FLOATING_POS_STORAGE_KEY = 'eldraw.sidebar-pos.v1';
 const SMOOTHING_STORAGE_KEY = 'eldraw.smoothing.v1';
 const LAYOUT_STORAGE_KEY = 'eldraw.sidebar-layout.v1';
+const STRAIGHT_EDGE_STORAGE_KEY = 'eldraw.straight-edge.v1';
 
 const VALID_TOOLS: ReadonlySet<ToolKind> = new Set<ToolKind>([
   'pen',
@@ -514,6 +538,21 @@ function loadPersistedSmoothing(): PersistedSmoothing | null {
   }
 }
 
+function loadPersistedStraightEdgeSnapStep(): number | null {
+  if (typeof localStorage === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(STRAIGHT_EDGE_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return null;
+    const p = parsed as Record<string, unknown>;
+    if (typeof p.snapStepDeg !== 'number' || !Number.isFinite(p.snapStepDeg)) return null;
+    return clamp(p.snapStepDeg, MIN_STRAIGHT_EDGE_SNAP_STEP, MAX_STRAIGHT_EDGE_SNAP_STEP);
+  } catch {
+    return null;
+  }
+}
+
 let hydrated = false;
 let hydrationUnsubscribe: (() => void) | null = null;
 
@@ -562,6 +601,9 @@ export function hydrateSidebarFromStorage(): () => void {
     sidebar.setSmoothing('temp-ink', smoothing.tempInk);
   }
 
+  const snapStep = loadPersistedStraightEdgeSnapStep();
+  if (snapStep !== null) sidebar.setStraightEdgeSnapStep(snapStep);
+
   const layout = loadPersistedLayout();
   if (layout) {
     sidebar.setHidden(layout.hidden);
@@ -585,6 +627,10 @@ export function hydrateSidebarFromStorage(): () => void {
           highlighter: s.smoothingHighlighter,
           tempInk: s.smoothingTempInk,
         }),
+      );
+      localStorage.setItem(
+        STRAIGHT_EDGE_STORAGE_KEY,
+        JSON.stringify({ snapStepDeg: s.straightEdgeSnapStep }),
       );
       localStorage.setItem(
         LAYOUT_STORAGE_KEY,
@@ -627,6 +673,7 @@ export type SyncableSidebarState = Pick<
   | 'smoothingPen'
   | 'smoothingHighlighter'
   | 'smoothingTempInk'
+  | 'straightEdgeSnapStep'
   | 'presets'
   | 'hidden'
   | 'minimized'
@@ -716,6 +763,13 @@ function sanitizeImportedSidebar(raw: Record<string, unknown>): Partial<Syncable
   if (typeof raw.smoothingTempInk === 'number' && Number.isFinite(raw.smoothingTempInk)) {
     out.smoothingTempInk = clamp(raw.smoothingTempInk, 0, 100);
   }
+  if (typeof raw.straightEdgeSnapStep === 'number' && Number.isFinite(raw.straightEdgeSnapStep)) {
+    out.straightEdgeSnapStep = clamp(
+      raw.straightEdgeSnapStep,
+      MIN_STRAIGHT_EDGE_SNAP_STEP,
+      MAX_STRAIGHT_EDGE_SNAP_STEP,
+    );
+  }
   if (Array.isArray(raw.presets)) {
     out.presets = raw.presets.filter(isValidPreset).map(sanitizePreset).slice(0, MAX_PRESETS);
   }
@@ -741,6 +795,7 @@ export function pickSyncable(state: SidebarState): SyncableSidebarState {
     smoothingPen: state.smoothingPen,
     smoothingHighlighter: state.smoothingHighlighter,
     smoothingTempInk: state.smoothingTempInk,
+    straightEdgeSnapStep: state.straightEdgeSnapStep,
     presets: state.presets,
     hidden: state.hidden,
     minimized: state.minimized,

--- a/src/lib/tools/lineSnap.ts
+++ b/src/lib/tools/lineSnap.ts
@@ -1,20 +1,30 @@
 import type { Point2 } from './shapes';
 
-const SNAP_STEP = Math.PI / 12;
+const DEG_TO_RAD = Math.PI / 180;
 
 /**
  * Snap `end` so the vector from `start` to `end` has an angle that is a
- * multiple of 15° (π/12 rad), preserving length. Zero-length drags are
- * returned unchanged.
+ * multiple of `stepDeg`, preserving length. Zero-length drags and
+ * non-positive step values return the endpoint unchanged.
  */
-export function snapAngle15(start: Point2, end: Point2): Point2 {
+export function snapAngleToStep(start: Point2, end: Point2, stepDeg: number): Point2 {
+  if (!Number.isFinite(stepDeg) || stepDeg <= 0) return { x: end.x, y: end.y };
   const dx = end.x - start.x;
   const dy = end.y - start.y;
   const length = Math.hypot(dx, dy);
   if (length === 0) return { x: end.x, y: end.y };
-  const snapped = Math.round(Math.atan2(dy, dx) / SNAP_STEP) * SNAP_STEP;
+  const stepRad = stepDeg * DEG_TO_RAD;
+  const snapped = Math.round(Math.atan2(dy, dx) / stepRad) * stepRad;
   return {
     x: start.x + length * Math.cos(snapped),
     y: start.y + length * Math.sin(snapped),
   };
+}
+
+/**
+ * Back-compat wrapper: snap to the nearest 15° multiple. `ShapeLiveLayer`
+ * still wires this for the line-tool Shift-drag snap.
+ */
+export function snapAngle15(start: Point2, end: Point2): Point2 {
+  return snapAngleToStep(start, end, 15);
 }

--- a/src/lib/tools/straightEdge.ts
+++ b/src/lib/tools/straightEdge.ts
@@ -1,0 +1,79 @@
+import type { LineObject, StrokeStyle } from '$lib/types';
+import { snapAngleToStep } from './lineSnap';
+
+export interface Vec2 {
+  x: number;
+  y: number;
+}
+
+export const DEFAULT_STRAIGHT_EDGE_SNAP_STEP = 15;
+
+export interface StraightEdgeEndpointInput {
+  start: Vec2;
+  current: Vec2;
+  snapStepDeg: number;
+  bypassSnap: boolean;
+}
+
+/**
+ * Resolve the committed endpoint for a Shift-held stroke. When Alt is held
+ * (`bypassSnap`) or the configured snap step is non-positive, the raw cursor
+ * position wins; otherwise the angle is locked to the nearest multiple.
+ */
+export function straightEdgeEndpoint(input: StraightEdgeEndpointInput): Vec2 {
+  if (input.bypassSnap) return { x: input.current.x, y: input.current.y };
+  return snapAngleToStep(input.start, input.current, input.snapStepDeg);
+}
+
+export interface StraightEdgeCommitInput {
+  shiftAtPointerUp: boolean;
+  rulerActive: boolean;
+  tool: 'pen' | 'highlighter' | 'eraser' | 'select' | string;
+  altAtPointerUp: boolean;
+  first: Vec2;
+  last: Vec2;
+  style: StrokeStyle;
+  snapStepDeg: number;
+}
+
+export type StraightEdgeCommit = { kind: 'line'; from: Vec2; to: Vec2 } | { kind: 'stroke' };
+
+/**
+ * Pure commit-time decision. Produces a `line` descriptor when Shift was
+ * held at pointer-up for a pen/highlighter stroke with no active ruler and
+ * the segment has non-zero length; otherwise signals that the caller should
+ * commit the stroke normally.
+ */
+export function decideStraightEdgeCommit(input: StraightEdgeCommitInput): StraightEdgeCommit {
+  if (!input.shiftAtPointerUp) return { kind: 'stroke' };
+  if (input.rulerActive) return { kind: 'stroke' };
+  if (input.tool !== 'pen' && input.tool !== 'highlighter') return { kind: 'stroke' };
+  const to = straightEdgeEndpoint({
+    start: input.first,
+    current: input.last,
+    snapStepDeg: input.snapStepDeg,
+    bypassSnap: input.altAtPointerUp,
+  });
+  if (Math.hypot(to.x - input.first.x, to.y - input.first.y) < 1e-6) {
+    return { kind: 'stroke' };
+  }
+  return { kind: 'line', from: { ...input.first }, to };
+}
+
+export function buildStraightEdgeLine(
+  id: string,
+  createdAt: number,
+  from: Vec2,
+  to: Vec2,
+  style: StrokeStyle,
+): LineObject {
+  return {
+    id,
+    createdAt,
+    type: 'line',
+    style: { ...style },
+    from: { ...from },
+    to: { ...to },
+    arrow: { start: false, end: false },
+  };
+}

--- a/src/lib/tools/straightEdge.ts
+++ b/src/lib/tools/straightEdge.ts
@@ -1,4 +1,4 @@
-import type { LineObject, StrokeStyle } from '$lib/types';
+import type { LineObject, Point, StrokeObject, StrokeStyle } from '$lib/types';
 import { snapAngleToStep } from './lineSnap';
 
 export interface Vec2 {
@@ -36,18 +36,22 @@ export interface StraightEdgeCommitInput {
   snapStepDeg: number;
 }
 
-export type StraightEdgeCommit = { kind: 'line'; from: Vec2; to: Vec2 } | { kind: 'stroke' };
+export type StraightEdgeCommit =
+  | { kind: 'line'; from: Vec2; to: Vec2 }
+  | { kind: 'stroke'; from: Vec2; to: Vec2 }
+  | { kind: 'none' };
 
 /**
- * Pure commit-time decision. Produces a `line` descriptor when Shift was
- * held at pointer-up for a pen/highlighter stroke with no active ruler and
- * the segment has non-zero length; otherwise signals that the caller should
- * commit the stroke normally.
+ * Pure commit-time decision for Shift-held strokes. Pen commits resolve to a
+ * `LineObject` so they render via `ShapeLayer`; highlighter commits resolve
+ * to a 2-point `StrokeObject` so the straight segment keeps the same
+ * multiply blend + opacity clamp as a normal highlighter stroke and matches
+ * the live preview. `none` means the caller should commit the stroke as-is.
  */
 export function decideStraightEdgeCommit(input: StraightEdgeCommitInput): StraightEdgeCommit {
-  if (!input.shiftAtPointerUp) return { kind: 'stroke' };
-  if (input.rulerActive) return { kind: 'stroke' };
-  if (input.tool !== 'pen' && input.tool !== 'highlighter') return { kind: 'stroke' };
+  if (!input.shiftAtPointerUp) return { kind: 'none' };
+  if (input.rulerActive) return { kind: 'none' };
+  if (input.tool !== 'pen' && input.tool !== 'highlighter') return { kind: 'none' };
   const to = straightEdgeEndpoint({
     start: input.first,
     current: input.last,
@@ -55,9 +59,11 @@ export function decideStraightEdgeCommit(input: StraightEdgeCommitInput): Straig
     bypassSnap: input.altAtPointerUp,
   });
   if (Math.hypot(to.x - input.first.x, to.y - input.first.y) < 1e-6) {
-    return { kind: 'stroke' };
+    return { kind: 'none' };
   }
-  return { kind: 'line', from: { ...input.first }, to };
+  const from = { ...input.first };
+  if (input.tool === 'highlighter') return { kind: 'stroke', from, to };
+  return { kind: 'line', from, to };
 }
 
 export function buildStraightEdgeLine(
@@ -75,5 +81,32 @@ export function buildStraightEdgeLine(
     from: { ...from },
     to: { ...to },
     arrow: { start: false, end: false },
+  };
+}
+
+/**
+ * Build a 2-point highlighter `StrokeObject` for a Shift-committed straight
+ * segment. Mirrors `strokeFromInput` shape so the stroke renders via the
+ * highlighter layer (multiply + opacity clamp) exactly like a free-drawn
+ * highlighter stroke.
+ */
+export function buildStraightEdgeStroke(
+  id: string,
+  createdAt: number,
+  from: Vec2,
+  to: Vec2,
+  style: StrokeStyle,
+): StrokeObject {
+  const endpoints: Point[] = [
+    { x: from.x, y: from.y, pressure: 0.5, t: 0 },
+    { x: to.x, y: to.y, pressure: 0.5, t: 0 },
+  ];
+  return {
+    id,
+    createdAt,
+    type: 'stroke',
+    tool: 'highlighter',
+    style: { ...style },
+    points: endpoints,
   };
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -688,6 +688,7 @@
               penStabilization={sidebarState.smoothingPen}
               highlighterStabilization={sidebarState.smoothingHighlighter}
               tempInkStabilization={sidebarState.smoothingTempInk}
+              straightEdgeSnapStep={sidebarState.straightEdgeSnapStep}
               rulerSnap={rulerSnapState}
               oncommit={onCommitStroke}
               onerase={onEraseAt}

--- a/tests/sidebar-straight-edge-persist.test.ts
+++ b/tests/sidebar-straight-edge-persist.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+function makeLocalStorageStub() {
+  const store = new Map<string, string>();
+  return {
+    store,
+    impl: {
+      getItem: (k: string) => (store.has(k) ? (store.get(k) ?? null) : null),
+      setItem: (k: string, v: string) => {
+        store.set(k, v);
+      },
+      removeItem: (k: string) => {
+        store.delete(k);
+      },
+      clear: () => store.clear(),
+      key: (i: number) => Array.from(store.keys())[i] ?? null,
+      get length() {
+        return store.size;
+      },
+    } as Storage,
+  };
+}
+
+describe('sidebar straight-edge snap setting', () => {
+  let stub: ReturnType<typeof makeLocalStorageStub>;
+
+  beforeEach(() => {
+    stub = makeLocalStorageStub();
+    vi.stubGlobal('localStorage', stub.impl);
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('defaults to 15°', async () => {
+    const mod = await import('$lib/store/sidebar');
+    expect(mod.sidebar.snapshot().straightEdgeSnapStep).toBe(mod.DEFAULT_STRAIGHT_EDGE_SNAP_STEP);
+  });
+
+  it('clamps out-of-range updates to [MIN, MAX]', async () => {
+    const mod = await import('$lib/store/sidebar');
+    mod.sidebar.setStraightEdgeSnapStep(-5);
+    expect(mod.sidebar.snapshot().straightEdgeSnapStep).toBe(mod.MIN_STRAIGHT_EDGE_SNAP_STEP);
+    mod.sidebar.setStraightEdgeSnapStep(9999);
+    expect(mod.sidebar.snapshot().straightEdgeSnapStep).toBe(mod.MAX_STRAIGHT_EDGE_SNAP_STEP);
+    mod.sidebar.setStraightEdgeSnapStep(30);
+    expect(mod.sidebar.snapshot().straightEdgeSnapStep).toBe(30);
+  });
+
+  it('persists and restores the snap step', async () => {
+    const mod = await import('$lib/store/sidebar');
+    const stop = mod.hydrateSidebarFromStorage();
+    mod.sidebar.setStraightEdgeSnapStep(45);
+    const raw = stub.store.get('eldraw.straight-edge.v1');
+    expect(raw).toBeDefined();
+    expect(JSON.parse(raw as string)).toEqual({ snapStepDeg: 45 });
+    stop();
+
+    vi.resetModules();
+    stub.store.set('eldraw.straight-edge.v1', JSON.stringify({ snapStepDeg: 60 }));
+    const reloaded = await import('$lib/store/sidebar');
+    const stop2 = reloaded.hydrateSidebarFromStorage();
+    expect(reloaded.sidebar.snapshot().straightEdgeSnapStep).toBe(60);
+    stop2();
+  });
+
+  it('ignores malformed persisted payload', async () => {
+    stub.store.set('eldraw.straight-edge.v1', '{"snapStepDeg":"nope"}');
+    const mod = await import('$lib/store/sidebar');
+    const stop = mod.hydrateSidebarFromStorage();
+    expect(mod.sidebar.snapshot().straightEdgeSnapStep).toBe(mod.DEFAULT_STRAIGHT_EDGE_SNAP_STEP);
+    stop();
+  });
+});

--- a/tests/straight-edge.test.ts
+++ b/tests/straight-edge.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildStraightEdgeLine,
+  decideStraightEdgeCommit,
+  straightEdgeEndpoint,
+} from '$lib/tools/straightEdge';
+import { snapAngleToStep } from '$lib/tools/lineSnap';
+import type { StrokeStyle } from '$lib/types';
+
+const STYLE: StrokeStyle = { color: '#123456', width: 3, dash: 'solid', opacity: 1 };
+
+function angle(a: { x: number; y: number }, b: { x: number; y: number }): number {
+  return Math.atan2(b.y - a.y, b.x - a.x);
+}
+
+describe('snapAngleToStep', () => {
+  it('snaps to a configurable step in degrees', () => {
+    const start = { x: 0, y: 0 };
+    const noisy = { x: 10 * Math.cos(0.4), y: 10 * Math.sin(0.4) };
+    const snapped30 = snapAngleToStep(start, noisy, 30);
+    expect(angle(start, snapped30)).toBeCloseTo((30 * Math.PI) / 180, 6);
+    const snapped45 = snapAngleToStep(start, noisy, 45);
+    expect(angle(start, snapped45)).toBeCloseTo((45 * Math.PI) / 180, 6);
+  });
+
+  it('returns endpoint unchanged when step is non-positive', () => {
+    const end = { x: 7, y: 3 };
+    expect(snapAngleToStep({ x: 0, y: 0 }, end, 0)).toEqual(end);
+    expect(snapAngleToStep({ x: 0, y: 0 }, end, -15)).toEqual(end);
+  });
+
+  it('preserves segment length after snapping', () => {
+    const start = { x: 1, y: 2 };
+    const end = { x: 51, y: 29 };
+    const snapped = snapAngleToStep(start, end, 15);
+    const original = Math.hypot(end.x - start.x, end.y - start.y);
+    const after = Math.hypot(snapped.x - start.x, snapped.y - start.y);
+    expect(after).toBeCloseTo(original, 6);
+  });
+});
+
+describe('straightEdgeEndpoint', () => {
+  it('bypasses snap when bypassSnap is true', () => {
+    const first = { x: 0, y: 0 };
+    const current = { x: 12, y: 5 };
+    const out = straightEdgeEndpoint({
+      start: first,
+      current,
+      snapStepDeg: 15,
+      bypassSnap: true,
+    });
+    expect(out).toEqual(current);
+  });
+
+  it('applies the configured snap step when not bypassed', () => {
+    const first = { x: 0, y: 0 };
+    const noisy = { x: 100 * Math.cos(0.05), y: 100 * Math.sin(0.05) };
+    const out = straightEdgeEndpoint({
+      start: first,
+      current: noisy,
+      snapStepDeg: 15,
+      bypassSnap: false,
+    });
+    expect(angle(first, out)).toBeCloseTo(0, 6);
+  });
+});
+
+describe('decideStraightEdgeCommit', () => {
+  const baseInput = {
+    shiftAtPointerUp: true,
+    altAtPointerUp: false,
+    rulerActive: false,
+    tool: 'pen' as const,
+    first: { x: 0, y: 0 },
+    last: { x: 100, y: 3 },
+    style: STYLE,
+    snapStepDeg: 15,
+  };
+
+  it('commits a line when Shift is held at pointer-up for the pen', () => {
+    const decision = decideStraightEdgeCommit(baseInput);
+    expect(decision.kind).toBe('line');
+    if (decision.kind !== 'line') return;
+    expect(decision.from).toEqual({ x: 0, y: 0 });
+    expect(angle(decision.from, decision.to)).toBeCloseTo(0, 6);
+  });
+
+  it('commits a line when Shift is held at pointer-up for the highlighter', () => {
+    const decision = decideStraightEdgeCommit({ ...baseInput, tool: 'highlighter' });
+    expect(decision.kind).toBe('line');
+  });
+
+  it('keeps the stroke commit when Shift is not held at pointer-up', () => {
+    const decision = decideStraightEdgeCommit({ ...baseInput, shiftAtPointerUp: false });
+    expect(decision.kind).toBe('stroke');
+  });
+
+  it('defers to ruler snap when ruler is active', () => {
+    const decision = decideStraightEdgeCommit({ ...baseInput, rulerActive: true });
+    expect(decision.kind).toBe('stroke');
+  });
+
+  it('does not trigger for non-pen tools', () => {
+    const decision = decideStraightEdgeCommit({ ...baseInput, tool: 'eraser' });
+    expect(decision.kind).toBe('stroke');
+  });
+
+  it('treats Alt as a snap bypass', () => {
+    const noisy = { x: 100 * Math.cos(0.05), y: 100 * Math.sin(0.05) };
+    const snapped = decideStraightEdgeCommit({ ...baseInput, last: noisy });
+    const bypassed = decideStraightEdgeCommit({
+      ...baseInput,
+      last: noisy,
+      altAtPointerUp: true,
+    });
+    expect(snapped.kind).toBe('line');
+    expect(bypassed.kind).toBe('line');
+    if (snapped.kind !== 'line' || bypassed.kind !== 'line') return;
+    expect(angle(snapped.from, snapped.to)).toBeCloseTo(0, 6);
+    expect(bypassed.to).toEqual(noisy);
+  });
+
+  it('falls back to stroke for zero-length shift drags', () => {
+    const decision = decideStraightEdgeCommit({ ...baseInput, last: { x: 0, y: 0 } });
+    expect(decision.kind).toBe('stroke');
+  });
+});
+
+describe('buildStraightEdgeLine', () => {
+  it('creates a LineObject with no arrowheads and a fresh style copy', () => {
+    const line = buildStraightEdgeLine('abc', 123, { x: 0, y: 0 }, { x: 50, y: 50 }, STYLE);
+    expect(line.type).toBe('line');
+    expect(line.id).toBe('abc');
+    expect(line.createdAt).toBe(123);
+    expect(line.arrow).toEqual({ start: false, end: false });
+    expect(line.style).toEqual(STYLE);
+    expect(line.style).not.toBe(STYLE);
+  });
+});

--- a/tests/straight-edge.test.ts
+++ b/tests/straight-edge.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildStraightEdgeLine,
+  buildStraightEdgeStroke,
   decideStraightEdgeCommit,
   straightEdgeEndpoint,
 } from '$lib/tools/straightEdge';
@@ -85,24 +86,27 @@ describe('decideStraightEdgeCommit', () => {
     expect(angle(decision.from, decision.to)).toBeCloseTo(0, 6);
   });
 
-  it('commits a line when Shift is held at pointer-up for the highlighter', () => {
+  it('commits a 2-point stroke when Shift is held at pointer-up for the highlighter', () => {
     const decision = decideStraightEdgeCommit({ ...baseInput, tool: 'highlighter' });
-    expect(decision.kind).toBe('line');
+    expect(decision.kind).toBe('stroke');
+    if (decision.kind !== 'stroke') return;
+    expect(decision.from).toEqual({ x: 0, y: 0 });
+    expect(angle(decision.from, decision.to)).toBeCloseTo(0, 6);
   });
 
-  it('keeps the stroke commit when Shift is not held at pointer-up', () => {
+  it('keeps the normal stroke commit when Shift is not held at pointer-up', () => {
     const decision = decideStraightEdgeCommit({ ...baseInput, shiftAtPointerUp: false });
-    expect(decision.kind).toBe('stroke');
+    expect(decision.kind).toBe('none');
   });
 
   it('defers to ruler snap when ruler is active', () => {
     const decision = decideStraightEdgeCommit({ ...baseInput, rulerActive: true });
-    expect(decision.kind).toBe('stroke');
+    expect(decision.kind).toBe('none');
   });
 
-  it('does not trigger for non-pen tools', () => {
+  it('does not trigger for non-pen/non-highlighter tools', () => {
     const decision = decideStraightEdgeCommit({ ...baseInput, tool: 'eraser' });
-    expect(decision.kind).toBe('stroke');
+    expect(decision.kind).toBe('none');
   });
 
   it('treats Alt as a snap bypass', () => {
@@ -120,9 +124,9 @@ describe('decideStraightEdgeCommit', () => {
     expect(bypassed.to).toEqual(noisy);
   });
 
-  it('falls back to stroke for zero-length shift drags', () => {
+  it('falls back to normal commit for zero-length shift drags', () => {
     const decision = decideStraightEdgeCommit({ ...baseInput, last: { x: 0, y: 0 } });
-    expect(decision.kind).toBe('stroke');
+    expect(decision.kind).toBe('none');
   });
 });
 
@@ -135,5 +139,20 @@ describe('buildStraightEdgeLine', () => {
     expect(line.arrow).toEqual({ start: false, end: false });
     expect(line.style).toEqual(STYLE);
     expect(line.style).not.toBe(STYLE);
+  });
+});
+
+describe('buildStraightEdgeStroke', () => {
+  it('creates a 2-point highlighter StrokeObject with a fresh style copy', () => {
+    const stroke = buildStraightEdgeStroke('abc', 123, { x: 0, y: 0 }, { x: 50, y: 50 }, STYLE);
+    expect(stroke.type).toBe('stroke');
+    expect(stroke.tool).toBe('highlighter');
+    expect(stroke.id).toBe('abc');
+    expect(stroke.createdAt).toBe(123);
+    expect(stroke.points).toHaveLength(2);
+    expect(stroke.points[0]).toMatchObject({ x: 0, y: 0 });
+    expect(stroke.points[1]).toMatchObject({ x: 50, y: 50 });
+    expect(stroke.style).toEqual(STYLE);
+    expect(stroke.style).not.toBe(STYLE);
   });
 });


### PR DESCRIPTION
Closes #137.

## Summary
Holding **Shift** at any point during a pen or highlighter stroke collapses the live preview to a straight segment from the first sample to the current cursor. The shift state at pointer-up picks the commit: Shift held → `LineObject` (erase/select treat it cleanly, no arrowheads); Shift released → normal freehand `StrokeObject`.

While Shift is held, the segment angle snaps to the nearest multiple of a user-configurable step (default **15°**). Hold **Alt** to bypass the angle snap. Ruler snap still wins when the ruler overlay is up — straight-edge mode backs off entirely in that case.

## Changes
- `src/lib/tools/lineSnap.ts` — generalized `snapAngle15` into `snapAngleToStep(start, end, stepDeg)`; `snapAngle15` kept as a thin wrapper for the existing line-tool consumer.
- `src/lib/tools/straightEdge.ts` — new pure helpers: `straightEdgeEndpoint`, `decideStraightEdgeCommit`, `buildStraightEdgeLine`.
- `src/lib/canvas/LiveLayer.svelte` — tracks `shiftKey` / `altKey` on every pointer event (not a separate keydown listener, per pointer-capture best practice), swaps preview between freehand and straight segment per frame, and dispatches the right commit callback at pointer-up. Straight previews render through `drawLine` so they match the committed `LineObject` pixel-for-pixel.
- `src/lib/canvas/CanvasStack.svelte`, `src/routes/+page.svelte` — wire the new `straightEdgeSnapStep` prop and route straight-edge line commits through the existing `oncommitobject` path.
- `src/lib/store/sidebar.ts` — new `straightEdgeSnapStep` field on `SidebarState` (default 15°, clamped to 1–90°), setter, remote-sync, import/export, and dedicated persistence under `eldraw.straight-edge.v1`.
- `src/lib/sidebar/Sidebar.svelte` — new "Straight-edge snap" section visible when pen or highlighter is active, with a range input and hint copy.

## Behavior / Edge Cases
- Shift pressed / released mid-stroke: preview toggles between straight and freehand every frame; the accumulated sample buffer keeps growing so releasing Shift resumes freehand naturally. Only the **final** shift state at pointer-up decides the commit kind.
- Zero-length Shift drag: falls back to a stroke commit (LineObject with length < 1e-6 is rejected).
- Non-pen/highlighter tools (eraser, select, graph, ruler, etc.): unchanged.
- Ruler overlay visible (`rulerSnap !== null`): straight-edge mode disables itself, ruler snap path wins both during preview and at commit.
- Session recorder: line commits flow through `mutationToSessionEvents` as `objectAdd`, so replay reproduces the behavior without any session-event changes.
- Undo/erase/select: a straight-edge commit is a regular `LineObject`, indistinguishable from line-tool output for every downstream consumer.

## Testing
- `tests/straight-edge.test.ts` — unit coverage for `snapAngleToStep` (configurable step, non-positive = no-op, length preserved), `straightEdgeEndpoint` (Alt bypass), `decideStraightEdgeCommit` (pen/highlighter only, shift-at-pointer-up authoritative, ruler active defers, zero-length rejects, Alt bypass), and `buildStraightEdgeLine` (arrow-less, style copy).
- `tests/sidebar-straight-edge-persist.test.ts` — default value, clamping, persistence round-trip, malformed payload ignored.
- `pnpm lint` ✓ (prettier + eslint + svelte-check)
- `pnpm test` ✓ (67 files / 628 tests)
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings` ✓
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check` ✓