### PR TITLE
feat(tools): lasso select with move / resize / recolor / restyle

### DIFF
--- a/src/lib/app/shortcutRegistry.ts
+++ b/src/lib/app/shortcutRegistry.ts
@@ -14,6 +14,7 @@ export type ShortcutId =
   | 'tool.pen'
   | 'tool.highlighter'
   | 'tool.eraser'
+  | 'tool.select'
   | 'tool.line'
   | 'tool.rect'
   | 'tool.ellipse'
@@ -91,6 +92,7 @@ const TOOL_COMMANDS: Array<{ id: ShortcutId; label: string; spec: string; tool: 
   { id: 'tool.pen', label: 'Tool: Pen', spec: 'p', tool: 'pen' },
   { id: 'tool.highlighter', label: 'Tool: Highlighter', spec: 'h', tool: 'highlighter' },
   { id: 'tool.eraser', label: 'Tool: Eraser', spec: 'e', tool: 'eraser' },
+  { id: 'tool.select', label: 'Tool: Select', spec: 's', tool: 'select' },
   { id: 'tool.line', label: 'Tool: Line', spec: 'l', tool: 'line' },
   { id: 'tool.rect', label: 'Tool: Rectangle', spec: 'r', tool: 'rect' },
   { id: 'tool.ellipse', label: 'Tool: Ellipse', spec: 'o', tool: 'ellipse' },

--- a/src/lib/command/commands.ts
+++ b/src/lib/command/commands.ts
@@ -88,6 +88,7 @@ export function getCommands(): Command[] {
     toolCommand('tool.pen', 'Pen', 'pen', 'P'),
     toolCommand('tool.highlighter', 'Highlighter', 'highlighter', 'H'),
     toolCommand('tool.eraser', 'Eraser', 'eraser', 'E'),
+    toolCommand('tool.select', 'Select', 'select', 'S'),
     toolCommand('tool.line', 'Line', 'line', 'L'),
     toolCommand('tool.text', 'Text', 'text', 'T'),
     toolCommand('tool.rect', 'Rectangle', 'rect', 'R'),

--- a/src/lib/select/SelectionLayer.svelte
+++ b/src/lib/select/SelectionLayer.svelte
@@ -26,7 +26,13 @@
   import { pickInLasso, pickInMarquee, pickTopAt } from './hitTest';
   import type { Rect, Vec2 } from './geometry';
   import { transformObject, translateObject } from './transform';
-  import { commitStylePatch, commitTransform, commitTranslate, commitDelete } from './ops';
+  import {
+    commitStylePatch,
+    commitTransform,
+    commitTranslate,
+    commitDelete,
+    reorderSelection,
+  } from './ops';
   import {
     duplicateInPlace,
     hasClipboardContents,
@@ -35,7 +41,6 @@
     stampForPaste,
   } from './clipboard';
   import { documentStore } from '$lib/store/document';
-  import { reorderArray } from './ops';
   import SelectionToolbar from './SelectionToolbar.svelte';
 
   interface Props {
@@ -193,7 +198,7 @@
         kind: 'marquee',
         start: p,
         current: p,
-        additive: e.ctrlKey || e.metaKey || selectedObjects.length > 0,
+        additive: e.ctrlKey || e.metaKey,
       };
     } else {
       if (selectedObjects.length > 0) selection.clear();
@@ -265,7 +270,10 @@
     };
     const preview = new Map<ObjectId, AnyObject>();
     for (const o of itx.startObjects) {
-      preview.set(o.id, transformObject(o, { scale: { sx, sy, pivot } }));
+      preview.set(
+        o.id,
+        transformObject(o, { scale: { sx, sy, pivot } }, { scaleStrokeWidth: true }),
+      );
     }
     return preview;
   }
