### PR TITLE
ci: harden GitHub Actions (pin to SHAs, least-privilege CI, persist-credentials)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,20 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: 10
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: pnpm
@@ -25,17 +30,19 @@ jobs:
   backend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy, rustfmt
       # Avoids reinstalling webkit/gtk on every CI run (~30-60s per run).
       - name: Install Linux build deps
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: awalsh128/cache-apt-pkgs-action@2c09a5e66da6c8016428a2172bd76e5e4f14bb17 # v1.5.3
         with:
           packages: libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libssl-dev
           version: 1.0
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: src-tauri
           shared-key: tauri-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,20 +13,21 @@ jobs:
     outputs:
       body: ${{ steps.cliff.outputs.content }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Generate release notes
         id: cliff
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0
         with:
           config: cliff.toml
           args: --latest --strip all
         env:
           OUTPUT: RELEASE_NOTES.md
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: release-notes
           path: RELEASE_NOTES.md
@@ -45,7 +46,9 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Resolve bundle list
         id: bundles
@@ -70,23 +73,23 @@ jobs:
           esac
           echo "list=$list" >> "$GITHUB_OUTPUT"
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: pnpm
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.rust-target }}
 
       # Caches ~/.cargo registry + src-tauri/target across runs. Biggest
       # single win for release build time; restore-keys fall back on version
       # bumps so only eldraw itself recompiles.
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: src-tauri
           shared-key: tauri-release
@@ -95,7 +98,7 @@ jobs:
       # Avoids reinstalling webkit/gtk on every release (~30-60s per run).
       - name: Install Linux build deps
         if: matrix.platform == 'ubuntu-latest'
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: awalsh128/cache-apt-pkgs-action@2c09a5e66da6c8016428a2172bd76e5e4f14bb17 # v1.5.3
         with:
           packages: libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libssl-dev
           version: 1.0
@@ -106,7 +109,7 @@ jobs:
       # the pinned tag or checksums busts the cache automatically.
       - name: Cache pdfium
         id: cache-pdfium
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: src-tauri/pdfium
           key: pdfium-${{ runner.os }}-${{ hashFiles('scripts/fetch-pdfium.sh') }}
@@ -120,7 +123,7 @@ jobs:
             Windows) bash scripts/fetch-pdfium.sh windows ;;
           esac
 
-      - uses: tauri-apps/tauri-action@action-v0.6.2
+      - uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # action-v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -135,11 +138,12 @@ jobs:
     needs: [build, changelog]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: release-notes
 


### PR DESCRIPTION
## Summary

Low-risk GitHub Actions hardening for `ci.yml` and `release.yml`. Applies only mechanical, safe changes; defers high-risk release-job changes for human review + a tag test.

### Changes applied
- **Pin all `uses:` to full commit SHAs** (via `pinact`) in both workflows. `dtolnay/rust-toolchain@stable` and `tauri-apps/tauri-action@action-v0.6.2` pinned manually (SHA + version comment retained). Note: `rust-toolchain` still resolves the rolling `stable` channel at runtime — the SHA pins the action code, not the toolchain version.
- **`persist-credentials: false`** on every `actions/checkout` (2 in ci.yml, 3 in release.yml). Safe: `tauri-action` and `gh release edit` authenticate via `GITHUB_TOKEN`/`GH_TOKEN` env, not the persisted git credential. No step does `git push`.
- **`permissions: contents: read`** added at workflow scope in `ci.yml` (jobs only build/lint/test; no token writes).

### Deferred (HIGH-RISK — NOT in this PR)
- **`release.yml` per-job permission scoping** (workflow-level `contents: write` → per-job `build`/`publish`). `contents: write` is **kept** as-is here — needed to create/publish releases & upload installers.
- **`release.yml` cache-poisoning fixes** (setup-node pnpm, `rust-cache`, apt cache, pdfium cache). Left unchanged — the release job runs rarely and altering its caches risks breaking the Tauri build.

These remain because `release.yml` is **tag-only (`push: tags: v*`) and NOT PR-testable** — a broken edit only surfaces at release time, so it needs a maintainer-approved throwaway-tag test.

### zizmor before → after
| Rule | Before | After |
|------|--------|-------|
| unpinned-uses | 20 | **0** |
| artipacked | 5 | **0** |
| excessive-permissions (ci.yml) | 3 | **0** |
| excessive-permissions (release.yml, high) | 1 | 1 *(intentional residual)* |
| cache-poisoning (release.yml) | 4 | 4 *(intentional residual)* |
| **distinct total** | **33** | **5** |

The 5 remaining findings are all in `release.yml` and are **expected/intentional** (deferred high-risk items above).

`actionlint`: clean (0 errors) on both workflows.