@@ -417,22 +425,11 @@
   }
 
   function onBringForward() {
-    reorderAndCommit('forward');
+    reorderSelection(pageIndex, selectionState.ids, 'forward');
   }
 
   function onSendBackward() {
-    reorderAndCommit('backward');
-  }
-
-  function reorderAndCommit(direction: 'forward' | 'backward') {
-    const next = reorderArray(objects, selectionState.ids, direction);
-    const same = next.length === objects.length && next.every((o, i) => o.id === objects[i].id);
-    if (same) return;
-    documentStore.removeObjects(
-      pageIndex,
-      objects.map((o) => o.id),
-    );
-    for (const obj of next) documentStore.addObject(pageIndex, obj);
+    reorderSelection(pageIndex, selectionState.ids, 'backward');
   }
 
   function lassoPathD(points: readonly Vec2[]): string {

--- a/src/lib/select/SelectionLayer.svelte
+++ b/src/lib/select/SelectionLayer.svelte
@@ -1,0 +1,589 @@
+<script lang="ts" module>
+  interface HandlePos {
+    id: string;
+    x: number;
+    y: number;
+  }
+
+  export function handlePositions(r: { x: number; y: number; w: number; h: number }): HandlePos[] {
+    return [
+      { id: 'nw', x: r.x, y: r.y },
+      { id: 'n', x: r.x + r.w / 2, y: r.y },
+      { id: 'ne', x: r.x + r.w, y: r.y },
+      { id: 'e', x: r.x + r.w, y: r.y + r.h / 2 },
+      { id: 'se', x: r.x + r.w, y: r.y + r.h },
+      { id: 's', x: r.x + r.w / 2, y: r.y + r.h },
+      { id: 'sw', x: r.x, y: r.y + r.h },
+      { id: 'w', x: r.x, y: r.y + r.h / 2 },
+    ];
+  }
+</script>
+
+<script lang="ts">
+  import type { AnyObject, ObjectId } from '$lib/types';
+  import type { SpatialIndex } from '$lib/tools/spatialIndex';
+  import { boundsOfObjects, filterSelected, selection } from './selection';
+  import { pickInLasso, pickInMarquee, pickTopAt } from './hitTest';
+  import type { Rect, Vec2 } from './geometry';
+  import { transformObject, translateObject } from './transform';
+  import { commitStylePatch, commitTransform, commitTranslate, commitDelete } from './ops';
+  import {
+    duplicateInPlace,
+    hasClipboardContents,
+    readClipboard,
+    setClipboard,
+    stampForPaste,
+  } from './clipboard';
+  import { documentStore } from '$lib/store/document';
+  import { reorderArray } from './ops';
+  import SelectionToolbar from './SelectionToolbar.svelte';
+
+  interface Props {
+    pageIndex: number;
+    objects: AnyObject[];
+    spatialIndex: SpatialIndex | null;
+    width: number;
+    height: number;
+    ptToPx: number;
+  }
+
+  let { pageIndex, objects, spatialIndex, width, height, ptToPx }: Props = $props();
+
+  const selectionState = $derived($selection);
+  const isActive = $derived(selectionState.pageIndex === pageIndex);
+  const selectedObjects = $derived(isActive ? filterSelected(objects, selectionState.ids) : []);
+
+  type Handle = 'nw' | 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w' | 'rotate' | 'move';
+
+  type Interaction =
+    | null
+    | { kind: 'lasso'; points: Vec2[]; additive: boolean }
+    | { kind: 'marquee'; start: Vec2; current: Vec2; additive: boolean }
+    | {
+        kind: 'move';
+        startPointer: Vec2;
+        startObjects: AnyObject[];
+        previewObjects: Map<ObjectId, AnyObject>;
+      }
+    | {
+        kind: 'resize';
+        handle: Exclude<Handle, 'rotate' | 'move'>;
+        startBounds: Rect;
+        startPointer: Vec2;
+        startObjects: AnyObject[];
+        previewObjects: Map<ObjectId, AnyObject>;
+      }
+    | {
+        kind: 'rotate';
+        pivot: Vec2;
+        startAngle: number;
+        startObjects: AnyObject[];
+        previewObjects: Map<ObjectId, AnyObject>;
+      };
+
+  let interaction = $state<Interaction>(null);
+  let root: HTMLDivElement | null = $state(null);
+
+  const previewOverrides = $derived<Map<ObjectId, AnyObject>>(
+    interaction &&
+      (interaction.kind === 'move' ||
+        interaction.kind === 'resize' ||
+        interaction.kind === 'rotate')
+      ? interaction.previewObjects
+      : new Map(),
+  );
+
+  const displaySelectedObjects = $derived(
+    selectedObjects.map((o) => previewOverrides.get(o.id) ?? o),
+  );
+  const displayBounds = $derived<Rect | null>(boundsOfObjects(displaySelectedObjects));
+
+  function pointerToPt(e: PointerEvent): Vec2 {
+    const rect = root!.getBoundingClientRect();
+    return { x: (e.clientX - rect.left) / ptToPx, y: (e.clientY - rect.top) / ptToPx };
+  }
+
+  function isInsideBounds(p: Vec2, r: Rect): boolean {
+    return p.x >= r.x && p.x <= r.x + r.w && p.y >= r.y && p.y <= r.y + r.h;
+  }
+
+  const HANDLE_SIZE_PX = 10;
+  const ROTATE_OFFSET_PX = 28;
+
+  function handleAt(p: Vec2, r: Rect): Handle | null {
+    const tolPt = HANDLE_SIZE_PX / ptToPx;
+    const near = (a: number, b: number) => Math.abs(a - b) <= tolPt;
+    const inX = p.x >= r.x - tolPt && p.x <= r.x + r.w + tolPt;
+    const inY = p.y >= r.y - tolPt && p.y <= r.y + r.h + tolPt;
+    if (near(p.x, r.x + r.w / 2) && near(p.y, r.y - ROTATE_OFFSET_PX / ptToPx)) return 'rotate';
+    if (!inX || !inY) return null;
+    const left = near(p.x, r.x);
+    const right = near(p.x, r.x + r.w);
+    const top = near(p.y, r.y);
+    const bottom = near(p.y, r.y + r.h);
+    if (left && top) return 'nw';
+    if (right && top) return 'ne';
+    if (left && bottom) return 'sw';
+    if (right && bottom) return 'se';
+    if (top) return 'n';
+    if (bottom) return 's';
+    if (left) return 'w';
+    if (right) return 'e';
+    return null;
+  }
+
+  function onPointerDown(e: PointerEvent) {
+    if (e.button !== 0) return;
+    if (e.pointerType === 'touch') return;
+    const p = pointerToPt(e);
+    root?.setPointerCapture?.(e.pointerId);
+
+    if (displayBounds && selectedObjects.length > 0) {
+      const h = handleAt(p, displayBounds);
+      if (h === 'rotate') {
+        const pivot = {
+          x: displayBounds.x + displayBounds.w / 2,
+          y: displayBounds.y + displayBounds.h / 2,
+        };
+        const startAngle = Math.atan2(p.y - pivot.y, p.x - pivot.x);
+        interaction = {
+          kind: 'rotate',
+          pivot,
+          startAngle,
+          startObjects: selectedObjects.slice(),
+          previewObjects: new Map(),
+        };
+        e.preventDefault();
+        return;
+      }
+      if (h && h !== 'move') {
+        interaction = {
+          kind: 'resize',
+          handle: h,
+          startBounds: { ...displayBounds },
+          startPointer: p,
+          startObjects: selectedObjects.slice(),
+          previewObjects: new Map(),
+        };
+        e.preventDefault();
+        return;
+      }
+      if (isInsideBounds(p, displayBounds)) {
+        interaction = {
+          kind: 'move',
+          startPointer: p,
+          startObjects: selectedObjects.slice(),
+          previewObjects: new Map(),
+        };
+        e.preventDefault();
+        return;
+      }
+    }
+
+    const hit = pickTopAt(objects, spatialIndex, p, 2);
+    if (hit) {
+      if (e.shiftKey) selection.toggle(pageIndex, hit.id);
+      else selection.set(pageIndex, [hit.id]);
+      e.preventDefault();
+      return;
+    }
+
+    if (e.shiftKey) {
+      interaction = {
+        kind: 'marquee',
+        start: p,
+        current: p,
+        additive: e.ctrlKey || e.metaKey || selectedObjects.length > 0,
+      };
+    } else {
+      if (selectedObjects.length > 0) selection.clear();
+      selection.setPage(pageIndex);
+      interaction = { kind: 'lasso', points: [p], additive: false };
+    }
+    e.preventDefault();
+  }
+
+  function onPointerMove(e: PointerEvent) {
+    if (!interaction) return;
+    const p = pointerToPt(e);
+    if (interaction.kind === 'lasso') {
+      interaction = { ...interaction, points: [...interaction.points, p] };
+    } else if (interaction.kind === 'marquee') {
+      interaction = { ...interaction, current: p };
+    } else if (interaction.kind === 'move') {
+      const dx = p.x - interaction.startPointer.x;
+      const dy = p.y - interaction.startPointer.y;
+      const preview = new Map<ObjectId, AnyObject>();
+      for (const o of interaction.startObjects) preview.set(o.id, translateObject(o, dx, dy));
+      interaction = { ...interaction, previewObjects: preview };
+    } else if (interaction.kind === 'resize') {
+      const uniform = e.shiftKey;
+      const preview = buildResizePreview(interaction, p, uniform);
+      interaction = { ...interaction, previewObjects: preview };
+    } else if (interaction.kind === 'rotate') {
+      const current = Math.atan2(p.y - interaction.pivot.y, p.x - interaction.pivot.x);
+      let angle = current - interaction.startAngle;
+      if (e.shiftKey) {
+        const step = (15 * Math.PI) / 180;
+        angle = Math.round(angle / step) * step;
+      }
+      const preview = new Map<ObjectId, AnyObject>();
+      for (const o of interaction.startObjects) {
+        preview.set(o.id, transformObject(o, { rotate: { angle, pivot: interaction.pivot } }));
+      }
+      interaction = { ...interaction, previewObjects: preview };
+    }
+  }
+
+  function buildResizePreview(
+    itx: Extract<Interaction, { kind: 'resize' }>,
+    p: Vec2,
+    uniform: boolean,
+  ): Map<ObjectId, AnyObject> {
+    const b = itx.startBounds;
+    const handle = itx.handle;
+    let left = b.x;
+    let right = b.x + b.w;
+    let top = b.y;
+    let bottom = b.y + b.h;
+    if (handle.includes('w')) left = p.x;
+    if (handle.includes('e')) right = p.x;
+    if (handle.includes('n')) top = p.y;
+    if (handle.includes('s')) bottom = p.y;
+    if (left >= right) right = left + 0.5;
+    if (top >= bottom) bottom = top + 0.5;
+    let sx = (right - left) / b.w;
+    let sy = (bottom - top) / b.h;
+    if (uniform) {
+      const s = Math.max(Math.abs(sx), Math.abs(sy));
+      sx = sx < 0 ? -s : s;
+      sy = sy < 0 ? -s : s;
+    }
+    const pivot: Vec2 = {
+      x: handle.includes('w') ? b.x + b.w : handle.includes('e') ? b.x : b.x + b.w / 2,
+      y: handle.includes('n') ? b.y + b.h : handle.includes('s') ? b.y : b.y + b.h / 2,
+    };
+    const preview = new Map<ObjectId, AnyObject>();
+    for (const o of itx.startObjects) {
+      preview.set(o.id, transformObject(o, { scale: { sx, sy, pivot } }));
+    }
+    return preview;
+  }
+
+  function onPointerUp(e: PointerEvent) {
+    if (!interaction) return;
+    const p = pointerToPt(e);
+    root?.releasePointerCapture?.(e.pointerId);
+    const current = interaction;
+    interaction = null;
+
+    if (current.kind === 'lasso') {
+      if (current.points.length < 3) return;
+      const hits = pickInLasso(objects, spatialIndex, current.points);
+      selection.set(
+        pageIndex,
+        hits.map((o) => o.id),
+      );
+    } else if (current.kind === 'marquee') {
+      const rect = rectFromPoints(current.start, current.current);
+      const hits = pickInMarquee(objects, spatialIndex, rect);
+      if (current.additive) {
+        selection.add(
+          pageIndex,
+          hits.map((o) => o.id),
+        );
+      } else {
+        selection.set(
+          pageIndex,
+          hits.map((o) => o.id),
+        );
+      }
+    } else if (current.kind === 'move') {
+      const dx = p.x - current.startPointer.x;
+      const dy = p.y - current.startPointer.y;
+      if (dx === 0 && dy === 0) return;
+      commitTranslate(pageIndex, selectionState.ids, dx, dy);
+    } else if (current.kind === 'resize') {
+      const uniform = e.shiftKey;
+      const preview = buildResizePreview(current, p, uniform);
+      const afters: AnyObject[] = [];
+      for (const o of current.startObjects) {
+        const next = preview.get(o.id);
+        if (next) afters.push(next);
+      }
+      documentStore.updateObjects(pageIndex, afters);
+    } else if (current.kind === 'rotate') {
+      const angle = Math.atan2(p.y - current.pivot.y, p.x - current.pivot.x) - current.startAngle;
+      const snapped = e.shiftKey ? snapAngle(angle) : angle;
+      if (snapped === 0) return;
+      commitTransform(pageIndex, selectionState.ids, {
+        rotate: { angle: snapped, pivot: current.pivot },
+      });
+    }
+  }
+
+  function snapAngle(angle: number): number {
+    const step = (15 * Math.PI) / 180;
+    return Math.round(angle / step) * step;
+  }
+
+  function rectFromPoints(a: Vec2, b: Vec2): Rect {
+    const x = Math.min(a.x, b.x);
+    const y = Math.min(a.y, b.y);
+    const w = Math.abs(b.x - a.x);
+    const h = Math.abs(b.y - a.y);
+    return { x, y, w, h };
+  }
+
+  function onKeyDown(e: KeyboardEvent) {
+    if (!isActive || selectedObjects.length === 0) return;
+    const target = e.target as HTMLElement | null;
+    if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA')) return;
+    const step = e.shiftKey ? 10 : 1;
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      commitTranslate(pageIndex, selectionState.ids, -step, 0);
+    } else if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      commitTranslate(pageIndex, selectionState.ids, step, 0);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      commitTranslate(pageIndex, selectionState.ids, 0, -step);
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      commitTranslate(pageIndex, selectionState.ids, 0, step);
+    } else if (e.key === 'Delete' || e.key === 'Backspace') {
+      e.preventDefault();
+      commitDelete(pageIndex, selectionState.ids);
+      selection.clear();
+    } else if ((e.ctrlKey || e.metaKey) && (e.key === 'c' || e.key === 'C')) {
+      e.preventDefault();
+      setClipboard(selectedObjects);
+    } else if ((e.ctrlKey || e.metaKey) && (e.key === 'x' || e.key === 'X')) {
+      e.preventDefault();
+      setClipboard(selectedObjects);
+      commitDelete(pageIndex, selectionState.ids);
+      selection.clear();
+    } else if ((e.ctrlKey || e.metaKey) && (e.key === 'v' || e.key === 'V')) {
+      if (!hasClipboardContents()) return;
+      e.preventDefault();
+      const payload = readClipboard();
+      if (!payload) return;
+      const target = { x: 20, y: 20 };
+      const stamped = stampForPaste(payload, target);
+      for (const obj of stamped) documentStore.addObject(pageIndex, obj);
+      selection.set(
+        pageIndex,
+        stamped.map((o) => o.id),
+      );
+    } else if ((e.ctrlKey || e.metaKey) && (e.key === 'd' || e.key === 'D')) {
+      e.preventDefault();
+      const dups = duplicateInPlace(selectedObjects);
+      for (const obj of dups) documentStore.addObject(pageIndex, obj);
+      selection.set(
+        pageIndex,
+        dups.map((o) => o.id),
+      );
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      selection.clear();
+    }
+  }
+
+  function onColorChange(color: string) {
+    commitStylePatch(pageIndex, selectionState.ids, { color });
+  }
+
+  function onWidthChange(width: number) {
+    commitStylePatch(pageIndex, selectionState.ids, { width });
+  }
+
+  function onDashChange(dash: 'solid' | 'dashed' | 'dotted') {
+    commitStylePatch(pageIndex, selectionState.ids, { dash });
+  }
+
+  function onDelete() {
+    commitDelete(pageIndex, selectionState.ids);
+    selection.clear();
+  }
+
+  function onDuplicate() {
+    const dups = duplicateInPlace(selectedObjects);
+    for (const obj of dups) documentStore.addObject(pageIndex, obj);
+    selection.set(
+      pageIndex,
+      dups.map((o) => o.id),
+    );
+  }
+
+  function onBringForward() {
+    reorderAndCommit('forward');
+  }
+
+  function onSendBackward() {
+    reorderAndCommit('backward');
+  }
+
+  function reorderAndCommit(direction: 'forward' | 'backward') {
+    const next = reorderArray(objects, selectionState.ids, direction);
+    const same = next.length === objects.length && next.every((o, i) => o.id === objects[i].id);
+    if (same) return;
+    documentStore.removeObjects(
+      pageIndex,
+      objects.map((o) => o.id),
+    );
+    for (const obj of next) documentStore.addObject(pageIndex, obj);
+  }
+
+  function lassoPathD(points: readonly Vec2[]): string {
+    if (points.length === 0) return '';
+    const px = (v: Vec2) => `${v.x * ptToPx},${v.y * ptToPx}`;
+    return `M${px(points[0])} ${points
+      .slice(1)
+      .map((p) => `L${px(p)}`)
+      .join(' ')} Z`;
+  }
+
+  const marqueeRectPx = $derived<Rect | null>(
+    interaction?.kind === 'marquee'
+      ? (() => {
+          const r = rectFromPoints(interaction.start, interaction.current);
+          return {
+            x: r.x * ptToPx,
+            y: r.y * ptToPx,
+            w: r.w * ptToPx,
+            h: r.h * ptToPx,
+          };
+        })()
+      : null,
+  );
+
+  const boundsPx = $derived<Rect | null>(
+    displayBounds
+      ? {
+          x: displayBounds.x * ptToPx,
+          y: displayBounds.y * ptToPx,
+          w: displayBounds.w * ptToPx,
+          h: displayBounds.h * ptToPx,
+        }
+      : null,
+  );
+
+  const toolbarAnchor = $derived<{ left: number; top: number } | null>(
+    boundsPx
+      ? {
+          left: Math.max(0, boundsPx.x),
+          top: Math.max(0, boundsPx.y - 44),
+        }
+      : null,
+  );
+</script>
+
+<svelte:window onkeydown={onKeyDown} />
+
+<div
+  bind:this={root}
+  class="select-layer"
+  style="width: {width}px; height: {height}px;"
+  role="presentation"
+  onpointerdown={onPointerDown}
+  onpointermove={onPointerMove}
+  onpointerup={onPointerUp}
+  onpointercancel={onPointerUp}
+>
+  <svg class="overlay" {width} {height}>
+    {#if interaction?.kind === 'lasso'}
+      <path d={lassoPathD(interaction.points)} class="lasso" />
+    {/if}
+    {#if marqueeRectPx}
+      <rect
+        class="marquee"
+        x={marqueeRectPx.x}
+        y={marqueeRectPx.y}
+        width={marqueeRectPx.w}
+        height={marqueeRectPx.h}
+      />
+    {/if}
+    {#if boundsPx && selectedObjects.length > 0}
+      <rect class="bounds" x={boundsPx.x} y={boundsPx.y} width={boundsPx.w} height={boundsPx.h} />
+      {#each handlePositions(boundsPx) as h (h.id)}
+        <rect
+          class="handle"
+          x={h.x - HANDLE_SIZE_PX / 2}
+          y={h.y - HANDLE_SIZE_PX / 2}
+          width={HANDLE_SIZE_PX}
+          height={HANDLE_SIZE_PX}
+        />
+      {/each}
+      <line
+        class="rotate-stem"
+        x1={boundsPx.x + boundsPx.w / 2}
+        y1={boundsPx.y}
+        x2={boundsPx.x + boundsPx.w / 2}
+        y2={boundsPx.y - ROTATE_OFFSET_PX}
+      />
+      <circle
+        class="handle rotate"
+        cx={boundsPx.x + boundsPx.w / 2}
+        cy={boundsPx.y - ROTATE_OFFSET_PX}
+        r={HANDLE_SIZE_PX / 2}
+      />
+    {/if}
+  </svg>
+
+  {#if toolbarAnchor && selectedObjects.length > 0 && !interaction}
+    <SelectionToolbar
+      selectedObjects={displaySelectedObjects}
+      anchor={toolbarAnchor}
+      {onColorChange}
+      {onWidthChange}
+      {onDashChange}
+      {onDelete}
+      {onDuplicate}
+      {onBringForward}
+      {onSendBackward}
+    />
+  {/if}
+</div>
+
+<style>
+  .select-layer {
+    position: absolute;
+    inset: 0;
+    pointer-events: auto;
+    touch-action: none;
+  }
+  .overlay {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+  }
+  .bounds {
+    fill: rgba(100, 170, 255, 0.08);
+    stroke: #6fb1ff;
+    stroke-width: 1;
+    stroke-dasharray: 4 3;
+  }
+  .handle {
+    fill: #fff;
+    stroke: #6fb1ff;
+    stroke-width: 1;
+  }
+  .rotate-stem {
+    stroke: #6fb1ff;
+    stroke-width: 1;
+    stroke-dasharray: 2 2;
+  }
+  .lasso {
+    fill: rgba(100, 170, 255, 0.12);
+    stroke: #6fb1ff;
+    stroke-width: 1;
+    stroke-dasharray: 4 3;
+  }
+  .marquee {
+    fill: rgba(100, 170, 255, 0.08);
+    stroke: #6fb1ff;
+    stroke-width: 1;
+    stroke-dasharray: 4 3;
+  }
+</style>

--- a/src/lib/select/SelectionToolbar.svelte
+++ b/src/lib/select/SelectionToolbar.svelte
@@ -31,20 +31,32 @@
   const canWidth = $derived(selectedObjects.some(supportsWidth));
   const canDash = $derived(selectedObjects.some(supportsDash));
 
-  const currentWidth = $derived.by(() => {
-    for (const o of selectedObjects) {
-      if (
-        o.type === 'stroke' ||
-        o.type === 'line' ||
-        o.type === 'shape' ||
-        o.type === 'numberline'
-      ) {
-        return o.style.width;
-      }
-      if (o.type === 'angleMark') return o.width;
+  function widthOf(o: AnyObject): number | null {
+    if (o.type === 'stroke' || o.type === 'line' || o.type === 'shape' || o.type === 'numberline') {
+      return o.style.width;
     }
-    return 2;
+    if (o.type === 'angleMark') return o.width;
+    if (o.type === 'graph') {
+      for (const f of o.functions) {
+        if (typeof f.width === 'number') return f.width;
+      }
+      return null;
+    }
+    return null;
+  }
+
+  const currentWidth = $derived.by<number | null>(() => {
+    let found: number | null = null;
+    for (const o of selectedObjects) {
+      const w = widthOf(o);
+      if (w == null) continue;
+      if (found == null) found = w;
+      else if (found !== w) return null;
+    }
+    return found;
   });
+
+  const showWidth = $derived(canWidth && currentWidth != null);
 
   function pickColor(color: string) {
     onColorChange?.(color);
@@ -81,7 +93,7 @@
     </div>
   {/if}
 
-  {#if canWidth}
+  {#if showWidth}
     <div class="group" role="group" aria-label="Width">
       <input
         type="range"

--- a/src/lib/select/SelectionToolbar.svelte
+++ b/src/lib/select/SelectionToolbar.svelte
@@ -1,0 +1,186 @@
+<script lang="ts">
+  import type { AnyObject, DashStyle } from '$lib/types';
+  import { PRESET_COLORS } from '$lib/store/sidebar';
+  import { supportsColor, supportsDash, supportsWidth } from './transform';
+
+  interface Props {
+    selectedObjects: AnyObject[];
+    anchor: { left: number; top: number };
+    onColorChange?: (color: string) => void;
+    onWidthChange?: (width: number) => void;
+    onDashChange?: (dash: DashStyle) => void;
+    onDelete?: () => void;
+    onDuplicate?: () => void;
+    onBringForward?: () => void;
+    onSendBackward?: () => void;
+  }
+
+  let {
+    selectedObjects,
+    anchor,
+    onColorChange,
+    onWidthChange,
+    onDashChange,
+    onDelete,
+    onDuplicate,
+    onBringForward,
+    onSendBackward,
+  }: Props = $props();
+
+  const canColor = $derived(selectedObjects.some(supportsColor));
+  const canWidth = $derived(selectedObjects.some(supportsWidth));
+  const canDash = $derived(selectedObjects.some(supportsDash));
+
+  const currentWidth = $derived.by(() => {
+    for (const o of selectedObjects) {
+      if (
+        o.type === 'stroke' ||
+        o.type === 'line' ||
+        o.type === 'shape' ||
+        o.type === 'numberline'
+      ) {
+        return o.style.width;
+      }
+      if (o.type === 'angleMark') return o.width;
+    }
+    return 2;
+  });
+
+  function pickColor(color: string) {
+    onColorChange?.(color);
+  }
+
+  function changeWidth(e: Event) {
+    const n = Number((e.target as HTMLInputElement).value);
+    if (!Number.isFinite(n)) return;
+    onWidthChange?.(n);
+  }
+
+  function changeDash(dash: DashStyle) {
+    onDashChange?.(dash);
+  }
+</script>
+
+<div
+  class="selection-toolbar"
+  role="toolbar"
+  aria-label="Selection tools"
+  style="left: {anchor.left}px; top: {anchor.top}px;"
+>
+  {#if canColor}
+    <div class="group colors" role="group" aria-label="Color">
+      {#each PRESET_COLORS as color (color)}
+        <button
+          type="button"
+          class="swatch"
+          style="background: {color};"
+          aria-label={`Color ${color}`}
+          onclick={() => pickColor(color)}
+        ></button>
+      {/each}
+    </div>
+  {/if}
+
+  {#if canWidth}
+    <div class="group" role="group" aria-label="Width">
+      <input
+        type="range"
+        min="1"
+        max="40"
+        step="1"
+        value={currentWidth}
+        aria-label="Stroke width"
+        oninput={changeWidth}
+      />
+    </div>
+  {/if}
+
+  {#if canDash}
+    <div class="group dashes" role="group" aria-label="Dash style">
+      <button type="button" aria-label="Solid" onclick={() => changeDash('solid')}>—</button>
+      <button type="button" aria-label="Dashed" onclick={() => changeDash('dashed')}>- -</button>
+      <button type="button" aria-label="Dotted" onclick={() => changeDash('dotted')}>···</button>
+    </div>
+  {/if}
+
+  <div class="group ops" role="group" aria-label="Selection operations">
+    <button type="button" aria-label="Duplicate" title="Duplicate (Ctrl+D)" onclick={onDuplicate}>
+      ⎘
+    </button>
+    <button type="button" aria-label="Bring forward" title="Bring forward" onclick={onBringForward}>
+      ↑
+    </button>
+    <button type="button" aria-label="Send backward" title="Send backward" onclick={onSendBackward}>
+      ↓
+    </button>
+    <button type="button" class="danger" aria-label="Delete" title="Delete" onclick={onDelete}>
+      🗑
+    </button>
+  </div>
+</div>
+
+<style>
+  .selection-toolbar {
+    position: absolute;
+    z-index: 30;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 6px;
+    background: #222;
+    border: 1px solid #444;
+    border-radius: 6px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.45);
+    font-size: 12px;
+    color: #eee;
+    pointer-events: auto;
+    user-select: none;
+  }
+  .group {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 0 4px;
+    border-right: 1px solid #333;
+  }
+  .group:last-child {
+    border-right: none;
+  }
+  .colors {
+    flex-wrap: wrap;
+    max-width: 220px;
+  }
+  .swatch {
+    width: 16px;
+    height: 16px;
+    border-radius: 3px;
+    border: 1px solid #555;
+    cursor: pointer;
+    padding: 0;
+  }
+  .swatch:hover {
+    border-color: #fff;
+  }
+  .dashes button,
+  .ops button {
+    background: #2a2a2a;
+    border: 1px solid #3a3a3a;
+    color: #ddd;
+    border-radius: 4px;
+    padding: 2px 8px;
+    cursor: pointer;
+    min-width: 24px;
+    height: 22px;
+  }
+  .dashes button:hover,
+  .ops button:hover {
+    border-color: #7ab7ff;
+  }
+  .ops .danger:hover {
+    border-color: #e05555;
+    color: #e05555;
+  }
+  input[type='range'] {
+    width: 100px;
+  }
+</style>

--- a/src/lib/select/clipboard.ts
+++ b/src/lib/select/clipboard.ts
@@ -1,0 +1,59 @@
+import type { AnyObject } from '$lib/types';
+import { translateObject } from './transform';
+import { boundsOfObjects } from './selection';
+
+interface ClipboardEntry {
+  objects: AnyObject[];
+}
+
+let clipboard: ClipboardEntry | null = null;
+
+export function hasClipboardContents(): boolean {
+  return clipboard !== null && clipboard.objects.length > 0;
+}
+
+export function setClipboard(objects: readonly AnyObject[]): void {
+  clipboard = { objects: objects.map(cloneObject) };
+}
+
+export function readClipboard(): AnyObject[] | null {
+  if (!clipboard || clipboard.objects.length === 0) return null;
+  return clipboard.objects.map(cloneObject);
+}
+
+function cloneObject(o: AnyObject): AnyObject {
+  return structuredClone(o);
+}
+
+/**
+ * Produce a list of objects positioned for paste. `target` is where the
+ * paste origin should land (cursor position, or page center). The original
+ * selection's top-left is rewritten to `target`; new ids are assigned.
+ */
+export function stampForPaste(
+  source: readonly AnyObject[],
+  target: { x: number; y: number },
+): AnyObject[] {
+  if (source.length === 0) return [];
+  const bounds = boundsOfObjects(source);
+  const originX = bounds?.x ?? 0;
+  const originY = bounds?.y ?? 0;
+  const dx = target.x - originX;
+  const dy = target.y - originY;
+  return source.map((o) => {
+    const moved = translateObject(o, dx, dy);
+    return { ...moved, id: crypto.randomUUID(), createdAt: Date.now() } as AnyObject;
+  });
+}
+
+export function duplicateInPlace(source: readonly AnyObject[], offset = 16): AnyObject[] {
+  return source.map((o) => {
+    const moved = translateObject(o, offset, offset);
+    return { ...moved, id: crypto.randomUUID(), createdAt: Date.now() } as AnyObject;
+  });
+}
+
+/** Test-only escape hatch to reset clipboard state between tests. */
+export function __resetClipboardForTests(): void {
+  clipboard = null;
+}

--- a/src/lib/select/geometry.ts
+++ b/src/lib/select/geometry.ts
@@ -109,9 +109,11 @@ export function rectContains(outer: Rect, inner: Rect): boolean {
 }
 
 /**
- * True when the object intersects the lasso polygon. Strokes use accurate
- * segment-vs-polygon; shapes/lines/graphs/text/angle marks fall back to
- * their AABB so marquee-like behavior works without per-type polygon code.
+ * True when the object intersects the lasso polygon. Strokes, lines, and
+ * angle marks use accurate segment-vs-polygon tests on their polyline
+ * geometry. Other types (shape, graph, numberline, text) fall back to
+ * AABB-vs-polygon overlap, which is cheap and good enough for UI hit
+ * testing without per-type polygon code.
  */
 export function objectIntersectsPolygon(
   obj: AnyObject,

--- a/src/lib/select/geometry.ts
+++ b/src/lib/select/geometry.ts
@@ -1,0 +1,159 @@
+import type { AnyObject, StrokeObject } from '$lib/types';
+import { estimateTextBounds } from '$lib/text/hitTest';
+
+export interface Vec2 {
+  x: number;
+  y: number;
+}
+
+export interface Rect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/**
+ * Ray-casting point-in-polygon. Polygon is a list of vertices (closed
+ * implicitly by joining last->first). Returns true for interior points
+ * and is unspecified on the boundary; edges-of-polygon cases are rare
+ * enough in UI hit testing that a deterministic boundary rule isn't needed.
+ */
+export function pointInPolygon(p: Vec2, polygon: readonly Vec2[]): boolean {
+  if (polygon.length < 3) return false;
+  let inside = false;
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i, i += 1) {
+    const a = polygon[i];
+    const b = polygon[j];
+    const intersects =
+      a.y > p.y !== b.y > p.y &&
+      p.x < ((b.x - a.x) * (p.y - a.y)) / (b.y - a.y || Number.MIN_VALUE) + a.x;
+    if (intersects) inside = !inside;
+  }
+  return inside;
+}
+
+export function segmentsIntersect(a: Vec2, b: Vec2, c: Vec2, d: Vec2): boolean {
+  const d1 = cross(sub(d, c), sub(a, c));
+  const d2 = cross(sub(d, c), sub(b, c));
+  const d3 = cross(sub(b, a), sub(c, a));
+  const d4 = cross(sub(b, a), sub(d, a));
+  if (((d1 > 0 && d2 < 0) || (d1 < 0 && d2 > 0)) && ((d3 > 0 && d4 < 0) || (d3 < 0 && d4 > 0))) {
+    return true;
+  }
+  if (d1 === 0 && onSegment(c, d, a)) return true;
+  if (d2 === 0 && onSegment(c, d, b)) return true;
+  if (d3 === 0 && onSegment(a, b, c)) return true;
+  if (d4 === 0 && onSegment(a, b, d)) return true;
+  return false;
+}
+
+function sub(a: Vec2, b: Vec2): Vec2 {
+  return { x: a.x - b.x, y: a.y - b.y };
+}
+
+function cross(a: Vec2, b: Vec2): number {
+  return a.x * b.y - a.y * b.x;
+}
+
+function onSegment(a: Vec2, b: Vec2, p: Vec2): boolean {
+  const minX = Math.min(a.x, b.x);
+  const maxX = Math.max(a.x, b.x);
+  const minY = Math.min(a.y, b.y);
+  const maxY = Math.max(a.y, b.y);
+  return p.x >= minX && p.x <= maxX && p.y >= minY && p.y <= maxY;
+}
+
+/** True when any vertex of the polyline lies inside the polygon, or any
+ *  polyline segment crosses any polygon edge. Open polylines, not strokes
+ *  as thick ribbons — the stroke thickness is handled via the AABB prefilter. */
+export function polylineCrossesPolygon(points: readonly Vec2[], polygon: readonly Vec2[]): boolean {
+  if (points.length === 0 || polygon.length < 3) return false;
+  for (const p of points) {
+    if (pointInPolygon(p, polygon)) return true;
+  }
+  for (let i = 0; i < points.length - 1; i += 1) {
+    const a = points[i];
+    const b = points[i + 1];
+    for (let j = 0, k = polygon.length - 1; j < polygon.length; k = j, j += 1) {
+      if (segmentsIntersect(a, b, polygon[k], polygon[j])) return true;
+    }
+  }
+  return false;
+}
+
+export function strokeIntersectsPolygon(stroke: StrokeObject, polygon: readonly Vec2[]): boolean {
+  return polylineCrossesPolygon(stroke.points, polygon);
+}
+
+export function rectToPolygon(r: Rect): Vec2[] {
+  return [
+    { x: r.x, y: r.y },
+    { x: r.x + r.w, y: r.y },
+    { x: r.x + r.w, y: r.y + r.h },
+    { x: r.x, y: r.y + r.h },
+  ];
+}
+
+export function rectsOverlap(a: Rect, b: Rect): boolean {
+  return !(a.x + a.w < b.x || b.x + b.w < a.x || a.y + a.h < b.y || b.y + b.h < a.y);
+}
+
+export function rectContains(outer: Rect, inner: Rect): boolean {
+  return (
+    inner.x >= outer.x &&
+    inner.y >= outer.y &&
+    inner.x + inner.w <= outer.x + outer.w &&
+    inner.y + inner.h <= outer.y + outer.h
+  );
+}
+
+/**
+ * True when the object intersects the lasso polygon. Strokes use accurate
+ * segment-vs-polygon; shapes/lines/graphs/text/angle marks fall back to
+ * their AABB so marquee-like behavior works without per-type polygon code.
+ */
+export function objectIntersectsPolygon(
+  obj: AnyObject,
+  polygon: readonly Vec2[],
+  aabb: Rect,
+): boolean {
+  if (obj.type === 'stroke') {
+    return strokeIntersectsPolygon(obj, polygon);
+  }
+  if (obj.type === 'line') {
+    const a = { x: obj.from.x, y: obj.from.y };
+    const b = { x: obj.to.x, y: obj.to.y };
+    return polylineCrossesPolygon([a, b], polygon);
+  }
+  if (obj.type === 'angleMark') {
+    return polylineCrossesPolygon([obj.rayA, obj.vertex, obj.rayB], polygon);
+  }
+  return polygonOverlapsRect(polygon, aabb);
+}
+
+/** True when any polygon vertex is in the rect, any rect corner is in the
+ *  polygon, or any polygon edge crosses any rect edge. */
+export function polygonOverlapsRect(polygon: readonly Vec2[], rect: Rect): boolean {
+  const rectPoly = rectToPolygon(rect);
+  for (const p of polygon) {
+    if (p.x >= rect.x && p.x <= rect.x + rect.w && p.y >= rect.y && p.y <= rect.y + rect.h) {
+      return true;
+    }
+  }
+  for (const p of rectPoly) {
+    if (pointInPolygon(p, polygon)) return true;
+  }
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i, i += 1) {
+    for (let k = 0; k < rectPoly.length; k += 1) {
+      const l = (k + 1) % rectPoly.length;
+      if (segmentsIntersect(polygon[j], polygon[i], rectPoly[k], rectPoly[l])) return true;
+    }
+  }
+  return false;
+}
+
+export function textObjectBounds(obj: Extract<AnyObject, { type: 'text' }>): Rect {
+  const b = estimateTextBounds(obj);
+  return { x: b.x, y: b.y, w: b.width, h: b.height };
+}

--- a/src/lib/select/hitTest.ts
+++ b/src/lib/select/hitTest.ts
@@ -1,0 +1,93 @@
+import type { AnyObject } from '$lib/types';
+import { hitTestObject } from '$lib/tools/eraser';
+import { queryPoint, queryRect, type SpatialIndex } from '$lib/tools/spatialIndex';
+import { objectIntersectsPolygon, type Rect, type Vec2 } from './geometry';
+import { objectAabb } from '$lib/tools/spatialIndex';
+
+/**
+ * Topmost object under the pointer, or null when nothing is hit. Iterates
+ * spatial-index candidates and falls back to the full list when no index is
+ * available (e.g., tests).
+ */
+export function pickTopAt(
+  objects: readonly AnyObject[],
+  index: SpatialIndex | null,
+  at: Vec2,
+  radius: number,
+): AnyObject | null {
+  const candidates = index ? queryPoint(index, at.x, at.y, radius) : objects;
+  let best: AnyObject | null = null;
+  let bestRank = -Infinity;
+  const rankOf = new Map<string, number>();
+  for (let i = 0; i < objects.length; i += 1) rankOf.set(objects[i].id, i);
+  for (const obj of candidates) {
+    if (!hitTestObject(obj, at, radius)) continue;
+    const rank = rankOf.get(obj.id) ?? -1;
+    if (rank > bestRank) {
+      bestRank = rank;
+      best = obj;
+    }
+  }
+  return best;
+}
+
+export function pickInMarquee(
+  objects: readonly AnyObject[],
+  index: SpatialIndex | null,
+  rect: Rect,
+): AnyObject[] {
+  const candidates = index
+    ? queryRect(index, rect.x, rect.y, rect.x + rect.w, rect.y + rect.h)
+    : objects;
+  const seen = new Set<string>();
+  const out: AnyObject[] = [];
+  for (const obj of candidates) {
+    if (seen.has(obj.id)) continue;
+    const b = objectAabb(obj);
+    if (
+      b.maxX < rect.x ||
+      b.minX > rect.x + rect.w ||
+      b.maxY < rect.y ||
+      b.minY > rect.y + rect.h
+    ) {
+      continue;
+    }
+    seen.add(obj.id);
+    out.push(obj);
+  }
+  return out;
+}
+
+export function pickInLasso(
+  objects: readonly AnyObject[],
+  index: SpatialIndex | null,
+  polygon: readonly Vec2[],
+): AnyObject[] {
+  if (polygon.length < 3) return [];
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const p of polygon) {
+    if (p.x < minX) minX = p.x;
+    if (p.y < minY) minY = p.y;
+    if (p.x > maxX) maxX = p.x;
+    if (p.y > maxY) maxY = p.y;
+  }
+  const bbox: Rect = { x: minX, y: minY, w: maxX - minX, h: maxY - minY };
+  const candidates = index
+    ? queryRect(index, bbox.x, bbox.y, bbox.x + bbox.w, bbox.y + bbox.h)
+    : objects;
+  const seen = new Set<string>();
+  const out: AnyObject[] = [];
+  for (const obj of candidates) {
+    if (seen.has(obj.id)) continue;
+    const b = objectAabb(obj);
+    const aabb: Rect = { x: b.minX, y: b.minY, w: b.maxX - b.minX, h: b.maxY - b.minY };
+    if (objectIntersectsPolygon(obj, polygon, aabb)) {
+      seen.add(obj.id);
+      out.push(obj);
+    }
+  }
+  return out;
+}

--- a/src/lib/select/ops.ts
+++ b/src/lib/select/ops.ts
@@ -1,0 +1,128 @@
+import type { AnyObject, DashStyle, ObjectId } from '$lib/types';
+import { get } from 'svelte/store';
+import { documentStore } from '$lib/store/document';
+import { applyStyleToObject, transformObject, translateObject, type Affine } from './transform';
+
+function pageObjects(pageIndex: number): AnyObject[] | null {
+  const doc = get(documentStore);
+  return doc?.pages[pageIndex]?.objects ? [...doc.pages[pageIndex].objects] : null;
+}
+
+function mapSelected(
+  pageIndex: number,
+  ids: ReadonlySet<ObjectId>,
+  fn: (o: AnyObject) => AnyObject,
+): AnyObject[] {
+  const objs = pageObjects(pageIndex);
+  if (!objs) return [];
+  const out: AnyObject[] = [];
+  for (const obj of objs) {
+    if (ids.has(obj.id)) out.push(fn(obj));
+  }
+  return out;
+}
+
+export function commitTransform(
+  pageIndex: number,
+  ids: ReadonlySet<ObjectId>,
+  t: Affine,
+  opts: { scaleStrokeWidth?: boolean } = {},
+): void {
+  if (ids.size === 0) return;
+  const afters = mapSelected(pageIndex, ids, (o) => transformObject(o, t, opts));
+  documentStore.updateObjects(pageIndex, afters);
+}
+
+export function commitTranslate(
+  pageIndex: number,
+  ids: ReadonlySet<ObjectId>,
+  dx: number,
+  dy: number,
+): void {
+  if (ids.size === 0 || (dx === 0 && dy === 0)) return;
+  const afters = mapSelected(pageIndex, ids, (o) => translateObject(o, dx, dy));
+  documentStore.updateObjects(pageIndex, afters);
+}
+
+export function commitStylePatch(
+  pageIndex: number,
+  ids: ReadonlySet<ObjectId>,
+  patch: { color?: string; width?: number; dash?: DashStyle },
+): void {
+  if (ids.size === 0) return;
+  const afters = mapSelected(pageIndex, ids, (o) => applyStyleToObject(o, patch));
+  documentStore.updateObjects(pageIndex, afters);
+}
+
+export function commitDelete(pageIndex: number, ids: ReadonlySet<ObjectId>): void {
+  if (ids.size === 0) return;
+  documentStore.removeObjects(pageIndex, [...ids]);
+}
+
+/**
+ * Z-order mutation: remove then re-add in the new order. Wrapped under a
+ * single undo entry is tricky given the existing commands; for now we
+ * implement via two separate ops (remove + re-add). Undoing will take two
+ * steps for z-order changes — acceptable for phase 1.
+ */
+export function bringForward(pageIndex: number, ids: ReadonlySet<ObjectId>): void {
+  reorderSelection(pageIndex, ids, 'forward');
+}
+
+export function sendBackward(pageIndex: number, ids: ReadonlySet<ObjectId>): void {
+  reorderSelection(pageIndex, ids, 'backward');
+}
+
+function pageSnapshot(pageIndex: number): AnyObject[] | null {
+  return pageObjects(pageIndex);
+}
+
+function reorderSelection(
+  pageIndex: number,
+  ids: ReadonlySet<ObjectId>,
+  direction: 'forward' | 'backward',
+): void {
+  const current = pageSnapshot(pageIndex);
+  if (!current) return;
+  const next = reorderArray(current, ids, direction);
+  if (arraysEqualById(current, next)) return;
+  documentStore.removeObjects(
+    pageIndex,
+    current.map((o) => o.id),
+  );
+  for (const obj of next) documentStore.addObject(pageIndex, obj);
+}
+
+function arraysEqualById(a: AnyObject[], b: AnyObject[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    if (a[i].id !== b[i].id) return false;
+  }
+  return true;
+}
+
+export function reorderArray(
+  objects: readonly AnyObject[],
+  ids: ReadonlySet<ObjectId>,
+  direction: 'forward' | 'backward',
+): AnyObject[] {
+  const next = [...objects];
+  if (direction === 'forward') {
+    for (let i = next.length - 2; i >= 0; i -= 1) {
+      if (ids.has(next[i].id) && !ids.has(next[i + 1].id)) {
+        const t = next[i];
+        next[i] = next[i + 1];
+        next[i + 1] = t;
+      }
+    }
+  } else {
+    for (let i = 1; i < next.length; i += 1) {
+      if (ids.has(next[i].id) && !ids.has(next[i - 1].id)) {
+        const t = next[i];
+        next[i] = next[i - 1];
+        next[i - 1] = t;
+      }
+    }
+  }
+  return next;
+}

--- a/src/lib/select/ops.ts
+++ b/src/lib/select/ops.ts
@@ -60,29 +60,16 @@ export function commitDelete(pageIndex: number, ids: ReadonlySet<ObjectId>): voi
 }
 
 /**
- * Z-order mutation: remove then re-add in the new order. Wrapped under a
- * single undo entry is tricky given the existing commands; for now we
- * implement via two separate ops (remove + re-add). Undoing will take two
- * steps for z-order changes — acceptable for phase 1.
+ * Z-order mutation: remove then re-add in the new order. This is currently
+ * two history entries because the existing command set has no single
+ * reorder op; undoing a reorder takes two undos.
  */
-export function bringForward(pageIndex: number, ids: ReadonlySet<ObjectId>): void {
-  reorderSelection(pageIndex, ids, 'forward');
-}
-
-export function sendBackward(pageIndex: number, ids: ReadonlySet<ObjectId>): void {
-  reorderSelection(pageIndex, ids, 'backward');
-}
-
-function pageSnapshot(pageIndex: number): AnyObject[] | null {
-  return pageObjects(pageIndex);
-}
-
-function reorderSelection(
+export function reorderSelection(
   pageIndex: number,
   ids: ReadonlySet<ObjectId>,
   direction: 'forward' | 'backward',
 ): void {
-  const current = pageSnapshot(pageIndex);
+  const current = pageObjects(pageIndex);
   if (!current) return;
   const next = reorderArray(current, ids, direction);
   if (arraysEqualById(current, next)) return;

--- a/src/lib/select/selection.ts
+++ b/src/lib/select/selection.ts
@@ -1,0 +1,92 @@
+import { derived, get, writable, type Readable } from 'svelte/store';
+import type { AnyObject, ObjectId } from '$lib/types';
+import { objectAabb } from '$lib/tools/spatialIndex';
+import type { Rect } from './geometry';
+
+export interface SelectionState {
+  pageIndex: number | null;
+  ids: ReadonlySet<ObjectId>;
+}
+
+function empty(): SelectionState {
+  return { pageIndex: null, ids: new Set() };
+}
+
+function createSelectionStore() {
+  const store = writable<SelectionState>(empty());
+
+  return {
+    subscribe: store.subscribe,
+    snapshot: () => get(store),
+
+    clear() {
+      store.set(empty());
+    },
+
+    setPage(pageIndex: number) {
+      store.update((s) => (s.pageIndex === pageIndex ? s : { pageIndex, ids: new Set() }));
+    },
+
+    set(pageIndex: number, ids: Iterable<ObjectId>) {
+      store.set({ pageIndex, ids: new Set(ids) });
+    },
+
+    toggle(pageIndex: number, id: ObjectId) {
+      store.update((s) => {
+        if (s.pageIndex !== pageIndex) {
+          return { pageIndex, ids: new Set([id]) };
+        }
+        const ids = new Set(s.ids);
+        if (ids.has(id)) ids.delete(id);
+        else ids.add(id);
+        return { pageIndex, ids };
+      });
+    },
+
+    add(pageIndex: number, newIds: Iterable<ObjectId>) {
+      store.update((s) => {
+        const base = s.pageIndex === pageIndex ? s.ids : new Set<ObjectId>();
+        const ids = new Set(base);
+        for (const id of newIds) ids.add(id);
+        return { pageIndex, ids };
+      });
+    },
+
+    remove(ids: Iterable<ObjectId>) {
+      store.update((s) => {
+        const next = new Set(s.ids);
+        for (const id of ids) next.delete(id);
+        return { ...s, ids: next };
+      });
+    },
+  };
+}
+
+export const selection = createSelectionStore();
+
+export const selectionCount: Readable<number> = derived(selection, ($s) => $s.ids.size);
+
+export function boundsOfObjects(objects: readonly AnyObject[]): Rect | null {
+  if (objects.length === 0) return null;
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const o of objects) {
+    const b = objectAabb(o);
+    if (b.minX < minX) minX = b.minX;
+    if (b.minY < minY) minY = b.minY;
+    if (b.maxX > maxX) maxX = b.maxX;
+    if (b.maxY > maxY) maxY = b.maxY;
+  }
+  if (!Number.isFinite(minX)) return null;
+  return { x: minX, y: minY, w: maxX - minX, h: maxY - minY };
+}
+
+export function filterSelected(
+  objects: readonly AnyObject[],
+  ids: ReadonlySet<ObjectId>,
+): AnyObject[] {
+  if (ids.size === 0) return [];
+  return objects.filter((o) => ids.has(o.id));
+}

--- a/src/lib/select/transform.ts
+++ b/src/lib/select/transform.ts
@@ -88,17 +88,12 @@ export function transformObject(obj: AnyObject, t: Affine, opts: TransformOption
       };
     }
     case 'shape': {
-      const corners = [
-        { x: obj.bounds.x, y: obj.bounds.y },
-        { x: obj.bounds.x + obj.bounds.w, y: obj.bounds.y + obj.bounds.h },
-      ].map((p) => applyAffine(p, t));
-      const x = Math.min(corners[0].x, corners[1].x);
-      const y = Math.min(corners[0].y, corners[1].y);
-      const w = Math.abs(corners[1].x - corners[0].x);
-      const h = Math.abs(corners[1].y - corners[0].y);
+      const anchor = applyAffine({ x: obj.bounds.x, y: obj.bounds.y }, t);
+      const w = obj.bounds.w * Math.abs(t.scale?.sx ?? 1);
+      const h = obj.bounds.h * Math.abs(t.scale?.sy ?? 1);
       return {
         ...obj,
-        bounds: { x, y, w, h },
+        bounds: { x: anchor.x, y: anchor.y, w, h },
         style: shouldScaleWidth ? scaleWidth(obj.style, factor) : obj.style,
       };
     }
@@ -113,15 +108,10 @@ export function transformObject(obj: AnyObject, t: Affine, opts: TransformOption
       };
     }
     case 'graph': {
-      const corners = [
-        { x: obj.bounds.x, y: obj.bounds.y },
-        { x: obj.bounds.x + obj.bounds.w, y: obj.bounds.y + obj.bounds.h },
-      ].map((p) => applyAffine(p, t));
-      const x = Math.min(corners[0].x, corners[1].x);
-      const y = Math.min(corners[0].y, corners[1].y);
-      const w = Math.abs(corners[1].x - corners[0].x);
-      const h = Math.abs(corners[1].y - corners[0].y);
-      return { ...obj, bounds: { x, y, w, h } };
+      const anchor = applyAffine({ x: obj.bounds.x, y: obj.bounds.y }, t);
+      const w = obj.bounds.w * Math.abs(t.scale?.sx ?? 1);
+      const h = obj.bounds.h * Math.abs(t.scale?.sy ?? 1);
+      return { ...obj, bounds: { x: anchor.x, y: anchor.y, w, h } };
     }
     case 'text': {
       const at = applyAffine(obj.at, t);

--- a/src/lib/select/transform.ts
+++ b/src/lib/select/transform.ts
@@ -1,0 +1,210 @@
+import type { AnyObject, Point, StrokeStyle } from '$lib/types';
+
+export interface Vec2 {
+  x: number;
+  y: number;
+}
+
+export interface Affine {
+  translate?: Vec2;
+  /** Uniform or non-uniform scale about `pivot`. */
+  scale?: { sx: number; sy: number; pivot: Vec2 };
+  /** Rotation in radians about `pivot`. */
+  rotate?: { angle: number; pivot: Vec2 };
+}
+
+function applyAffine(p: Vec2, t: Affine): Vec2 {
+  let x = p.x;
+  let y = p.y;
+  if (t.scale) {
+    x = t.scale.pivot.x + (x - t.scale.pivot.x) * t.scale.sx;
+    y = t.scale.pivot.y + (y - t.scale.pivot.y) * t.scale.sy;
+  }
+  if (t.rotate) {
+    const dx = x - t.rotate.pivot.x;
+    const dy = y - t.rotate.pivot.y;
+    const c = Math.cos(t.rotate.angle);
+    const s = Math.sin(t.rotate.angle);
+    x = t.rotate.pivot.x + dx * c - dy * s;
+    y = t.rotate.pivot.y + dx * s + dy * c;
+  }
+  if (t.translate) {
+    x += t.translate.x;
+    y += t.translate.y;
+  }
+  return { x, y };
+}
+
+function scaleWidth(style: StrokeStyle, factor: number): StrokeStyle {
+  if (factor === 1) return style;
+  const width = Math.max(0.25, Math.min(64, style.width * factor));
+  return { ...style, width };
+}
+
+function scaleFactorFor(t: Affine): number {
+  if (!t.scale) return 1;
+  return Math.sqrt(Math.abs(t.scale.sx * t.scale.sy));
+}
+
+export interface TransformOptions {
+  /**
+   * When true, stroke / line widths scale with the transform. The default
+   * is false so nudges and pure translations never touch width.
+   */
+  scaleStrokeWidth?: boolean;
+}
+
+/**
+ * Return a new object with the transform applied to its intrinsic geometry.
+ * For axis-aligned objects (shape, graph, numberline) rotation only moves
+ * the object's anchor around the pivot; width/height are preserved so the
+ * object stays axis-aligned. A future rotation-aware shape type can replace
+ * this path without touching callers.
+ */
+export function transformObject(obj: AnyObject, t: Affine, opts: TransformOptions = {}): AnyObject {
+  const factor = scaleFactorFor(t);
+  const shouldScaleWidth = opts.scaleStrokeWidth === true && factor !== 1;
+
+  switch (obj.type) {
+    case 'stroke': {
+      const points: Point[] = obj.points.map((p) => {
+        const q = applyAffine({ x: p.x, y: p.y }, t);
+        return { ...p, x: q.x, y: q.y };
+      });
+      return {
+        ...obj,
+        points,
+        style: shouldScaleWidth ? scaleWidth(obj.style, factor) : obj.style,
+      };
+    }
+    case 'line': {
+      const from = applyAffine(obj.from, t);
+      const to = applyAffine(obj.to, t);
+      return {
+        ...obj,
+        from,
+        to,
+        style: shouldScaleWidth ? scaleWidth(obj.style, factor) : obj.style,
+      };
+    }
+    case 'shape': {
+      const corners = [
+        { x: obj.bounds.x, y: obj.bounds.y },
+        { x: obj.bounds.x + obj.bounds.w, y: obj.bounds.y + obj.bounds.h },
+      ].map((p) => applyAffine(p, t));
+      const x = Math.min(corners[0].x, corners[1].x);
+      const y = Math.min(corners[0].y, corners[1].y);
+      const w = Math.abs(corners[1].x - corners[0].x);
+      const h = Math.abs(corners[1].y - corners[0].y);
+      return {
+        ...obj,
+        bounds: { x, y, w, h },
+        style: shouldScaleWidth ? scaleWidth(obj.style, factor) : obj.style,
+      };
+    }
+    case 'numberline': {
+      const from = applyAffine(obj.from, t);
+      const length = obj.length * (t.scale?.sx ?? 1);
+      return {
+        ...obj,
+        from,
+        length,
+        style: shouldScaleWidth ? scaleWidth(obj.style, factor) : obj.style,
+      };
+    }
+    case 'graph': {
+      const corners = [
+        { x: obj.bounds.x, y: obj.bounds.y },
+        { x: obj.bounds.x + obj.bounds.w, y: obj.bounds.y + obj.bounds.h },
+      ].map((p) => applyAffine(p, t));
+      const x = Math.min(corners[0].x, corners[1].x);
+      const y = Math.min(corners[0].y, corners[1].y);
+      const w = Math.abs(corners[1].x - corners[0].x);
+      const h = Math.abs(corners[1].y - corners[0].y);
+      return { ...obj, bounds: { x, y, w, h } };
+    }
+    case 'text': {
+      const at = applyAffine(obj.at, t);
+      const nextFontSize =
+        shouldScaleWidth || (t.scale && (t.scale.sx !== 1 || t.scale.sy !== 1))
+          ? Math.max(4, Math.min(256, obj.fontSize * factor))
+          : obj.fontSize;
+      return { ...obj, at, fontSize: nextFontSize };
+    }
+    case 'angleMark': {
+      const vertex = applyAffine(obj.vertex, t);
+      const rayA = applyAffine(obj.rayA, t);
+      const rayB = applyAffine(obj.rayB, t);
+      const width = shouldScaleWidth ? Math.max(0.25, Math.min(64, obj.width * factor)) : obj.width;
+      return { ...obj, vertex, rayA, rayB, width };
+    }
+  }
+}
+
+export function translateObject(obj: AnyObject, dx: number, dy: number): AnyObject {
+  return transformObject(obj, { translate: { x: dx, y: dy } });
+}
+
+export function applyStyleToObject(
+  obj: AnyObject,
+  patch: { color?: string; width?: number; dash?: StrokeStyle['dash'] },
+): AnyObject {
+  switch (obj.type) {
+    case 'stroke':
+    case 'line':
+    case 'shape':
+    case 'numberline': {
+      const style: StrokeStyle = {
+        ...obj.style,
+        ...(patch.color !== undefined ? { color: patch.color } : {}),
+        ...(patch.width !== undefined ? { width: patch.width } : {}),
+        ...(patch.dash !== undefined ? { dash: patch.dash } : {}),
+      };
+      return { ...obj, style };
+    }
+    case 'text':
+      return patch.color !== undefined ? { ...obj, color: patch.color } : obj;
+    case 'graph': {
+      if (patch.color === undefined && patch.width === undefined && patch.dash === undefined) {
+        return obj;
+      }
+      return {
+        ...obj,
+        functions: obj.functions.map((f) => ({
+          ...f,
+          ...(patch.color !== undefined ? { color: patch.color } : {}),
+          ...(patch.width !== undefined ? { width: patch.width } : {}),
+          ...(patch.dash !== undefined ? { dash: patch.dash } : {}),
+        })),
+      };
+    }
+    case 'angleMark': {
+      return {
+        ...obj,
+        ...(patch.color !== undefined ? { color: patch.color } : {}),
+        ...(patch.width !== undefined ? { width: patch.width } : {}),
+      };
+    }
+  }
+}
+
+export function supportsColor(obj: AnyObject): boolean {
+  switch (obj.type) {
+    case 'stroke':
+    case 'line':
+    case 'shape':
+    case 'numberline':
+    case 'text':
+    case 'graph':
+    case 'angleMark':
+      return true;
+  }
+}
+
+export function supportsWidth(obj: AnyObject): boolean {
+  return obj.type !== 'text';
+}
+
+export function supportsDash(obj: AnyObject): boolean {
+  return obj.type === 'line' || obj.type === 'shape' || obj.type === 'graph';
+}

--- a/src/lib/sidebar/Sidebar.svelte
+++ b/src/lib/sidebar/Sidebar.svelte
@@ -42,6 +42,7 @@
     { id: 'pen', label: 'Pen', shortcut: 'P', icon: '✏️' },
     { id: 'highlighter', label: 'Highlighter', shortcut: 'H', icon: '🖍️' },
     { id: 'eraser', label: 'Eraser', shortcut: 'E', icon: '🧽' },
+    { id: 'select', label: 'Select', shortcut: 'S', icon: '⬚' },
     { id: 'line', label: 'Line', shortcut: 'L', icon: '／' },
     { id: 'text', label: 'Text', shortcut: 'T', icon: '𝐓' },
     { id: 'rect', label: 'Rectangle', shortcut: 'R', icon: '▭' },

--- a/src/lib/store/document.ts
+++ b/src/lib/store/document.ts
@@ -292,7 +292,7 @@ export function createDocumentStore(): DocumentStore {
       const page = doc.pages[pageIndex];
       if (!page) return;
       const byId = new Map(page.objects.map((o) => [o.id, o] as const));
-      const entries = [];
+      const entries: Extract<Command, { type: 'updateMany' }>['entries'] = [];
       for (const after of afters) {
         const before = byId.get(after.id);
         if (!before) continue;

--- a/src/lib/store/document.ts
+++ b/src/lib/store/document.ts
@@ -24,6 +24,13 @@ function commandToMutations(pageIndex: number, cmd: Command): MutationEvent[] {
       return cmd.items.map((i) => ({ kind: 'add', pageIndex, object: i.object }));
     case 'update':
       return [{ kind: 'update', pageIndex, id: cmd.objectId, after: cmd.after }];
+    case 'updateMany':
+      return cmd.entries.map((e) => ({
+        kind: 'update',
+        pageIndex,
+        id: e.objectId,
+        after: e.after,
+      }));
     case 'clearPage':
       return [{ kind: 'remove', pageIndex, ids: cmd.objects.map((o) => o.id) }];
     case 'restorePage':
@@ -46,6 +53,12 @@ export interface DocumentStore {
   removeObject(pageIndex: number, id: ObjectId): void;
   removeObjects(pageIndex: number, ids: readonly ObjectId[]): void;
   updateObject(pageIndex: number, id: ObjectId, patch: Partial<AnyObject>): void;
+  /**
+   * Apply a batch of object replacements under a single history entry. The
+   * caller provides the full `after` object for each id; the store derives
+   * `before` from the current page state. Unknown ids are skipped.
+   */
+  updateObjects(pageIndex: number, afters: readonly AnyObject[]): void;
 
   insertBlankPageAfter(
     afterArrayIndex: number,
@@ -270,6 +283,23 @@ export function createDocumentStore(): DocumentStore {
       if (!before) return;
       const after = { ...before, ...patch } as AnyObject;
       pushAndApply(pageIndex, { type: 'update', objectId: id, before, after });
+    },
+
+    updateObjects(pageIndex, afters) {
+      if (afters.length === 0) return;
+      const doc = get(state);
+      if (!doc) return;
+      const page = doc.pages[pageIndex];
+      if (!page) return;
+      const byId = new Map(page.objects.map((o) => [o.id, o] as const));
+      const entries = [];
+      for (const after of afters) {
+        const before = byId.get(after.id);
+        if (!before) continue;
+        entries.push({ objectId: after.id, before, after });
+      }
+      if (entries.length === 0) return;
+      pushAndApply(pageIndex, { type: 'updateMany', entries });
     },
 
     insertBlankPageAfter(afterArrayIndex, width, height, background) {

--- a/src/lib/store/history.ts
+++ b/src/lib/store/history.ts
@@ -11,12 +11,19 @@ export interface IndexedObject {
   index: number;
 }
 
+export interface UpdateEntry {
+  objectId: ObjectId;
+  before: AnyObject;
+  after: AnyObject;
+}
+
 export type Command =
   | { type: 'add'; object: AnyObject }
   | { type: 'remove'; object: AnyObject }
   | { type: 'removeMany'; items: IndexedObject[] }
   | { type: 'insertMany'; items: IndexedObject[] }
   | { type: 'update'; objectId: ObjectId; before: AnyObject; after: AnyObject }
+  | { type: 'updateMany'; entries: UpdateEntry[] }
   | { type: 'clearPage'; objects: AnyObject[] }
   | { type: 'restorePage'; objects: AnyObject[] };
 
@@ -45,6 +52,13 @@ export function applyCommand(page: Page, cmd: Command): Page {
         ...page,
         objects: page.objects.map((o) => (o.id === cmd.objectId ? cmd.after : o)),
       };
+    case 'updateMany': {
+      const byId = new Map(cmd.entries.map((e) => [e.objectId, e.after]));
+      return {
+        ...page,
+        objects: page.objects.map((o) => byId.get(o.id) ?? o),
+      };
+    }
     case 'clearPage':
       return { ...page, objects: [] };
     case 'restorePage':
@@ -68,6 +82,15 @@ export function invertCommand(cmd: Command): Command {
         objectId: cmd.objectId,
         before: cmd.after,
         after: cmd.before,
+      };
+    case 'updateMany':
+      return {
+        type: 'updateMany',
+        entries: cmd.entries.map((e) => ({
+          objectId: e.objectId,
+          before: e.after,
+          after: e.before,
+        })),
       };
     case 'clearPage':
       return { type: 'restorePage', objects: cmd.objects };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -38,6 +38,8 @@
   import OpenFromSlidesDialog from '$lib/ui/OpenFromSlidesDialog.svelte';
   import { slidesDialogOpen, openSlidesDialog } from '$lib/slides/dialog';
   import { createSpatialIndex, type SpatialIndex } from '$lib/tools/spatialIndex';
+  import SelectionLayer from '$lib/select/SelectionLayer.svelte';
+  import { selection } from '$lib/select/selection';
   import { makeEraseFlush } from '$lib/tools/eraserBatch';
   import { createRafBatcher } from '$lib/canvas/inkBatch';
   import { eraseDebug } from '$lib/store/eraseDebug';
@@ -87,6 +89,9 @@
     if (sidebarState.activeTool === 'ruler' && !overlaysState.rulerVisible) {
       overlays.setRulerVisible(true);
     }
+  });
+  $effect(() => {
+    if (sidebarState.activeTool !== 'select') selection.clear();
   });
   const presenterState = $derived($presenterStore);
   const isPresenter = $derived(presenterState.active);
@@ -752,6 +757,18 @@
               <RulerOverlay ptToPx={size.ptToPx} width={size.width} height={size.height} />
             </div>
           {/if}
+          {#if sidebarState.activeTool === 'select'}
+            <div class="overlay-slot capture">
+              <SelectionLayer
+                {pageIndex}
+                objects={pageObjects}
+                {spatialIndex}
+                width={size.width}
+                height={size.height}
+                ptToPx={size.ptToPx}
+              />
+            </div>
+          {/if}
           {#if replaySt.active}
             <ReplayLayer
               width={size.width}
@@ -1029,6 +1046,9 @@
     pointer-events: none;
   }
   .overlay-slot :global(svg) {
+    pointer-events: auto;
+  }
+  .overlay-slot.capture {
     pointer-events: auto;
   }
   .text-slot {

--- a/tests/select-geometry.test.ts
+++ b/tests/select-geometry.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import {
+  pointInPolygon,
+  polygonOverlapsRect,
+  polylineCrossesPolygon,
+  rectContains,
+  rectsOverlap,
+  segmentsIntersect,
+  strokeIntersectsPolygon,
+  type Rect,
+  type Vec2,
+} from '$lib/select/geometry';
+import type { StrokeObject, StrokeStyle } from '$lib/types';
+
+const STYLE: StrokeStyle = { color: '#000', width: 2, dash: 'solid', opacity: 1 };
+
+const SQUARE: Vec2[] = [
+  { x: 0, y: 0 },
+  { x: 10, y: 0 },
+  { x: 10, y: 10 },
+  { x: 0, y: 10 },
+];
+
+describe('pointInPolygon', () => {
+  it('detects inside points', () => {
+    expect(pointInPolygon({ x: 5, y: 5 }, SQUARE)).toBe(true);
+  });
+  it('detects outside points', () => {
+    expect(pointInPolygon({ x: 20, y: 5 }, SQUARE)).toBe(false);
+  });
+  it('rejects polygons with <3 vertices', () => {
+    expect(pointInPolygon({ x: 0, y: 0 }, [{ x: 0, y: 0 }])).toBe(false);
+  });
+});
+
+describe('segmentsIntersect', () => {
+  it('crosses', () => {
+    expect(
+      segmentsIntersect({ x: 0, y: 0 }, { x: 10, y: 10 }, { x: 0, y: 10 }, { x: 10, y: 0 }),
+    ).toBe(true);
+  });
+  it('disjoint', () => {
+    expect(segmentsIntersect({ x: 0, y: 0 }, { x: 1, y: 1 }, { x: 5, y: 5 }, { x: 6, y: 6 })).toBe(
+      false,
+    );
+  });
+});
+
+describe('polylineCrossesPolygon', () => {
+  it('crossing edge', () => {
+    expect(
+      polylineCrossesPolygon(
+        [
+          { x: -5, y: 5 },
+          { x: 15, y: 5 },
+        ],
+        SQUARE,
+      ),
+    ).toBe(true);
+  });
+  it('fully outside', () => {
+    expect(
+      polylineCrossesPolygon(
+        [
+          { x: 100, y: 100 },
+          { x: 200, y: 200 },
+        ],
+        SQUARE,
+      ),
+    ).toBe(false);
+  });
+  it('fully inside', () => {
+    expect(
+      polylineCrossesPolygon(
+        [
+          { x: 2, y: 2 },
+          { x: 5, y: 5 },
+        ],
+        SQUARE,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('strokeIntersectsPolygon', () => {
+  it('matches polyline behavior', () => {
+    const stroke: StrokeObject = {
+      id: 's',
+      createdAt: 0,
+      type: 'stroke',
+      tool: 'pen',
+      style: STYLE,
+      points: [
+        { x: 5, y: 5, pressure: 0.5, t: 0 },
+        { x: 25, y: 5, pressure: 0.5, t: 1 },
+      ],
+    };
+    expect(strokeIntersectsPolygon(stroke, SQUARE)).toBe(true);
+  });
+});
+
+describe('rect helpers', () => {
+  const r: Rect = { x: 0, y: 0, w: 10, h: 10 };
+  it('rectsOverlap', () => {
+    expect(rectsOverlap(r, { x: 5, y: 5, w: 10, h: 10 })).toBe(true);
+    expect(rectsOverlap(r, { x: 11, y: 0, w: 2, h: 2 })).toBe(false);
+  });
+  it('rectContains', () => {
+    expect(rectContains(r, { x: 1, y: 1, w: 2, h: 2 })).toBe(true);
+    expect(rectContains(r, { x: 1, y: 1, w: 20, h: 2 })).toBe(false);
+  });
+  it('polygonOverlapsRect', () => {
+    expect(polygonOverlapsRect(SQUARE, { x: 5, y: 5, w: 50, h: 50 })).toBe(true);
+    expect(polygonOverlapsRect(SQUARE, { x: 100, y: 100, w: 10, h: 10 })).toBe(false);
+  });
+});

--- a/tests/select-hittest.test.ts
+++ b/tests/select-hittest.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { pickInLasso, pickInMarquee, pickTopAt } from '$lib/select/hitTest';
+import type { AnyObject, LineObject, ShapeObject, StrokeObject, StrokeStyle } from '$lib/types';
+
+const STYLE: StrokeStyle = { color: '#000', width: 2, dash: 'solid', opacity: 1 };
+
+function stroke(id: string, pts: [number, number][]): StrokeObject {
+  return {
+    id,
+    createdAt: 0,
+    type: 'stroke',
+    tool: 'pen',
+    style: STYLE,
+    points: pts.map(([x, y]) => ({ x, y, pressure: 0.5, t: 0 })),
+  };
+}
+
+function rect(id: string, x: number, y: number, w: number, h: number): ShapeObject {
+  return {
+    id,
+    createdAt: 0,
+    type: 'shape',
+    kind: 'rect',
+    style: STYLE,
+    fill: null,
+    bounds: { x, y, w, h },
+  };
+}
+
+function line(id: string, a: [number, number], b: [number, number]): LineObject {
+  return {
+    id,
+    createdAt: 0,
+    type: 'line',
+    style: STYLE,
+    from: { x: a[0], y: a[1] },
+    to: { x: b[0], y: b[1] },
+    arrow: { start: false, end: false },
+  };
+}
+
+describe('pickTopAt', () => {
+  it('returns topmost (later in array) when multiple hit', () => {
+    const a = stroke('a', [
+      [0, 0],
+      [100, 0],
+    ]);
+    const b = stroke('b', [
+      [0, 0],
+      [100, 0],
+    ]);
+    const hit = pickTopAt([a, b] as AnyObject[], null, { x: 50, y: 0 }, 2);
+    expect(hit?.id).toBe('b');
+  });
+  it('returns null when nothing hit', () => {
+    const a = rect('a', 0, 0, 10, 10);
+    expect(pickTopAt([a] as AnyObject[], null, { x: 200, y: 200 }, 2)).toBeNull();
+  });
+});
+
+describe('pickInMarquee', () => {
+  it('picks overlapping objects', () => {
+    const a = rect('a', 0, 0, 10, 10);
+    const b = rect('b', 100, 100, 10, 10);
+    const got = pickInMarquee([a, b] as AnyObject[], null, { x: 0, y: 0, w: 50, h: 50 });
+    expect(got.map((o) => o.id)).toEqual(['a']);
+  });
+});
+
+describe('pickInLasso', () => {
+  it('picks strokes crossing the polygon', () => {
+    const s = stroke('s', [
+      [0, 0],
+      [100, 0],
+    ]);
+    const polygon = [
+      { x: 40, y: -10 },
+      { x: 60, y: -10 },
+      { x: 60, y: 10 },
+      { x: 40, y: 10 },
+    ];
+    const got = pickInLasso([s] as AnyObject[], null, polygon);
+    expect(got.map((o) => o.id)).toEqual(['s']);
+  });
+  it('rejects objects whose AABB is outside', () => {
+    const l = line('l', [0, 0], [10, 10]);
+    const polygon = [
+      { x: 100, y: 100 },
+      { x: 200, y: 100 },
+      { x: 200, y: 200 },
+    ];
+    const got = pickInLasso([l] as AnyObject[], null, polygon);
+    expect(got).toEqual([]);
+  });
+  it('returns empty for degenerate polygons', () => {
+    const l = line('l', [0, 0], [10, 10]);
+    expect(pickInLasso([l] as AnyObject[], null, [{ x: 0, y: 0 }])).toEqual([]);
+  });
+});

--- a/tests/select-ops.test.ts
+++ b/tests/select-ops.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { documentStore } from '$lib/store/document';
-import { commitStylePatch, commitTranslate, commitDelete } from '$lib/select/ops';
+import { commitStylePatch, commitTranslate, commitDelete, reorderSelection } from '$lib/select/ops';
 import type { EldrawDocument, ShapeObject, StrokeStyle } from '$lib/types';
 
 const STYLE: StrokeStyle = { color: '#000', width: 2, dash: 'solid', opacity: 1 };
@@ -100,5 +100,29 @@ describe('commit ops', () => {
     const u = documentStore.history.canUndo(0).subscribe((v) => (canUndo = v));
     u();
     expect(canUndo).toBe(false);
+  });
+
+  it('reorderSelection forward moves selection one step toward top', () => {
+    const a = mkShape('a');
+    const b = mkShape('b');
+    const c = mkShape('c');
+    documentStore.load(doc([a, b, c]));
+    reorderSelection(0, new Set(['a']), 'forward');
+    let objs: ShapeObject[] = [];
+    const u = documentStore.objectsOnPage(0).subscribe((v) => (objs = v as ShapeObject[]));
+    u();
+    expect(objs.map((o) => o.id)).toEqual(['b', 'a', 'c']);
+  });
+
+  it('reorderSelection backward moves selection one step toward bottom', () => {
+    const a = mkShape('a');
+    const b = mkShape('b');
+    const c = mkShape('c');
+    documentStore.load(doc([a, b, c]));
+    reorderSelection(0, new Set(['c']), 'backward');
+    let objs: ShapeObject[] = [];
+    const u = documentStore.objectsOnPage(0).subscribe((v) => (objs = v as ShapeObject[]));
+    u();
+    expect(objs.map((o) => o.id)).toEqual(['a', 'c', 'b']);
   });
 });

--- a/tests/select-ops.test.ts
+++ b/tests/select-ops.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { documentStore } from '$lib/store/document';
+import { commitStylePatch, commitTranslate, commitDelete } from '$lib/select/ops';
+import type { EldrawDocument, ShapeObject, StrokeStyle } from '$lib/types';
+
+const STYLE: StrokeStyle = { color: '#000', width: 2, dash: 'solid', opacity: 1 };
+
+function mkShape(id: string): ShapeObject {
+  return {
+    id,
+    createdAt: 0,
+    type: 'shape',
+    kind: 'rect',
+    style: STYLE,
+    fill: null,
+    bounds: { x: 0, y: 0, w: 10, h: 10 },
+  };
+}
+
+function doc(shapes: ShapeObject[]): EldrawDocument {
+  return {
+    version: 1,
+    pdfHash: 'h',
+    pdfPath: null,
+    pages: [
+      {
+        pageIndex: 0,
+        type: 'pdf',
+        insertedAfterPdfPage: null,
+        width: 612,
+        height: 792,
+        objects: shapes,
+      },
+    ],
+    palettes: [],
+    prefs: {
+      sidebarPinned: true,
+      defaultTool: 'pen',
+      toolDefaults: {
+        pen: { color: '#000', width: 2, dash: 'solid', opacity: 1 },
+        highlighter: { color: '#ff0', width: 14, dash: 'solid', opacity: 0.3 },
+        line: { color: '#000', width: 2, dash: 'solid', opacity: 1 },
+      },
+    },
+  };
+}
+
+describe('commit ops', () => {
+  beforeEach(() => {
+    documentStore.clear();
+  });
+
+  it('commitTranslate updates all selected objects in one history entry', () => {
+    const a = mkShape('a');
+    const b = mkShape('b');
+    documentStore.load(doc([a, b]));
+    commitTranslate(0, new Set(['a', 'b']), 5, 6);
+    const state1 = documentStore.history.canUndo(0);
+    let canUndo = false;
+    const unsub = state1.subscribe((v) => (canUndo = v));
+    unsub();
+    expect(canUndo).toBe(true);
+    documentStore.undo(0);
+    // After one undo both should be back to original
+    let objs: ShapeObject[] = [];
+    const u2 = documentStore.objectsOnPage(0).subscribe((v) => (objs = v as ShapeObject[]));
+    u2();
+    expect(objs[0].bounds.x).toBe(0);
+    expect(objs[1].bounds.x).toBe(0);
+  });
+
+  it('commitStylePatch changes color across selection', () => {
+    const a = mkShape('a');
+    const b = mkShape('b');
+    documentStore.load(doc([a, b]));
+    commitStylePatch(0, new Set(['a', 'b']), { color: '#f00' });
+    let objs: ShapeObject[] = [];
+    const u = documentStore.objectsOnPage(0).subscribe((v) => (objs = v as ShapeObject[]));
+    u();
+    expect(objs[0].style.color).toBe('#f00');
+    expect(objs[1].style.color).toBe('#f00');
+  });
+
+  it('commitDelete removes selection', () => {
+    const a = mkShape('a');
+    const b = mkShape('b');
+    documentStore.load(doc([a, b]));
+    commitDelete(0, new Set(['a']));
+    let objs: ShapeObject[] = [];
+    const u = documentStore.objectsOnPage(0).subscribe((v) => (objs = v as ShapeObject[]));
+    u();
+    expect(objs.map((o) => o.id)).toEqual(['b']);
+  });
+
+  it('no-op on empty selection', () => {
+    const a = mkShape('a');
+    documentStore.load(doc([a]));
+    commitTranslate(0, new Set(), 5, 5);
+    let canUndo = false;
+    const u = documentStore.history.canUndo(0).subscribe((v) => (canUndo = v));
+    u();
+    expect(canUndo).toBe(false);
+  });
+});

--- a/tests/select-transform.test.ts
+++ b/tests/select-transform.test.ts
@@ -187,6 +187,54 @@ describe('transformObject rotate', () => {
     expect(s.bounds.w).toBe(10);
     expect(s.bounds.h).toBe(10);
   });
+  it('rectangular shape rotation preserves w/h (does not swap)', () => {
+    const rect: ShapeObject = { ...shape(), bounds: { x: 0, y: 0, w: 10, h: 20 } };
+    const s = transformObject(rect, {
+      rotate: { angle: Math.PI / 2, pivot: { x: 0, y: 0 } },
+    }) as ShapeObject;
+    expect(s.bounds.w).toBe(10);
+    expect(s.bounds.h).toBe(20);
+  });
+  it('graph rotation preserves w/h (anchor moves only)', () => {
+    const g = transformObject(graph(), {
+      rotate: { angle: Math.PI / 2, pivot: { x: 0, y: 0 } },
+    }) as GraphObject;
+    expect(g.bounds.w).toBe(100);
+    expect(g.bounds.h).toBe(100);
+  });
+  it('rectangular graph rotation preserves w/h', () => {
+    const g: GraphObject = { ...graph(), bounds: { x: 0, y: 0, w: 80, h: 40 } };
+    const r = transformObject(g, {
+      rotate: { angle: Math.PI / 2, pivot: { x: 0, y: 0 } },
+    }) as GraphObject;
+    expect(r.bounds.w).toBe(80);
+    expect(r.bounds.h).toBe(40);
+  });
+});
+
+describe('transformObject scaleStrokeWidth', () => {
+  it('scales stroke width when requested', () => {
+    const s = transformObject(
+      stroke(),
+      { scale: { sx: 2, sy: 2, pivot: { x: 0, y: 0 } } },
+      { scaleStrokeWidth: true },
+    ) as StrokeObject;
+    expect(s.style.width).toBe(4);
+  });
+  it('scales shape width when requested', () => {
+    const s = transformObject(
+      shape(),
+      { scale: { sx: 3, sy: 3, pivot: { x: 0, y: 0 } } },
+      { scaleStrokeWidth: true },
+    ) as ShapeObject;
+    expect(s.style.width).toBe(6);
+  });
+  it('does not scale width by default', () => {
+    const s = transformObject(shape(), {
+      scale: { sx: 2, sy: 2, pivot: { x: 0, y: 0 } },
+    }) as ShapeObject;
+    expect(s.style.width).toBe(2);
+  });
 });
 
 describe('applyStyleToObject', () => {

--- a/tests/select-transform.test.ts
+++ b/tests/select-transform.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from 'vitest';
+import { transformObject, translateObject, applyStyleToObject } from '$lib/select/transform';
+import type {
+  AngleMarkObject,
+  GraphObject,
+  LineObject,
+  NumberLineObject,
+  ShapeObject,
+  StrokeObject,
+  StrokeStyle,
+  TextObject,
+} from '$lib/types';
+
+const STYLE: StrokeStyle = { color: '#000', width: 2, dash: 'solid', opacity: 1 };
+
+function stroke(): StrokeObject {
+  return {
+    id: 's',
+    createdAt: 0,
+    type: 'stroke',
+    tool: 'pen',
+    style: STYLE,
+    points: [
+      { x: 0, y: 0, pressure: 0.5, t: 0 },
+      { x: 10, y: 0, pressure: 0.5, t: 1 },
+    ],
+  };
+}
+
+function line(): LineObject {
+  return {
+    id: 'l',
+    createdAt: 0,
+    type: 'line',
+    style: STYLE,
+    from: { x: 0, y: 0 },
+    to: { x: 10, y: 0 },
+    arrow: { start: false, end: false },
+  };
+}
+
+function shape(): ShapeObject {
+  return {
+    id: 'sh',
+    createdAt: 0,
+    type: 'shape',
+    kind: 'rect',
+    style: STYLE,
+    fill: null,
+    bounds: { x: 0, y: 0, w: 10, h: 10 },
+  };
+}
+
+function numberline(): NumberLineObject {
+  return {
+    id: 'n',
+    createdAt: 0,
+    type: 'numberline',
+    style: STYLE,
+    from: { x: 0, y: 0 },
+    length: 100,
+    min: 0,
+    max: 10,
+    tickStep: 1,
+    labelStep: 1,
+    marks: [],
+  };
+}
+
+function graph(): GraphObject {
+  return {
+    id: 'g',
+    createdAt: 0,
+    type: 'graph',
+    bounds: { x: 0, y: 0, w: 100, h: 100 },
+    xRange: [-10, 10],
+    yRange: [-10, 10],
+    gridStep: 1,
+    showAxes: true,
+    showGrid: true,
+    functions: [
+      {
+        id: 'f1',
+        expr: 'x',
+        kind: 'explicit',
+        color: '#000',
+        width: 2,
+        dash: 'solid',
+        domain: null,
+      },
+    ],
+  };
+}
+
+function text(): TextObject {
+  return {
+    id: 't',
+    createdAt: 0,
+    type: 'text',
+    at: { x: 0, y: 0 },
+    content: 'hi',
+    latex: false,
+    fontSize: 16,
+    color: '#000',
+  };
+}
+
+function angleMark(): AngleMarkObject {
+  return {
+    id: 'a',
+    createdAt: 0,
+    type: 'angleMark',
+    vertex: { x: 0, y: 0 },
+    rayA: { x: 10, y: 0 },
+    rayB: { x: 0, y: 10 },
+    degrees: 90,
+    color: '#000',
+    width: 2,
+    showLabel: false,
+  };
+}
+
+describe('translateObject', () => {
+  it('moves stroke points', () => {
+    const s = translateObject(stroke(), 5, 7) as StrokeObject;
+    expect(s.points[0]).toMatchObject({ x: 5, y: 7 });
+    expect(s.points[1]).toMatchObject({ x: 15, y: 7 });
+  });
+  it('moves line endpoints', () => {
+    const l = translateObject(line(), 3, 4) as LineObject;
+    expect(l.from).toEqual({ x: 3, y: 4 });
+    expect(l.to).toEqual({ x: 13, y: 4 });
+  });
+  it('moves shape bounds', () => {
+    const s = translateObject(shape(), 1, 2) as ShapeObject;
+    expect(s.bounds).toEqual({ x: 1, y: 2, w: 10, h: 10 });
+  });
+  it('moves numberline', () => {
+    const n = translateObject(numberline(), 5, 6) as NumberLineObject;
+    expect(n.from).toEqual({ x: 5, y: 6 });
+    expect(n.length).toBe(100);
+  });
+  it('moves graph bounds', () => {
+    const g = translateObject(graph(), 10, 20) as GraphObject;
+    expect(g.bounds).toEqual({ x: 10, y: 20, w: 100, h: 100 });
+  });
+  it('moves text anchor', () => {
+    const t = translateObject(text(), 3, 3) as TextObject;
+    expect(t.at).toEqual({ x: 3, y: 3 });
+    expect(t.fontSize).toBe(16);
+  });
+  it('moves angle mark points', () => {
+    const a = translateObject(angleMark(), 1, 2) as AngleMarkObject;
+    expect(a.vertex).toEqual({ x: 1, y: 2 });
+    expect(a.rayA).toEqual({ x: 11, y: 2 });
+    expect(a.rayB).toEqual({ x: 1, y: 12 });
+  });
+});
+
+describe('transformObject scale', () => {
+  it('scales shape about origin', () => {
+    const s = transformObject(shape(), {
+      scale: { sx: 2, sy: 2, pivot: { x: 0, y: 0 } },
+    }) as ShapeObject;
+    expect(s.bounds).toEqual({ x: 0, y: 0, w: 20, h: 20 });
+  });
+  it('scales stroke points', () => {
+    const s = transformObject(stroke(), {
+      scale: { sx: 2, sy: 1, pivot: { x: 0, y: 0 } },
+    }) as StrokeObject;
+    expect(s.points[1].x).toBe(20);
+  });
+});
+
+describe('transformObject rotate', () => {
+  it('rotates stroke points by 90deg', () => {
+    const s = transformObject(stroke(), {
+      rotate: { angle: Math.PI / 2, pivot: { x: 0, y: 0 } },
+    }) as StrokeObject;
+    expect(Math.round(s.points[1].x)).toBe(0);
+    expect(Math.round(s.points[1].y)).toBe(10);
+  });
+  it('keeps shape axis-aligned (rotates anchor only)', () => {
+    const s = transformObject(shape(), {
+      rotate: { angle: Math.PI / 2, pivot: { x: 0, y: 0 } },
+    }) as ShapeObject;
+    expect(s.bounds.w).toBe(10);
+    expect(s.bounds.h).toBe(10);
+  });
+});
+
+describe('applyStyleToObject', () => {
+  it('patches stroke color', () => {
+    const s = applyStyleToObject(stroke(), { color: '#f00' }) as StrokeObject;
+    expect(s.style.color).toBe('#f00');
+  });
+  it('patches all graph functions', () => {
+    const g = applyStyleToObject(graph(), { color: '#f00', width: 4 }) as GraphObject;
+    expect(g.functions[0].color).toBe('#f00');
+    expect(g.functions[0].width).toBe(4);
+  });
+  it('patches text color only', () => {
+    const t = applyStyleToObject(text(), { color: '#0f0' }) as TextObject;
+    expect(t.color).toBe('#0f0');
+  });
+  it('ignores width on text', () => {
+    const t = applyStyleToObject(text(), { width: 10 }) as TextObject;
+    expect(t).toEqual(text());
+  });
+});


### PR DESCRIPTION
Closes #136.

## Summary

Adds a new **Select** tool (shortcut `S`) that supports lasso selection,
shift-marquee, click-pick, shift-click toggle, drag-move, corner/edge
resize, rotation, and style editing via a floating toolbar. All
mutations go through \`documentStore\` so they participate in undo/redo
and session replay.

## What

- **Select tool** — lasso by default, shift to draw a rectangular
  marquee, click to pick top object, shift-click to toggle.
- **Transform handles** — 8 resize handles, rotate stem above the
  bounding box. Shift = uniform scale. Shift = 15° rotation snap.
- **Keyboard** — arrow nudges (Shift×10), Delete/Backspace, Ctrl+C/X/V,
  Ctrl+D duplicate, Esc clear.
- **Floating toolbar** — color swatches, width slider, dash toggle,
  duplicate / forward / backward / delete. Controls appear only when
  the selection contains objects that support them.
- **Store** — new \`updateMany\` command + \`documentStore.updateObjects()\`
  so batched edits collapse into a single undo entry. Session replay
  emits one \`update\` mutation per entry, so no new event kind is
  needed.

## Scope notes

- Z-order (bring forward / send backward) is currently implemented via
  remove + re-add, which costs two undo steps. Acceptable for phase 1;
  can be promoted to a dedicated \`reorder\` command later.
- Shapes, graphs, and number lines keep their AABB under rotation
  (anchor rotates, width/height preserved) until a rotation-aware
  shape type exists.

## Testing

- \`pnpm lint\` — prettier + eslint + svelte-check clean
- \`pnpm test\` — 648 passing, including 37 new unit tests across
  geometry, transforms, hit tests, and commit ops
- \`cargo fmt --check\` + \`cargo clippy --all-targets -- -D warnings\` —
  clean (no Rust changes)