### PR TITLE
feat: LaTeX auto-detection, slide authoring, graph parameter sliders, PDF export, and 19 bug fixes

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,6 +433,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,6 +495,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -571,6 +597,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,6 +677,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -918,6 +963,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1090,6 +1166,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecb"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1099,8 +1184,11 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 name = "eldraw"
 version = "0.1.0-rc.12"
 dependencies = [
+ "font8x8",
  "image",
+ "lopdf",
  "lru",
+ "meval",
  "pdfium-render",
  "reqwest",
  "serde",
@@ -1333,6 +1421,12 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "font8x8"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875488b8711a968268c7cf5d139578713097ca4635a76044e8fe8eedf831d07e"
 
 [[package]]
 name = "foreign-types"
@@ -2216,6 +2310,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "interpolate_name"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2306,6 +2410,59 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
 ]
 
 [[package]]
@@ -2537,6 +2694,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "lopdf"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7184fdea2bc3cd272a1acec4030c321a8f9875e877b3f92a53f2f6033fdc289"
+dependencies = [
+ "aes",
+ "bitflags 2.11.1",
+ "cbc",
+ "chrono",
+ "ecb",
+ "encoding_rs",
+ "flate2",
+ "getrandom 0.3.4",
+ "indexmap 2.14.0",
+ "itoa",
+ "jiff",
+ "log",
+ "md-5",
+ "nom 8.0.0",
+ "nom_locate",
+ "rand 0.9.4",
+ "rangemap",
+ "rayon",
+ "sha2",
+ "stringprep",
+ "thiserror 2.0.18",
+ "time",
+ "ttf-parser",
+ "weezl",
+]
+
+[[package]]
 name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2616,6 +2805,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2628,6 +2827,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "meval"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79496a5651c8d57cd033c5add8ca7ee4e3d5f7587a4777484640d9cb60392d9"
+dependencies = [
+ "fnv",
+ "nom 1.2.4",
 ]
 
 [[package]]
@@ -2747,6 +2956,12 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nom"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5b8c256fd9471521bcb84c3cdba98921497f1a331cbc15b8030fc63b82050ce"
+
+[[package]]
+name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
@@ -2762,6 +2977,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "nom_locate"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b577e2d69827c4740cba2b52efaad1c4cc7c73042860b199710b3575c68438d"
+dependencies = [
+ "bytecount",
+ "memchr",
+ "nom 8.0.0",
 ]
 
 [[package]]
@@ -3108,7 +3334,7 @@ dependencies = [
  "image",
  "itertools 0.14.0",
  "js-sys",
- "libloading 0.7.4",
+ "libloading 0.8.9",
  "log",
  "maybe-owned",
  "once_cell",
@@ -3392,6 +3618,21 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -3739,6 +3980,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rangemap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
+
+[[package]]
 name = "rav1e"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4052,7 +4299,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4568,6 +4815,17 @@ dependencies = [
  "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
 ]
 
 [[package]]
@@ -5402,6 +5660,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5466,10 +5730,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,6 +27,9 @@ pdfium-render = { version = "0.9", default-features = false, features = [
   "thread_safe",
 ] }
 image = "0.25"
+font8x8 = "0.3"
+lopdf = "0.38"
+meval = "0.2"
 tauri-plugin-dialog = "2.7.0"
 lru = "0.12"
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "http2", "charset"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,9 +4,10 @@ version = "0.1.0-rc.12"
 description = "PDF annotation tool for live math teaching"
 authors = ["Adam"]
 edition = "2021"
-# File locking (std::fs::File::try_lock / TryLockError) used by storage.rs was
-# stabilized in 1.89. Declared so an older toolchain fails with a clear message.
-rust-version = "1.89"
+# Pinned by the newest std APIs in use: file locking (File::try_lock /
+# TryLockError, 1.89) in storage.rs and f64::midpoint (1.91) in export.rs.
+# Declared so an older toolchain fails with a clear message.
+rust-version = "1.91"
 
 [lib]
 name = "eldraw_lib"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0-rc.12"
 description = "PDF annotation tool for live math teaching"
 authors = ["Adam"]
 edition = "2021"
+# File locking (std::fs::File::try_lock / TryLockError) used by storage.rs was
+# stabilized in 1.89. Declared so an older toolchain fails with a clear message.
+rust-version = "1.89"
 
 [lib]
 name = "eldraw_lib"

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -27,6 +27,15 @@ pub enum AppError {
     #[error("invalid input: {0}")]
     InvalidInput(String),
 
+    #[error("invalid output path: {0}")]
+    InvalidOutputPath(String),
+
+    #[error("export: {0}")]
+    Export(String),
+
+    #[error("resource limit: {0}")]
+    ResourceLimit(String),
+
     #[error("window: {0}")]
     Window(String),
 }

--- a/src-tauri/src/export.rs
+++ b/src-tauri/src/export.rs
@@ -1,12 +1,2251 @@
+//! Flattened PDF export.
+//!
+//! Source PDF pages are rasterized with pdfium at 144 DPI, annotations are
+//! composited into that bitmap, and each bitmap is embedded as a JPEG page in
+//! a new PDF. This deliberately trades selectable source text for predictable
+//! output across all annotation kinds. Slide text uses a portable bitmap font;
+//! LaTeX is emitted as source text and data-URL slide images use an explicit
+//! placeholder rather than being silently omitted.
+
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    clippy::many_single_char_names,
+    clippy::similar_names,
+    clippy::too_many_arguments,
+    clippy::too_many_lines
+)]
+
+use std::fs::{self, File, OpenOptions};
+use std::io::{ErrorKind, Write};
+use std::path::{Component, Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use font8x8::UnicodeFonts;
+use image::codecs::jpeg::JpegEncoder;
+use image::{ExtendedColorType, RgbImage, Rgba, RgbaImage};
+use lopdf::{dictionary, Dictionary, Document, Object, Stream};
+use pdfium_render::prelude::{PdfDocument, PdfRenderConfig, Pdfium};
+use tauri::AppHandle;
+
 use crate::error::{AppError, AppResult};
-use crate::model::EldrawDocument;
+use crate::model::{
+    AngleMarkObject, Bounds, DashStyle, DrawableObject, EldrawDocument, GraphFunction,
+    GraphFunctionKind, GraphObject, LineObject, NumberLineMarkKind, NumberLineObject, Page,
+    PageKind, PartialSlideTheme, ShapeKind, ShapeObject, Slide, SlideAlign, SlideBlock,
+    SlideCalloutTone, SlideLayoutKind, SlideListMarker, SlideTheme, StrokeObject, StrokeStyle,
+    StrokeTool, TextObject,
+};
+use crate::state::pdfium;
+
+const EXPORT_SCALE: f64 = 2.0;
+const MAX_PAGE_COUNT: usize = 500;
+const MAX_PIXEL_DIMENSION: u32 = 8192;
+const MAX_PIXEL_AREA: u64 = 32 * 1024 * 1024;
+const MAX_OBJECTS_PER_PAGE: usize = 100_000;
+const MAX_POINTS_PER_STROKE: usize = 1_000_000;
+const MAX_SOURCE_BYTES: u64 = 512 * 1024 * 1024;
+const MAX_GRAPH_SAMPLES: usize = 2048;
+const JPEG_QUALITY: u8 = 92;
+
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PageSource {
+    Pdf(usize),
+    Blank,
+    Slide,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PixelSize {
+    width: u32,
+    height: u32,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Color {
+    r: u8,
+    g: u8,
+    b: u8,
+    a: u8,
+}
+
+impl Color {
+    const WHITE: Self = Self {
+        r: 255,
+        g: 255,
+        b: 255,
+        a: 255,
+    };
+
+    const BLACK: Self = Self {
+        r: 0,
+        g: 0,
+        b: 0,
+        a: 255,
+    };
+
+    fn with_opacity(self, opacity: f64) -> Self {
+        Self {
+            a: (f64::from(self.a) * opacity.clamp(0.0, 1.0)).round() as u8,
+            ..self
+        }
+    }
+}
+
+struct Canvas {
+    image: RgbaImage,
+    scale: f64,
+}
+
+impl Canvas {
+    fn new(size: PixelSize, background: Color) -> Self {
+        Self {
+            image: RgbaImage::from_pixel(
+                size.width,
+                size.height,
+                Rgba([background.r, background.g, background.b, 255]),
+            ),
+            scale: EXPORT_SCALE,
+        }
+    }
+
+    fn from_image(image: RgbaImage) -> Self {
+        Self {
+            image,
+            scale: EXPORT_SCALE,
+        }
+    }
+
+    fn width(&self) -> u32 {
+        self.image.width()
+    }
+
+    fn height(&self) -> u32 {
+        self.image.height()
+    }
+
+    fn pt(&self, value: f64) -> f64 {
+        value * self.scale
+    }
+
+    fn blend(&mut self, x: i32, y: i32, color: Color, multiply: bool) {
+        let (Ok(x), Ok(y)) = (u32::try_from(x), u32::try_from(y)) else {
+            return;
+        };
+        if x >= self.width() || y >= self.height() || color.a == 0 {
+            return;
+        }
+        let dst = self.image.get_pixel_mut(x, y);
+        let alpha = f64::from(color.a) / 255.0;
+        let [dst_r, dst_g, dst_b, dst_a] = &mut dst.0;
+        for (dst_channel, src) in [dst_r, dst_g, dst_b]
+            .into_iter()
+            .zip([color.r, color.g, color.b])
+        {
+            let base = f64::from(*dst_channel);
+            let painted = if multiply {
+                base * f64::from(src) / 255.0
+            } else {
+                f64::from(src)
+            };
+            *dst_channel = (base * (1.0 - alpha) + painted * alpha).round() as u8;
+        }
+        *dst_a = 255;
+    }
+
+    fn circle(&mut self, cx: f64, cy: f64, radius: f64, color: Color, multiply: bool) {
+        if !cx.is_finite() || !cy.is_finite() || !radius.is_finite() || radius <= 0.0 {
+            return;
+        }
+        let min_x = (cx - radius).floor().max(0.0) as i32;
+        let max_x = (cx + radius).ceil().min(f64::from(self.width())) as i32;
+        let min_y = (cy - radius).floor().max(0.0) as i32;
+        let max_y = (cy + radius).ceil().min(f64::from(self.height())) as i32;
+        let radius_sq = radius * radius;
+        for y in min_y..max_y {
+            for x in min_x..max_x {
+                let dx = f64::from(x) + 0.5 - cx;
+                let dy = f64::from(y) + 0.5 - cy;
+                if dx.mul_add(dx, dy * dy) <= radius_sq {
+                    self.blend(x, y, color, multiply);
+                }
+            }
+        }
+    }
+
+    fn segment(
+        &mut self,
+        from: (f64, f64),
+        to: (f64, f64),
+        width: f64,
+        color: Color,
+        multiply: bool,
+        dash: DashStyle,
+    ) {
+        let dx = to.0 - from.0;
+        let dy = to.1 - from.1;
+        let distance = dx.hypot(dy);
+        if !distance.is_finite() || width <= 0.0 {
+            return;
+        }
+        let steps = distance.ceil().max(1.0) as usize;
+        let dash_length = (width * 3.0).max(1.0);
+        for i in 0..=steps {
+            let t = i as f64 / steps as f64;
+            let along = distance * t;
+            let paint = match dash {
+                DashStyle::Solid => true,
+                DashStyle::Dashed => (along / dash_length).floor() as i64 % 2 == 0,
+                DashStyle::Dotted => {
+                    let period = (width * 2.5).max(1.0);
+                    along % period <= width
+                }
+            };
+            if paint {
+                self.circle(
+                    from.0 + dx * t,
+                    from.1 + dy * t,
+                    width / 2.0,
+                    color,
+                    multiply,
+                );
+            }
+        }
+    }
+
+    fn polygon(&mut self, points: &[(f64, f64)], color: Color, multiply: bool) {
+        if points.len() < 3 {
+            return;
+        }
+        let min_y = points
+            .iter()
+            .map(|p| p.1)
+            .fold(f64::INFINITY, f64::min)
+            .floor()
+            .max(0.0) as i32;
+        let max_y = points
+            .iter()
+            .map(|p| p.1)
+            .fold(f64::NEG_INFINITY, f64::max)
+            .ceil()
+            .min(f64::from(self.height())) as i32;
+        for y in min_y..max_y {
+            let scan_y = f64::from(y) + 0.5;
+            let mut intersections = Vec::with_capacity(points.len());
+            for (a, b) in points
+                .iter()
+                .zip(points.iter().cycle().skip(1))
+                .take(points.len())
+            {
+                if (a.1 > scan_y) != (b.1 > scan_y) {
+                    intersections.push(a.0 + (scan_y - a.1) * (b.0 - a.0) / (b.1 - a.1));
+                }
+            }
+            intersections.sort_by(f64::total_cmp);
+            for pair in intersections.chunks_exact(2) {
+                let [start, end] = pair else {
+                    continue;
+                };
+                let start = start.floor().max(0.0) as i32;
+                let end = end.ceil().min(f64::from(self.width())) as i32;
+                for x in start..end {
+                    self.blend(x, y, color, multiply);
+                }
+            }
+        }
+    }
+
+    fn arrowhead(&mut self, tip: (f64, f64), from: (f64, f64), size: f64, color: Color) {
+        let angle = (tip.1 - from.1).atan2(tip.0 - from.0);
+        let wing = std::f64::consts::PI / 6.0;
+        self.polygon(
+            &[
+                tip,
+                (
+                    tip.0 - size * (angle - wing).cos(),
+                    tip.1 - size * (angle - wing).sin(),
+                ),
+                (
+                    tip.0 - size * (angle + wing).cos(),
+                    tip.1 - size * (angle + wing).sin(),
+                ),
+            ],
+            color,
+            false,
+        );
+    }
+
+    fn text(&mut self, text: &str, x: f64, y: f64, size_pt: f64, color: Color) {
+        let pixel_height = self.pt(size_pt).max(8.0);
+        let glyph_scale = (pixel_height / 8.0).round().max(1.0) as i32;
+        let mut cursor_x = x.round() as i32;
+        let mut cursor_y = y.round() as i32;
+        let origin_x = cursor_x;
+        for ch in text.chars() {
+            if ch == '\n' {
+                cursor_x = origin_x;
+                cursor_y += glyph_scale * 10;
+                continue;
+            }
+            let glyph = font8x8::BASIC_FONTS
+                .get(ch)
+                .or_else(|| font8x8::BASIC_FONTS.get('?'));
+            if let Some(rows) = glyph {
+                for (row, bits) in rows.iter().enumerate() {
+                    for col in 0..8 {
+                        if bits & (1 << col) != 0 {
+                            for sy in 0..glyph_scale {
+                                for sx in 0..glyph_scale {
+                                    self.blend(
+                                        cursor_x + col * glyph_scale + sx,
+                                        cursor_y
+                                            + i32::try_from(row).unwrap_or(0) * glyph_scale
+                                            + sy,
+                                        color,
+                                        false,
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            cursor_x += glyph_scale * 9;
+        }
+    }
+}
 
 #[tauri::command]
 pub async fn export_flattened_pdf(
+    app: AppHandle,
     pdf_path: String,
     doc: EldrawDocument,
     out_path: String,
 ) -> AppResult<()> {
-    let _ = (pdf_path, doc, out_path);
-    Err(AppError::NotImplemented("export_flattened_pdf"))
+    tauri::async_runtime::spawn_blocking(move || {
+        export_impl(&app, Path::new(&pdf_path), &doc, Path::new(&out_path))
+    })
+    .await
+    .map_err(|error| AppError::Export(format!("export worker failed: {error}")))?
+}
+
+fn export_impl(
+    app: &AppHandle,
+    pdf_path: &Path,
+    doc: &EldrawDocument,
+    out_path: &Path,
+) -> AppResult<()> {
+    let output = validate_output_path(pdf_path, out_path)?;
+    let sources = select_page_sources(&doc.pages)?;
+    validate_document(doc)?;
+
+    let has_pdf_pages = sources
+        .iter()
+        .any(|source| matches!(source, PageSource::Pdf(_)));
+    let source_bytes = if has_pdf_pages {
+        Some(read_source_pdf(pdf_path)?)
+    } else {
+        None
+    };
+    if let Some(bytes) = source_bytes.as_deref() {
+        let actual_hash = crate::pdf::hash_bytes(bytes);
+        if !doc.pdf_hash.is_empty() && doc.pdf_hash != actual_hash {
+            return Err(AppError::InvalidInput(format!(
+                "sidecar PDF hash {} does not match source PDF hash {actual_hash}",
+                doc.pdf_hash
+            )));
+        }
+    }
+    let source_page_count = source_bytes
+        .as_deref()
+        .map(inspect_source_pdf)
+        .transpose()?
+        .unwrap_or(0);
+    validate_page_selection(&doc.pages, &sources, source_page_count)?;
+
+    let pdfium = source_bytes.as_ref().map(|_| pdfium(app)).transpose()?;
+    let loaded_pdf = match (pdfium, source_bytes.as_deref()) {
+        (Some(engine), Some(bytes)) => Some(load_pdfium_document(engine, bytes)?),
+        _ => None,
+    };
+
+    let mut rendered = Vec::with_capacity(doc.pages.len());
+    for (page, source) in doc.pages.iter().zip(&sources) {
+        rendered.push(render_page(
+            page,
+            *source,
+            loaded_pdf.as_ref(),
+            doc.slide_theme.as_ref(),
+        )?);
+    }
+    let bytes = encode_pdf(&doc.pages, &rendered)?;
+    atomic_write(&output, |file| {
+        file.write_all(&bytes)?;
+        file.sync_all()
+    })
+}
+
+fn read_source_pdf(path: &Path) -> AppResult<Vec<u8>> {
+    let metadata = fs::metadata(path).map_err(|error| {
+        AppError::Export(format!(
+            "cannot read source PDF {}: {error}",
+            path.display()
+        ))
+    })?;
+    if !metadata.is_file() {
+        return Err(AppError::Export(format!(
+            "source PDF is not a file: {}",
+            path.display()
+        )));
+    }
+    if metadata.len() > MAX_SOURCE_BYTES {
+        return Err(AppError::ResourceLimit(format!(
+            "source PDF is {} bytes; limit is {MAX_SOURCE_BYTES}",
+            metadata.len()
+        )));
+    }
+    fs::read(path).map_err(|error| {
+        AppError::Export(format!(
+            "cannot read source PDF {}: {error}",
+            path.display()
+        ))
+    })
+}
+
+fn inspect_source_pdf(bytes: &[u8]) -> AppResult<usize> {
+    let document = Document::load_mem(bytes)
+        .map_err(|error| AppError::Pdf(format!("source PDF is corrupt or unsupported: {error}")))?;
+    if document.is_encrypted() {
+        return Err(AppError::Pdf(
+            "source PDF is encrypted or password-protected".into(),
+        ));
+    }
+    let count = document.get_pages().len();
+    if count == 0 {
+        return Err(AppError::Pdf("source PDF has no pages".into()));
+    }
+    Ok(count)
+}
+
+fn load_pdfium_document<'a>(engine: &'a Pdfium, bytes: &'a [u8]) -> AppResult<PdfDocument<'a>> {
+    engine
+        .load_pdf_from_byte_slice(bytes, None)
+        .map_err(|error| AppError::Pdf(format!("cannot render source PDF: {error}")))
+}
+
+fn select_page_sources(pages: &[Page]) -> AppResult<Vec<PageSource>> {
+    let legacy_pdf_count = pages
+        .iter()
+        .filter(|page| page.kind == PageKind::Pdf && page.pdf_source_index.is_none())
+        .count();
+    let has_explicit = pages
+        .iter()
+        .any(|page| page.kind == PageKind::Pdf && page.pdf_source_index.is_some());
+    if legacy_pdf_count > 0 && has_explicit {
+        return Err(AppError::InvalidInput(
+            "sidecar mixes explicit and legacy PDF page references".into(),
+        ));
+    }
+
+    let mut next_legacy = 0usize;
+    let mut sources = Vec::with_capacity(pages.len());
+    for page in pages {
+        let source = match page.kind {
+            PageKind::Pdf => {
+                let index = page.pdf_source_index.unwrap_or_else(|| {
+                    let index = next_legacy;
+                    next_legacy = next_legacy.saturating_add(1);
+                    index
+                });
+                PageSource::Pdf(index)
+            }
+            PageKind::Blank => PageSource::Blank,
+            PageKind::Slide => PageSource::Slide,
+        };
+        sources.push(source);
+    }
+    Ok(sources)
+}
+
+fn validate_page_selection(
+    pages: &[Page],
+    sources: &[PageSource],
+    source_page_count: usize,
+) -> AppResult<()> {
+    let legacy_count = pages
+        .iter()
+        .filter(|page| page.kind == PageKind::Pdf && page.pdf_source_index.is_none())
+        .count();
+    if legacy_count > 0 && legacy_count != source_page_count {
+        return Err(AppError::InvalidInput(format!(
+            "legacy sidecar has {legacy_count} PDF pages but source PDF has {source_page_count}"
+        )));
+    }
+    for (array_index, source) in sources.iter().enumerate() {
+        if let PageSource::Pdf(source_index) = source {
+            if *source_index >= source_page_count {
+                return Err(AppError::InvalidInput(format!(
+                    "page {array_index} references pdfSourceIndex {source_index}, but source PDF has {source_page_count} pages"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_document(doc: &EldrawDocument) -> AppResult<()> {
+    if doc.pages.is_empty() {
+        return Err(AppError::InvalidInput(
+            "cannot export an empty document".into(),
+        ));
+    }
+    if doc.pages.len() > MAX_PAGE_COUNT {
+        return Err(AppError::ResourceLimit(format!(
+            "document has {} pages; limit is {MAX_PAGE_COUNT}",
+            doc.pages.len()
+        )));
+    }
+    for (index, page) in doc.pages.iter().enumerate() {
+        if page.page_index != index {
+            return Err(AppError::InvalidInput(format!(
+                "pageIndex {} disagrees with document position {index}",
+                page.page_index
+            )));
+        }
+        pixel_size(page.width, page.height)?;
+        if page.objects.len() > MAX_OBJECTS_PER_PAGE {
+            return Err(AppError::ResourceLimit(format!(
+                "page {index} has {} objects; limit is {MAX_OBJECTS_PER_PAGE}",
+                page.objects.len()
+            )));
+        }
+        if page.kind == PageKind::Slide && page.slide.is_none() {
+            return Err(AppError::InvalidInput(format!(
+                "slide page {index} has no slide content"
+            )));
+        }
+        for object in &page.objects {
+            validate_object(object, index)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_object(object: &DrawableObject, page_index: usize) -> AppResult<()> {
+    let values: &[f64] = match object {
+        DrawableObject::Stroke(stroke) => {
+            if stroke.points.len() > MAX_POINTS_PER_STROKE {
+                return Err(AppError::ResourceLimit(format!(
+                    "stroke {} on page {page_index} has {} points; limit is {MAX_POINTS_PER_STROKE}",
+                    stroke.base.id,
+                    stroke.points.len()
+                )));
+            }
+            for point in &stroke.points {
+                finite_values(&[point.x, point.y, point.pressure, point.t], "stroke point")?;
+            }
+            &[stroke.style.width, stroke.style.opacity]
+        }
+        DrawableObject::Line(line) => &[
+            line.from.x,
+            line.from.y,
+            line.to.x,
+            line.to.y,
+            line.style.width,
+            line.style.opacity,
+        ],
+        DrawableObject::Shape(shape) => &[
+            shape.bounds.x,
+            shape.bounds.y,
+            shape.bounds.w,
+            shape.bounds.h,
+            shape.style.width,
+            shape.style.opacity,
+        ],
+        DrawableObject::NumberLine(line) => &[
+            line.from.x,
+            line.from.y,
+            line.length,
+            line.min,
+            line.max,
+            line.tick_step,
+            line.label_step,
+            line.style.width,
+            line.style.opacity,
+        ],
+        DrawableObject::Graph(graph) => &[
+            graph.bounds.x,
+            graph.bounds.y,
+            graph.bounds.w,
+            graph.bounds.h,
+            graph.x_range[0],
+            graph.x_range[1],
+            graph.y_range[0],
+            graph.y_range[1],
+            graph.grid_step,
+        ],
+        DrawableObject::Text(text) => &[text.at.x, text.at.y, text.font_size],
+        DrawableObject::AngleMark(mark) => &[
+            mark.vertex.x,
+            mark.vertex.y,
+            mark.ray_a.x,
+            mark.ray_a.y,
+            mark.ray_b.x,
+            mark.ray_b.y,
+            mark.degrees,
+            mark.width,
+        ],
+    };
+    finite_values(values, "annotation")
+}
+
+fn finite_values(values: &[f64], label: &str) -> AppResult<()> {
+    if values.iter().all(|value| value.is_finite()) {
+        Ok(())
+    } else {
+        Err(AppError::InvalidInput(format!(
+            "{label} contains a non-finite number"
+        )))
+    }
+}
+
+fn pixel_size(width_pt: f64, height_pt: f64) -> AppResult<PixelSize> {
+    if !width_pt.is_finite() || !height_pt.is_finite() || width_pt <= 0.0 || height_pt <= 0.0 {
+        return Err(AppError::InvalidInput(format!(
+            "invalid page dimensions {width_pt}x{height_pt} points"
+        )));
+    }
+    let width = (width_pt * EXPORT_SCALE).round();
+    let height = (height_pt * EXPORT_SCALE).round();
+    if width > f64::from(MAX_PIXEL_DIMENSION) || height > f64::from(MAX_PIXEL_DIMENSION) {
+        return Err(AppError::ResourceLimit(format!(
+            "page bitmap {width:.0}x{height:.0} exceeds {MAX_PIXEL_DIMENSION}-pixel dimension cap"
+        )));
+    }
+    let width = width.max(1.0) as u32;
+    let height = height.max(1.0) as u32;
+    let area = u64::from(width)
+        .checked_mul(u64::from(height))
+        .ok_or_else(|| AppError::ResourceLimit("page pixel area overflow".into()))?;
+    if area > MAX_PIXEL_AREA {
+        return Err(AppError::ResourceLimit(format!(
+            "page bitmap {width}x{height} exceeds {MAX_PIXEL_AREA}-pixel area cap"
+        )));
+    }
+    let byte_count = area
+        .checked_mul(4)
+        .ok_or_else(|| AppError::ResourceLimit("page byte count overflow".into()))?;
+    usize::try_from(byte_count)
+        .map_err(|_| AppError::ResourceLimit("page byte count exceeds platform limit".into()))?;
+    Ok(PixelSize { width, height })
+}
+
+fn render_page(
+    page: &Page,
+    source: PageSource,
+    pdf: Option<&PdfDocument<'_>>,
+    document_theme: Option<&SlideTheme>,
+) -> AppResult<RgbaImage> {
+    let size = pixel_size(page.width, page.height)?;
+    let mut canvas = match source {
+        PageSource::Pdf(index) => {
+            let pdf = pdf.ok_or_else(|| AppError::Pdf("source PDF was not loaded".into()))?;
+            Canvas::from_image(render_source_page(
+                pdf,
+                index,
+                size,
+                page.width,
+                page.height,
+            )?)
+        }
+        PageSource::Blank => Canvas::new(size, page_background(page)?),
+        PageSource::Slide => {
+            let slide = page.slide.as_ref().ok_or_else(|| {
+                AppError::InvalidInput(format!(
+                    "slide page {} has no slide content",
+                    page.page_index
+                ))
+            })?;
+            let theme = merged_slide_theme(document_theme, slide.theme.as_ref())?;
+            let mut canvas = Canvas::new(size, parse_color(&theme.background)?);
+            render_slide(&mut canvas, slide, &theme)?;
+            canvas
+        }
+    };
+
+    for object in &page.objects {
+        draw_object(&mut canvas, object)?;
+    }
+    Ok(canvas.image)
+}
+
+fn render_source_page(
+    document: &PdfDocument<'_>,
+    index: usize,
+    size: PixelSize,
+    expected_width: f64,
+    expected_height: f64,
+) -> AppResult<RgbaImage> {
+    let index = i32::try_from(index)
+        .map_err(|_| AppError::InvalidInput(format!("pdfSourceIndex {index} is too large")))?;
+    let page = document
+        .pages()
+        .get(index)
+        .map_err(|_| AppError::InvalidInput(format!("pdfSourceIndex {index} is out of range")))?;
+    let source_width = f64::from(page.width().value);
+    let source_height = f64::from(page.height().value);
+    if (source_width - expected_width).abs() > 1.0 || (source_height - expected_height).abs() > 1.0
+    {
+        return Err(AppError::InvalidInput(format!(
+            "page dimensions {expected_width}x{expected_height} disagree with source page {index} dimensions {source_width}x{source_height}"
+        )));
+    }
+    let config = PdfRenderConfig::new()
+        .set_target_width(i32::try_from(size.width).map_err(|_| {
+            AppError::ResourceLimit("page width exceeds pdfium integer limit".into())
+        })?)
+        .set_target_height(i32::try_from(size.height).map_err(|_| {
+            AppError::ResourceLimit("page height exceeds pdfium integer limit".into())
+        })?);
+    let bitmap = page
+        .render_with_config(&config)
+        .map_err(|error| AppError::Pdf(format!("render page {index}: {error}")))?;
+    let image = bitmap
+        .as_image()
+        .map_err(|error| AppError::Pdf(format!("read rendered page {index}: {error}")))?;
+    Ok(image.into_rgba8())
+}
+
+fn page_background(page: &Page) -> AppResult<Color> {
+    page.background
+        .as_deref()
+        .map(parse_color)
+        .transpose()
+        .map(Option::unwrap_or_default)
+}
+
+impl Default for Color {
+    fn default() -> Self {
+        Self::WHITE
+    }
+}
+
+fn draw_object(canvas: &mut Canvas, object: &DrawableObject) -> AppResult<()> {
+    match object {
+        DrawableObject::Stroke(stroke) => draw_stroke(canvas, stroke),
+        DrawableObject::Line(line) => draw_line(canvas, line),
+        DrawableObject::Shape(shape) => draw_shape(canvas, shape),
+        DrawableObject::NumberLine(line) => draw_number_line(canvas, line),
+        DrawableObject::Graph(graph) => draw_graph(canvas, graph),
+        DrawableObject::Text(text) => draw_text(canvas, text),
+        DrawableObject::AngleMark(mark) => draw_angle_mark(canvas, mark),
+    }
+}
+
+fn style_color(style: &StrokeStyle) -> AppResult<Color> {
+    Ok(parse_color(&style.color)?.with_opacity(style.opacity))
+}
+
+fn draw_stroke(canvas: &mut Canvas, stroke: &StrokeObject) -> AppResult<()> {
+    if stroke.points.is_empty() {
+        return Ok(());
+    }
+    let color = style_color(&stroke.style)?;
+    let multiply = matches!(stroke.tool, StrokeTool::Highlighter);
+    let base_width = canvas.pt(stroke.style.width).max(0.5);
+    if stroke.points.len() == 1 {
+        let Some(point) = stroke.points.first().copied() else {
+            return Ok(());
+        };
+        let radius = base_width * pressure_factor(point.pressure) / 2.0;
+        canvas.circle(
+            canvas.pt(point.x),
+            canvas.pt(point.y),
+            radius,
+            color,
+            multiply,
+        );
+        return Ok(());
+    }
+    for points in stroke.points.windows(2) {
+        let [from, to] = points else {
+            continue;
+        };
+        let (from, to) = (*from, *to);
+        let start_width = base_width * pressure_factor(from.pressure);
+        let end_width = base_width * pressure_factor(to.pressure);
+        let dx = canvas.pt(to.x - from.x);
+        let dy = canvas.pt(to.y - from.y);
+        let distance = dx.hypot(dy);
+        let steps = distance.ceil().max(1.0) as usize;
+        for i in 0..=steps {
+            let t = i as f64 / steps as f64;
+            let along = distance * t;
+            let width = start_width + (end_width - start_width) * t;
+            let paint = match stroke.style.dash {
+                DashStyle::Solid => true,
+                DashStyle::Dashed => (along / (base_width * 3.0).max(1.0)).floor() as i64 % 2 == 0,
+                DashStyle::Dotted => along % (base_width * 2.5).max(1.0) <= base_width,
+            };
+            if paint {
+                canvas.circle(
+                    canvas.pt(from.x) + dx * t,
+                    canvas.pt(from.y) + dy * t,
+                    width / 2.0,
+                    color,
+                    multiply,
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn pressure_factor(pressure: f64) -> f64 {
+    0.4 + pressure.clamp(0.0, 1.0) * 0.6
+}
+
+fn draw_line(canvas: &mut Canvas, line: &LineObject) -> AppResult<()> {
+    let color = style_color(&line.style)?;
+    let width = canvas.pt(line.style.width).max(0.5);
+    let from = (canvas.pt(line.from.x), canvas.pt(line.from.y));
+    let to = (canvas.pt(line.to.x), canvas.pt(line.to.y));
+    canvas.segment(from, to, width, color, false, line.style.dash);
+    let head = (width * 4.0).max(6.0);
+    if line.arrow.end {
+        canvas.arrowhead(to, from, head, color);
+    }
+    if line.arrow.start {
+        canvas.arrowhead(from, to, head, color);
+    }
+    Ok(())
+}
+
+fn draw_shape(canvas: &mut Canvas, shape: &ShapeObject) -> AppResult<()> {
+    let stroke = style_color(&shape.style)?;
+    let fill = shape
+        .fill
+        .as_deref()
+        .map(parse_color)
+        .transpose()?
+        .map(|color| color.with_opacity(shape.style.opacity));
+    let x = canvas.pt(shape.bounds.x);
+    let y = canvas.pt(shape.bounds.y);
+    let w = canvas.pt(shape.bounds.w);
+    let h = canvas.pt(shape.bounds.h);
+    let width = canvas.pt(shape.style.width).max(0.5);
+    match shape.kind {
+        ShapeKind::Rect => {
+            let x0 = x.min(x + w);
+            let x1 = x.max(x + w);
+            let y0 = y.min(y + h);
+            let y1 = y.max(y + h);
+            if let Some(fill) = fill {
+                canvas.polygon(&[(x0, y0), (x1, y0), (x1, y1), (x0, y1)], fill, false);
+            }
+            for (from, to) in [
+                ((x0, y0), (x1, y0)),
+                ((x1, y0), (x1, y1)),
+                ((x1, y1), (x0, y1)),
+                ((x0, y1), (x0, y0)),
+            ] {
+                canvas.segment(from, to, width, stroke, false, shape.style.dash);
+            }
+        }
+        ShapeKind::Ellipse => {
+            let cx = x + w / 2.0;
+            let cy = y + h / 2.0;
+            let rx = w.abs() / 2.0;
+            let ry = h.abs() / 2.0;
+            let steps = 180usize;
+            let points: Vec<_> = (0..steps)
+                .map(|i| {
+                    let angle = std::f64::consts::TAU * i as f64 / steps as f64;
+                    (cx + rx * angle.cos(), cy + ry * angle.sin())
+                })
+                .collect();
+            if let Some(fill) = fill {
+                canvas.polygon(&points, fill, false);
+            }
+            for pair in points
+                .iter()
+                .zip(points.iter().cycle().skip(1))
+                .take(points.len())
+            {
+                canvas.segment(*pair.0, *pair.1, width, stroke, false, shape.style.dash);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn draw_number_line(canvas: &mut Canvas, line: &NumberLineObject) -> AppResult<()> {
+    if line.max <= line.min || line.length == 0.0 {
+        return Ok(());
+    }
+    let color = style_color(&line.style)?;
+    let width = canvas.pt(line.style.width).max(0.5);
+    let y = canvas.pt(line.from.y);
+    let x0 = canvas.pt(line.from.x);
+    let x1 = canvas.pt(line.from.x + line.length);
+    canvas.segment((x0, y), (x1, y), width, color, false, line.style.dash);
+    let head = (width * 4.0).max(6.0);
+    canvas.arrowhead((x0, y), (x1, y), head, color);
+    canvas.arrowhead((x1, y), (x0, y), head, color);
+
+    for value in values_in_range(line.min, line.max, line.tick_step) {
+        let x = number_line_x(line, value, canvas.scale);
+        canvas.segment(
+            (x, y - width * 2.0),
+            (x, y + width * 2.0),
+            width,
+            color,
+            false,
+            DashStyle::Solid,
+        );
+    }
+    for value in values_in_range(line.min, line.max, line.label_step) {
+        let x = number_line_x(line, value, canvas.scale);
+        let label = format_number(value);
+        let approx_width = f64::from(label.len() as u32) * canvas.pt(10.0) * 0.6;
+        canvas.text(&label, x - approx_width / 2.0, y + width * 3.0, 10.0, color);
+    }
+    for mark in &line.marks {
+        let x = number_line_x(line, mark.value, canvas.scale);
+        let radius = (width * 2.2).max(4.0);
+        match mark.kind {
+            NumberLineMarkKind::Closed => canvas.circle(x, y, radius, color, false),
+            NumberLineMarkKind::Open => {
+                canvas.circle(x, y, radius, Color::WHITE, false);
+                draw_circle_outline(canvas, x, y, radius, width, color);
+            }
+            NumberLineMarkKind::ArrowLeft => {
+                canvas.segment((x, y), (x0, y), width, color, false, DashStyle::Solid);
+                canvas.arrowhead((x0, y), (x, y), head, color);
+            }
+            NumberLineMarkKind::ArrowRight => {
+                canvas.segment((x, y), (x1, y), width, color, false, DashStyle::Solid);
+                canvas.arrowhead((x1, y), (x, y), head, color);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn values_in_range(min: f64, max: f64, step: f64) -> Vec<f64> {
+    if !step.is_finite() || step <= 0.0 || max < min {
+        return Vec::new();
+    }
+    let first = (min / step).ceil() * step;
+    let raw_count = ((max - first) / step).floor().max(0.0) as usize + 1;
+    let count = raw_count.min(10_000);
+    (0..count).map(|i| first + i as f64 * step).collect()
+}
+
+fn number_line_x(line: &NumberLineObject, value: f64, scale: f64) -> f64 {
+    (line.from.x + (value - line.min) / (line.max - line.min) * line.length) * scale
+}
+
+fn draw_graph(canvas: &mut Canvas, graph: &GraphObject) -> AppResult<()> {
+    draw_graph_spec(
+        canvas,
+        graph.bounds,
+        graph.x_range,
+        graph.y_range,
+        graph.grid_step,
+        graph.show_axes,
+        graph.show_grid,
+        &graph.functions,
+    )
+}
+
+fn draw_graph_spec(
+    canvas: &mut Canvas,
+    bounds: Bounds,
+    x_range: [f64; 2],
+    y_range: [f64; 2],
+    grid_step: f64,
+    show_axes: bool,
+    show_grid: bool,
+    functions: &[GraphFunction],
+) -> AppResult<()> {
+    let x_span = x_range[1] - x_range[0];
+    let y_span = y_range[1] - y_range[0];
+    if bounds.w <= 0.0 || bounds.h <= 0.0 || x_span <= 0.0 || y_span <= 0.0 {
+        return Ok(());
+    }
+    let rect = Bounds {
+        x: canvas.pt(bounds.x),
+        y: canvas.pt(bounds.y),
+        w: canvas.pt(bounds.w),
+        h: canvas.pt(bounds.h),
+    };
+    let grid = Color {
+        r: 210,
+        g: 210,
+        b: 210,
+        a: 255,
+    };
+    let axis = Color::BLACK;
+    let x_to_px = |x: f64| rect.x + (x - x_range[0]) / x_span * rect.w;
+    let y_to_px = |y: f64| rect.y + (1.0 - (y - y_range[0]) / y_span) * rect.h;
+    let step = if grid_step > 0.0 {
+        grid_step
+    } else {
+        nice_step(x_span.max(y_span) / 8.0)
+    };
+    if show_grid {
+        for value in values_in_range(x_range[0], x_range[1], step) {
+            let x = x_to_px(value);
+            canvas.segment(
+                (x, rect.y),
+                (x, rect.y + rect.h),
+                1.0,
+                grid,
+                false,
+                DashStyle::Solid,
+            );
+        }
+        for value in values_in_range(y_range[0], y_range[1], step) {
+            let y = y_to_px(value);
+            canvas.segment(
+                (rect.x, y),
+                (rect.x + rect.w, y),
+                1.0,
+                grid,
+                false,
+                DashStyle::Solid,
+            );
+        }
+    }
+    if show_axes {
+        if x_range[0] <= 0.0 && x_range[1] >= 0.0 {
+            let x = x_to_px(0.0);
+            canvas.segment(
+                (x, rect.y),
+                (x, rect.y + rect.h),
+                2.0,
+                axis,
+                false,
+                DashStyle::Solid,
+            );
+        }
+        if y_range[0] <= 0.0 && y_range[1] >= 0.0 {
+            let y = y_to_px(0.0);
+            canvas.segment(
+                (rect.x, y),
+                (rect.x + rect.w, y),
+                2.0,
+                axis,
+                false,
+                DashStyle::Solid,
+            );
+        }
+    }
+    for function in functions {
+        draw_graph_function(canvas, function, rect, x_range, y_range)?;
+    }
+    Ok(())
+}
+
+fn nice_step(raw: f64) -> f64 {
+    if !raw.is_finite() || raw <= 0.0 {
+        return 1.0;
+    }
+    let power = 10_f64.powf(raw.log10().floor());
+    let scaled = raw / power;
+    let nice = if scaled <= 1.0 {
+        1.0
+    } else if scaled <= 2.0 {
+        2.0
+    } else if scaled <= 5.0 {
+        5.0
+    } else {
+        10.0
+    };
+    nice * power
+}
+
+fn draw_graph_function(
+    canvas: &mut Canvas,
+    function: &GraphFunction,
+    rect: Bounds,
+    x_range: [f64; 2],
+    y_range: [f64; 2],
+) -> AppResult<()> {
+    let color = parse_color(&function.color)?;
+    let width = canvas.pt(function.width).max(0.5);
+    let x_span = x_range[1] - x_range[0];
+    let y_span = y_range[1] - y_range[0];
+    let x_to_px = |x: f64| rect.x + (x - x_range[0]) / x_span * rect.w;
+    let y_to_px = |y: f64| rect.y + (1.0 - (y - y_range[0]) / y_span) * rect.h;
+    match function.kind {
+        GraphFunctionKind::Explicit => {
+            let expression: meval::Expr = function.expr.parse().map_err(|error| {
+                AppError::InvalidInput(format!(
+                    "cannot parse graph expression '{}': {error}",
+                    function.expr
+                ))
+            })?;
+            let evaluator = expression.bind("x").map_err(|error| {
+                AppError::InvalidInput(format!(
+                    "cannot bind graph expression '{}': {error}",
+                    function.expr
+                ))
+            })?;
+            let domain = function.domain.unwrap_or(x_range);
+            let start = domain[0].max(x_range[0]);
+            let end = domain[1].min(x_range[1]);
+            if start >= end {
+                return Ok(());
+            }
+            let samples = (rect.w.ceil() as usize).clamp(64, MAX_GRAPH_SAMPLES);
+            let mut previous: Option<(f64, f64)> = None;
+            for i in 0..=samples {
+                let x = start + (end - start) * i as f64 / samples as f64;
+                let y = evaluator(x);
+                let current = if y.is_finite() && y >= y_range[0] && y <= y_range[1] {
+                    Some((x_to_px(x), y_to_px(y)))
+                } else {
+                    None
+                };
+                if let (Some(from), Some(to)) = (previous, current) {
+                    if (to.1 - from.1).abs() < rect.h {
+                        canvas.segment(from, to, width, color, false, function.dash);
+                    }
+                }
+                previous = current;
+            }
+        }
+        GraphFunctionKind::Implicit => {
+            let normalized = if let Some((left, right)) = function.expr.split_once('=') {
+                format!("({left})-({right})")
+            } else {
+                function.expr.clone()
+            };
+            let expression: meval::Expr = normalized.parse().map_err(|error| {
+                AppError::InvalidInput(format!(
+                    "cannot parse implicit graph expression '{}': {error}",
+                    function.expr
+                ))
+            })?;
+            let evaluator = expression.bind2("x", "y").map_err(|error| {
+                AppError::InvalidInput(format!(
+                    "cannot bind implicit graph expression '{}': {error}",
+                    function.expr
+                ))
+            })?;
+            draw_implicit(
+                canvas,
+                &evaluator,
+                rect,
+                x_range,
+                y_range,
+                width,
+                color,
+                function.dash,
+            );
+        }
+    }
+    Ok(())
+}
+
+fn draw_implicit(
+    canvas: &mut Canvas,
+    evaluator: &impl Fn(f64, f64) -> f64,
+    rect: Bounds,
+    x_range: [f64; 2],
+    y_range: [f64; 2],
+    width: f64,
+    color: Color,
+    dash: DashStyle,
+) {
+    let cols = (rect.w / 5.0).ceil().clamp(16.0, 256.0) as usize;
+    let rows = (rect.h / 5.0).ceil().clamp(16.0, 256.0) as usize;
+    for row in 0..rows {
+        for col in 0..cols {
+            let x0 = x_range[0] + (x_range[1] - x_range[0]) * col as f64 / cols as f64;
+            let x1 = x_range[0] + (x_range[1] - x_range[0]) * (col + 1) as f64 / cols as f64;
+            let y0 = y_range[0] + (y_range[1] - y_range[0]) * row as f64 / rows as f64;
+            let y1 = y_range[0] + (y_range[1] - y_range[0]) * (row + 1) as f64 / rows as f64;
+            let values = [
+                evaluator(x0, y0),
+                evaluator(x1, y0),
+                evaluator(x1, y1),
+                evaluator(x0, y1),
+            ];
+            if values.iter().any(|value| !value.is_finite()) {
+                continue;
+            }
+            let has_positive = values.iter().any(|value| *value >= 0.0);
+            let has_negative = values.iter().any(|value| *value < 0.0);
+            if has_positive && has_negative {
+                let px0 = rect.x + rect.w * col as f64 / cols as f64;
+                let px1 = rect.x + rect.w * (col + 1) as f64 / cols as f64;
+                let py0 = rect.y + rect.h * (rows - row - 1) as f64 / rows as f64;
+                let py1 = rect.y + rect.h * (rows - row) as f64 / rows as f64;
+                canvas.segment(
+                    (f64::midpoint(px0, px1), py0),
+                    (f64::midpoint(px0, px1), py1),
+                    width,
+                    color,
+                    false,
+                    dash,
+                );
+            }
+        }
+    }
+}
+
+fn draw_text(canvas: &mut Canvas, text: &TextObject) -> AppResult<()> {
+    let color = parse_color(&text.color)?;
+    let content = match text.math_mode {
+        Some(crate::model::TextMathMode::Latex) => format!("[LaTeX] {}", text.content),
+        _ if text.latex => format!("[LaTeX] {}", text.content),
+        _ => text.content.clone(),
+    };
+    canvas.text(
+        &content,
+        canvas.pt(text.at.x),
+        canvas.pt(text.at.y),
+        text.font_size,
+        color,
+    );
+    Ok(())
+}
+
+fn draw_angle_mark(canvas: &mut Canvas, mark: &AngleMarkObject) -> AppResult<()> {
+    let color = parse_color(&mark.color)?;
+    let width = canvas.pt(mark.width).max(0.5);
+    let vertex = (canvas.pt(mark.vertex.x), canvas.pt(mark.vertex.y));
+    let ray_a = (canvas.pt(mark.ray_a.x), canvas.pt(mark.ray_a.y));
+    let ray_b = (canvas.pt(mark.ray_b.x), canvas.pt(mark.ray_b.y));
+    canvas.segment(vertex, ray_a, width, color, false, DashStyle::Solid);
+    canvas.segment(vertex, ray_b, width, color, false, DashStyle::Solid);
+    let distance_a = (ray_a.0 - vertex.0).hypot(ray_a.1 - vertex.1);
+    let distance_b = (ray_b.0 - vertex.0).hypot(ray_b.1 - vertex.1);
+    let radius = distance_a
+        .min(distance_b)
+        .mul_add(0.25, 0.0)
+        .clamp(12.0, 50.0);
+    let start = (ray_a.1 - vertex.1).atan2(ray_a.0 - vertex.0);
+    let sweep = mark.degrees.to_radians();
+    let steps = (sweep.abs() * radius / 2.0).ceil().clamp(8.0, 256.0) as usize;
+    let mut previous = (
+        vertex.0 + radius * start.cos(),
+        vertex.1 + radius * start.sin(),
+    );
+    for i in 1..=steps {
+        let angle = start + sweep * i as f64 / steps as f64;
+        let current = (
+            vertex.0 + radius * angle.cos(),
+            vertex.1 + radius * angle.sin(),
+        );
+        canvas.segment(previous, current, width, color, false, DashStyle::Solid);
+        previous = current;
+    }
+    if mark.show_label {
+        let middle = start + sweep / 2.0;
+        let label_radius = radius + canvas.pt(10.0);
+        let label = format!("{} deg", format_number(mark.degrees.abs()));
+        canvas.text(
+            &label,
+            vertex.0 + label_radius * middle.cos(),
+            vertex.1 + label_radius * middle.sin(),
+            10.0,
+            color,
+        );
+    }
+    Ok(())
+}
+
+fn draw_circle_outline(
+    canvas: &mut Canvas,
+    cx: f64,
+    cy: f64,
+    radius: f64,
+    width: f64,
+    color: Color,
+) {
+    let steps = 72usize;
+    let mut previous = (cx + radius, cy);
+    for i in 1..=steps {
+        let angle = std::f64::consts::TAU * i as f64 / steps as f64;
+        let current = (cx + radius * angle.cos(), cy + radius * angle.sin());
+        canvas.segment(previous, current, width, color, false, DashStyle::Solid);
+        previous = current;
+    }
+}
+
+fn merged_slide_theme(
+    document: Option<&SlideTheme>,
+    page: Option<&PartialSlideTheme>,
+) -> AppResult<SlideTheme> {
+    let base = document.cloned().unwrap_or_else(default_slide_theme);
+    let Some(page) = page else {
+        validate_slide_theme(&base)?;
+        return Ok(base);
+    };
+    let merged = SlideTheme {
+        font_family: page
+            .font_family
+            .clone()
+            .unwrap_or_else(|| base.font_family.clone()),
+        background: page
+            .background
+            .clone()
+            .unwrap_or_else(|| base.background.clone()),
+        title_color: page
+            .title_color
+            .clone()
+            .unwrap_or_else(|| base.title_color.clone()),
+        text_color: page
+            .text_color
+            .clone()
+            .unwrap_or_else(|| base.text_color.clone()),
+        accent: page.accent.clone().unwrap_or_else(|| base.accent.clone()),
+        title_size: page.title_size.unwrap_or(base.title_size),
+        heading_size: page.heading_size.unwrap_or(base.heading_size),
+        body_size: page.body_size.unwrap_or(base.body_size),
+    };
+    validate_slide_theme(&merged)?;
+    Ok(merged)
+}
+
+fn default_slide_theme() -> SlideTheme {
+    SlideTheme {
+        font_family: "sans-serif".into(),
+        background: "#ffffff".into(),
+        title_color: "#172033".into(),
+        text_color: "#172033".into(),
+        accent: "#2563eb".into(),
+        title_size: 34.0,
+        heading_size: 24.0,
+        body_size: 18.0,
+    }
+}
+
+fn validate_slide_theme(theme: &SlideTheme) -> AppResult<()> {
+    parse_color(&theme.background)?;
+    parse_color(&theme.title_color)?;
+    parse_color(&theme.text_color)?;
+    parse_color(&theme.accent)?;
+    finite_values(
+        &[theme.title_size, theme.heading_size, theme.body_size],
+        "slide theme",
+    )
+}
+
+fn render_slide(canvas: &mut Canvas, slide: &Slide, theme: &SlideTheme) -> AppResult<()> {
+    let margin = canvas.pt(36.0);
+    let content_width = f64::from(canvas.width()) - margin * 2.0;
+    let title_color = parse_color(&theme.title_color)?;
+    let text_color = parse_color(&theme.text_color)?;
+    let accent = parse_color(&theme.accent)?;
+    let mut y = margin;
+    if !matches!(slide.layout, SlideLayoutKind::Blank) {
+        canvas.text(&slide.title, margin, y, theme.title_size, title_color);
+        y += canvas.pt(theme.title_size + 12.0);
+        if let Some(subtitle) = slide.subtitle.as_deref() {
+            canvas.text(subtitle, margin, y, theme.heading_size, text_color);
+            y += canvas.pt(theme.heading_size + 14.0);
+        }
+        canvas.segment(
+            (margin, y),
+            (margin + content_width, y),
+            canvas.pt(1.5),
+            accent,
+            false,
+            DashStyle::Solid,
+        );
+        y += canvas.pt(18.0);
+    }
+    for block in &slide.blocks {
+        y += canvas.pt(block_margin(block));
+        y = render_slide_block(canvas, block, theme, margin, y, content_width)?;
+        if y > f64::from(canvas.height()) - margin {
+            break;
+        }
+    }
+    if let Some(asides) = slide.aside.as_deref() {
+        let aside_width = content_width * 0.35;
+        let mut aside_y = margin;
+        for aside in asides {
+            aside_y = render_callout(
+                canvas,
+                &aside.text,
+                aside.tone,
+                aside.font_size.unwrap_or(theme.body_size * 0.8),
+                margin + content_width - aside_width,
+                aside_y,
+                aside_width,
+                theme,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn block_margin(block: &SlideBlock) -> f64 {
+    match block {
+        SlideBlock::Text(block) => block.base.margin_top,
+        SlideBlock::List(block) => block.base.margin_top,
+        SlideBlock::Definitions(block) => block.base.margin_top,
+        SlideBlock::Table(block) => block.base.margin_top,
+        SlideBlock::Math(block) => block.base.margin_top,
+        SlideBlock::Graph(block) => block.base.margin_top,
+        SlideBlock::Callout(block) => block.base.margin_top,
+        SlideBlock::Image(block) => block.base.margin_top,
+        SlideBlock::Spacer(block) => block.base.margin_top,
+    }
+    .unwrap_or(10.0)
+}
+
+fn render_slide_block(
+    canvas: &mut Canvas,
+    block: &SlideBlock,
+    theme: &SlideTheme,
+    x: f64,
+    y: f64,
+    width: f64,
+) -> AppResult<f64> {
+    let text_color = parse_color(&theme.text_color)?;
+    match block {
+        SlideBlock::Text(block) => {
+            let size = block.font_size.unwrap_or(theme.body_size);
+            let color = block
+                .color
+                .as_deref()
+                .map(parse_color)
+                .transpose()?
+                .unwrap_or(text_color);
+            let x = aligned_x(
+                x,
+                width,
+                &block.text,
+                size,
+                block.align.unwrap_or(SlideAlign::Left),
+                canvas.scale,
+            );
+            canvas.text(&block.text, x, y, size, color);
+            Ok(y + canvas.pt(size + 8.0))
+        }
+        SlideBlock::List(block) => {
+            let size = block.font_size.unwrap_or(theme.body_size);
+            let mut next_y = y;
+            let mut decimal = 1usize;
+            for item in &block.items {
+                let marker = match block.marker {
+                    SlideListMarker::Bullet => "*".into(),
+                    SlideListMarker::Decimal if item.level == 0 => {
+                        let result = format!("{decimal}.");
+                        decimal = decimal.saturating_add(1);
+                        result
+                    }
+                    _ => String::new(),
+                };
+                let line = if marker.is_empty() {
+                    item.text.clone()
+                } else {
+                    format!("{marker} {}", item.text)
+                };
+                canvas.text(
+                    &line,
+                    x + canvas.pt((item.level.min(3) * 18) as f64),
+                    next_y,
+                    size,
+                    text_color,
+                );
+                next_y += canvas.pt(size + 6.0);
+            }
+            Ok(next_y)
+        }
+        SlideBlock::Definitions(block) => {
+            let size = block.font_size.unwrap_or(theme.body_size);
+            let mut next_y = y;
+            for item in &block.items {
+                canvas.text(
+                    &format!("{}: {}", item.term, item.text),
+                    x,
+                    next_y,
+                    size,
+                    text_color,
+                );
+                next_y += canvas.pt(size + 6.0);
+            }
+            Ok(next_y)
+        }
+        SlideBlock::Table(block) => {
+            let size = block.font_size.unwrap_or(theme.body_size * 0.75);
+            let columns = block
+                .header
+                .len()
+                .max(block.rows.iter().map(Vec::len).max().unwrap_or(0))
+                .max(1);
+            let cell_width = width / columns as f64;
+            let row_height = canvas.pt(size + 8.0);
+            let mut next_y = y;
+            if let Some(caption) = block.caption.as_deref() {
+                canvas.text(caption, x, next_y, size, text_color);
+                next_y += row_height;
+            }
+            let rows = std::iter::once(&block.header).chain(block.rows.iter());
+            for row in rows {
+                for col in 0..columns {
+                    let cell_x = x + cell_width * col as f64;
+                    canvas.segment(
+                        (cell_x, next_y),
+                        (cell_x + cell_width, next_y),
+                        1.0,
+                        text_color,
+                        false,
+                        DashStyle::Solid,
+                    );
+                    if let Some(value) = row.get(col) {
+                        canvas.text(value, cell_x + 4.0, next_y + 4.0, size, text_color);
+                    }
+                }
+                next_y += row_height;
+            }
+            Ok(next_y)
+        }
+        SlideBlock::Math(block) => {
+            let size = block.font_size.unwrap_or(theme.heading_size);
+            let color = block
+                .color
+                .as_deref()
+                .map(parse_color)
+                .transpose()?
+                .unwrap_or(text_color);
+            let label = format!("[LaTeX] {}", block.latex);
+            let x = aligned_x(
+                x,
+                width,
+                &label,
+                size,
+                block.align.unwrap_or(SlideAlign::Left),
+                canvas.scale,
+            );
+            canvas.text(&label, x, y, size, color);
+            Ok(y + canvas.pt(size + 10.0))
+        }
+        SlideBlock::Graph(block) => {
+            let mut next_y = y;
+            if let Some(caption) = block.caption.as_deref() {
+                canvas.text(caption, x, next_y, theme.body_size, text_color);
+                next_y += canvas.pt(theme.body_size + 6.0);
+            }
+            let graph = &block.graph;
+            draw_graph_spec(
+                canvas,
+                Bounds {
+                    x: x / canvas.scale,
+                    y: next_y / canvas.scale,
+                    w: width / canvas.scale,
+                    h: block.height,
+                },
+                graph.x_range,
+                graph.y_range,
+                graph.grid_step,
+                graph.show_axes,
+                graph.show_grid,
+                &graph.functions,
+            )?;
+            Ok(next_y + canvas.pt(block.height))
+        }
+        SlideBlock::Callout(block) => render_callout(
+            canvas,
+            &block.text,
+            block.tone,
+            block.font_size.unwrap_or(theme.body_size),
+            x,
+            y,
+            width,
+            theme,
+        ),
+        SlideBlock::Image(block) => {
+            let height = canvas.pt(block.height.max(12.0));
+            let border = parse_color(&theme.accent)?;
+            for (from, to) in [
+                ((x, y), (x + width, y)),
+                ((x + width, y), (x + width, y + height)),
+                ((x + width, y + height), (x, y + height)),
+                ((x, y + height), (x, y)),
+            ] {
+                canvas.segment(from, to, 2.0, border, false, DashStyle::Solid);
+            }
+            canvas.text(
+                &format!("[image: {}]", block.alt),
+                x + 8.0,
+                y + 8.0,
+                theme.body_size * 0.75,
+                text_color,
+            );
+            Ok(y + height)
+        }
+        SlideBlock::Spacer(block) => Ok(y + canvas.pt(block.height.max(0.0))),
+    }
+}
+
+fn render_callout(
+    canvas: &mut Canvas,
+    text: &str,
+    tone: SlideCalloutTone,
+    size: f64,
+    x: f64,
+    y: f64,
+    width: f64,
+    theme: &SlideTheme,
+) -> AppResult<f64> {
+    let fill = match tone {
+        SlideCalloutTone::Tip => parse_color("#dcfce7")?,
+        SlideCalloutTone::Warn => parse_color("#fef3c7")?,
+        SlideCalloutTone::Note => parse_color("#dbeafe")?,
+    };
+    let color = parse_color(&theme.text_color)?;
+    let height = canvas.pt(size + 18.0);
+    canvas.polygon(
+        &[
+            (x, y),
+            (x + width, y),
+            (x + width, y + height),
+            (x, y + height),
+        ],
+        fill,
+        false,
+    );
+    canvas.text(text, x + 8.0, y + 8.0, size, color);
+    Ok(y + height + canvas.pt(6.0))
+}
+
+fn aligned_x(x: f64, width: f64, text: &str, size: f64, align: SlideAlign, scale: f64) -> f64 {
+    let approximate = text.chars().count() as f64 * size * scale * 0.6;
+    match align {
+        SlideAlign::Left => x,
+        SlideAlign::Center => x + (width - approximate) / 2.0,
+        SlideAlign::Right => x + width - approximate,
+    }
+}
+
+fn parse_color(value: &str) -> AppResult<Color> {
+    let bytes = value.as_bytes();
+    let &[b'#', r1, r2, g1, g2, b1, b2] = bytes else {
+        return Err(AppError::InvalidInput(format!(
+            "invalid color '{value}'; expected #rrggbb"
+        )));
+    };
+    let parse = |high: u8, low: u8| -> AppResult<u8> {
+        let digit = |byte: u8| match byte {
+            b'0'..=b'9' => Some(byte - b'0'),
+            b'a'..=b'f' => Some(byte - b'a' + 10),
+            b'A'..=b'F' => Some(byte - b'A' + 10),
+            _ => None,
+        };
+        let high = digit(high)
+            .ok_or_else(|| AppError::InvalidInput(format!("invalid color '{value}'")))?;
+        let low =
+            digit(low).ok_or_else(|| AppError::InvalidInput(format!("invalid color '{value}'")))?;
+        Ok(high * 16 + low)
+    };
+    Ok(Color {
+        r: parse(r1, r2)?,
+        g: parse(g1, g2)?,
+        b: parse(b1, b2)?,
+        a: 255,
+    })
+}
+
+fn format_number(value: f64) -> String {
+    if (value - value.round()).abs() < 1e-9 {
+        format!("{value:.0}")
+    } else {
+        let formatted = format!("{value:.2}");
+        formatted
+            .trim_end_matches('0')
+            .trim_end_matches('.')
+            .to_owned()
+    }
+}
+
+fn encode_pdf(pages: &[Page], images: &[RgbaImage]) -> AppResult<Vec<u8>> {
+    if pages.len() != images.len() {
+        return Err(AppError::Export(
+            "internal page/image count mismatch".into(),
+        ));
+    }
+    let mut document = Document::with_version("1.5");
+    let pages_id = document.new_object_id();
+    let catalog_id = document.new_object_id();
+    let mut page_ids = Vec::with_capacity(pages.len());
+
+    for (index, (page, image)) in pages.iter().zip(images).enumerate() {
+        let image_id = document.new_object_id();
+        let content_id = document.new_object_id();
+        let page_id = document.new_object_id();
+        page_ids.push(page_id);
+
+        let rgb = rgba_to_rgb(image)?;
+        let mut jpeg = Vec::new();
+        JpegEncoder::new_with_quality(&mut jpeg, JPEG_QUALITY)
+            .encode(
+                rgb.as_raw(),
+                rgb.width(),
+                rgb.height(),
+                ExtendedColorType::Rgb8,
+            )
+            .map_err(|error| AppError::Export(format!("encode page {index} image: {error}")))?;
+        document.objects.insert(
+            image_id,
+            Object::Stream(Stream::new(
+                dictionary! {
+                    "Type" => "XObject",
+                    "Subtype" => "Image",
+                    "Width" => i64::from(rgb.width()),
+                    "Height" => i64::from(rgb.height()),
+                    "ColorSpace" => "DeviceRGB",
+                    "BitsPerComponent" => 8,
+                    "Filter" => "DCTDecode",
+                },
+                jpeg,
+            )),
+        );
+
+        let image_name = format!("Im{index}");
+        let (_, pdf_y) = top_left_rect_to_pdf(0.0, 0.0, page.height, page.height);
+        let content = format!(
+            "q\n{} 0 0 {} 0 {} cm\n/{} Do\nQ\n",
+            page.width, page.height, pdf_y, image_name
+        );
+        document.objects.insert(
+            content_id,
+            Object::Stream(Stream::new(Dictionary::new(), content.into_bytes())),
+        );
+        let mut xobjects = Dictionary::new();
+        xobjects.set(image_name.as_bytes(), Object::Reference(image_id));
+        document.objects.insert(
+            page_id,
+            dictionary! {
+                "Type" => "Page",
+                "Parent" => pages_id,
+                "MediaBox" => vec![0.into(), 0.into(), page.width.into(), page.height.into()],
+                "Resources" => dictionary! {
+                    "XObject" => xobjects,
+                },
+                "Contents" => content_id,
+            }
+            .into(),
+        );
+    }
+
+    document.objects.insert(
+        pages_id,
+        dictionary! {
+            "Type" => "Pages",
+            "Kids" => page_ids.iter().copied().map(Object::Reference).collect::<Vec<_>>(),
+            "Count" => i64::try_from(page_ids.len())
+                .map_err(|_| AppError::ResourceLimit("PDF page count exceeds i64".into()))?,
+        }
+        .into(),
+    );
+    document.objects.insert(
+        catalog_id,
+        dictionary! {
+            "Type" => "Catalog",
+            "Pages" => pages_id,
+        }
+        .into(),
+    );
+    document.trailer.set("Root", catalog_id);
+    document.compress();
+    let mut output = Vec::new();
+    document
+        .save_to(&mut output)
+        .map_err(|error| AppError::Export(format!("write PDF structure: {error}")))?;
+    Ok(output)
+}
+
+fn rgba_to_rgb(image: &RgbaImage) -> AppResult<RgbImage> {
+    let pixel_count = u64::from(image.width())
+        .checked_mul(u64::from(image.height()))
+        .ok_or_else(|| AppError::ResourceLimit("RGB pixel count overflow".into()))?;
+    let byte_count = pixel_count
+        .checked_mul(3)
+        .ok_or_else(|| AppError::ResourceLimit("RGB byte count overflow".into()))?;
+    let capacity = usize::try_from(byte_count)
+        .map_err(|_| AppError::ResourceLimit("RGB image exceeds platform limit".into()))?;
+    let mut bytes = Vec::with_capacity(capacity);
+    for pixel in image.pixels() {
+        bytes.extend_from_slice(&pixel.0[..3]);
+    }
+    RgbImage::from_raw(image.width(), image.height(), bytes)
+        .ok_or_else(|| AppError::Export("could not construct RGB page image".into()))
+}
+
+fn validate_output_path(pdf_path: &Path, out_path: &Path) -> AppResult<PathBuf> {
+    if !out_path.is_absolute() {
+        return Err(AppError::InvalidOutputPath(
+            "output path must be absolute".into(),
+        ));
+    }
+    if out_path
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
+    {
+        return Err(AppError::InvalidOutputPath(
+            "output path must not contain '..'".into(),
+        ));
+    }
+    if out_path.extension().and_then(|value| value.to_str()) != Some("pdf") {
+        return Err(AppError::InvalidOutputPath(
+            "output filename must end in .pdf".into(),
+        ));
+    }
+    let filename = out_path
+        .file_name()
+        .ok_or_else(|| AppError::InvalidOutputPath("output path must include a filename".into()))?;
+    let parent = out_path.parent().ok_or_else(|| {
+        AppError::InvalidOutputPath("output path must have a parent directory".into())
+    })?;
+    let canonical_parent = fs::canonicalize(parent).map_err(|error| {
+        AppError::InvalidOutputPath(format!(
+            "output directory {} is unavailable: {error}",
+            parent.display()
+        ))
+    })?;
+    if !canonical_parent.is_dir() {
+        return Err(AppError::InvalidOutputPath(format!(
+            "output parent is not a directory: {}",
+            canonical_parent.display()
+        )));
+    }
+    if canonical_parent.parent().is_none() {
+        return Err(AppError::InvalidOutputPath(
+            "refusing to write directly to the filesystem root".into(),
+        ));
+    }
+    let output = canonical_parent.join(filename);
+    if let Ok(metadata) = fs::symlink_metadata(&output) {
+        if metadata.file_type().is_symlink() {
+            return Err(AppError::InvalidOutputPath(
+                "refusing to replace a symbolic link".into(),
+            ));
+        }
+        if !metadata.is_file() {
+            return Err(AppError::InvalidOutputPath(
+                "output path exists and is not a regular file".into(),
+            ));
+        }
+        if metadata.permissions().readonly() {
+            return Err(AppError::InvalidOutputPath(
+                "output file is read-only".into(),
+            ));
+        }
+    }
+    if let (Ok(source), Ok(output_existing)) =
+        (fs::canonicalize(pdf_path), fs::canonicalize(&output))
+    {
+        if source == output_existing {
+            return Err(AppError::InvalidOutputPath(
+                "output path must differ from the source PDF".into(),
+            ));
+        }
+    }
+    Ok(output)
+}
+
+fn atomic_write(
+    output: &Path,
+    write: impl FnOnce(&mut File) -> std::io::Result<()>,
+) -> AppResult<()> {
+    let parent = output
+        .parent()
+        .ok_or_else(|| AppError::InvalidOutputPath("output has no parent directory".into()))?;
+    let filename = output
+        .file_name()
+        .and_then(|value| value.to_str())
+        .ok_or_else(|| AppError::InvalidOutputPath("output filename is not valid UTF-8".into()))?;
+    let temp = unique_temp_path(parent, filename);
+    let result = (|| -> std::io::Result<()> {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp)?;
+        write(&mut file)?;
+        drop(file);
+        fs::rename(&temp, output)?;
+        sync_directory(parent)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temp);
+    }
+    result.map_err(|error| {
+        let detail = if error.kind() == ErrorKind::PermissionDenied {
+            "permission denied or destination is read-only".to_owned()
+        } else {
+            error.to_string()
+        };
+        AppError::Export(format!(
+            "atomic write to {} failed: {detail}",
+            output.display()
+        ))
+    })
+}
+
+fn unique_temp_path(parent: &Path, filename: &str) -> PathBuf {
+    let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    parent.join(format!(
+        ".{filename}.eldraw-export-{}-{counter}.tmp",
+        std::process::id()
+    ))
+}
+
+#[cfg(unix)]
+fn sync_directory(parent: &Path) -> std::io::Result<()> {
+    File::open(parent)?.sync_all()
+}
+
+#[cfg(not(unix))]
+fn sync_directory(_parent: &Path) -> std::io::Result<()> {
+    Ok(())
+}
+
+/// Convert an app-space point to native PDF user space.
+fn top_left_to_pdf(x: f64, y: f64, page_height: f64) -> (f64, f64) {
+    (x, page_height - y)
+}
+
+fn top_left_rect_to_pdf(x: f64, y: f64, height: f64, page_height: f64) -> (f64, f64) {
+    top_left_to_pdf(x, y + height, page_height)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    #[allow(clippy::needless_pass_by_value)]
+    fn document(pages: Vec<serde_json::Value>) -> EldrawDocument {
+        serde_json::from_value(json!({
+            "version": 1,
+            "pdfHash": "fixture",
+            "pdfPath": null,
+            "pages": pages,
+            "palettes": [],
+            "prefs": {},
+        }))
+        .unwrap()
+    }
+
+    fn page(kind: &str, index: usize) -> serde_json::Value {
+        json!({
+            "pageIndex": index,
+            "type": kind,
+            "insertedAfterPdfPage": null,
+            "width": 100.0,
+            "height": 200.0,
+            "background": "#ffffff",
+            "objects": [],
+        })
+    }
+
+    fn fixture_pdf(page_count: usize) -> Vec<u8> {
+        let pages: Vec<Page> = (0..page_count)
+            .map(|index| serde_json::from_value(page("blank", index)).expect("fixture page"))
+            .collect();
+        let images: Vec<RgbaImage> = (0..page_count)
+            .map(|_| RgbaImage::from_pixel(200, 400, Rgba([255, 255, 255, 255])))
+            .collect();
+        encode_pdf(&pages, &images).expect("fixture PDF")
+    }
+
+    #[test]
+    fn coordinate_transform_flips_y_exactly() {
+        assert_eq!(top_left_to_pdf(12.5, 25.0, 792.0), (12.5, 767.0));
+        assert_eq!(top_left_rect_to_pdf(10.0, 20.0, 30.0, 200.0), (10.0, 150.0));
+    }
+
+    #[test]
+    fn selection_honors_reorder_duplicates_and_deletion() {
+        let mut p0 = page("pdf", 0);
+        p0["pdfSourceIndex"] = json!(2);
+        let mut p1 = page("pdf", 1);
+        p1["pdfSourceIndex"] = json!(0);
+        let mut p2 = page("pdf", 2);
+        p2["pdfSourceIndex"] = json!(2);
+        let doc = document(vec![p0, p1, p2]);
+        assert_eq!(
+            select_page_sources(&doc.pages).unwrap(),
+            vec![PageSource::Pdf(2), PageSource::Pdf(0), PageSource::Pdf(2)]
+        );
+        validate_page_selection(&doc.pages, &select_page_sources(&doc.pages).unwrap(), 3).unwrap();
+    }
+
+    #[test]
+    fn blank_and_slide_pages_render_without_source_pdf() {
+        let blank = page("blank", 0);
+        let mut slide = page("slide", 1);
+        slide["slide"] = json!({
+            "layout": "content",
+            "title": "Lesson",
+            "blocks": [{"id":"b1","kind":"text","text":"Hello"}],
+        });
+        let doc = document(vec![blank, slide]);
+        validate_document(&doc).unwrap();
+        let sources = select_page_sources(&doc.pages).unwrap();
+        let blank_image = render_page(&doc.pages[0], sources[0], None, None).unwrap();
+        let slide_image = render_page(&doc.pages[1], sources[1], None, None).unwrap();
+        assert_eq!(blank_image.dimensions(), (200, 400));
+        assert_eq!(slide_image.dimensions(), (200, 400));
+        assert_ne!(slide_image, blank_image);
+    }
+
+    #[test]
+    fn every_annotation_kind_renders_and_encodes() {
+        let style = json!({
+            "color": "#2255aa",
+            "width": 2.0,
+            "dash": "solid",
+            "opacity": 0.8,
+        });
+        let mut annotated = page("blank", 0);
+        annotated["objects"] = json!([
+            {
+                "id":"stroke","createdAt":0,"type":"stroke","tool":"pen","style":style,
+                "points":[
+                    {"x":5,"y":5,"pressure":0.2,"t":0},
+                    {"x":30,"y":20,"pressure":1.0,"t":10}
+                ]
+            },
+            {
+                "id":"highlight","createdAt":0,"type":"stroke","tool":"highlighter",
+                "style":{"color":"#ffff00","width":8,"dash":"solid","opacity":0.4},
+                "points":[
+                    {"x":5,"y":25,"pressure":0.5,"t":0},
+                    {"x":40,"y":25,"pressure":0.5,"t":10}
+                ]
+            },
+            {
+                "id":"line","createdAt":0,"type":"line","style":style,
+                "from":{"x":5,"y":35},"to":{"x":50,"y":35},
+                "arrow":{"start":true,"end":true}
+            },
+            {
+                "id":"rect","createdAt":0,"type":"shape","kind":"rect","style":style,
+                "fill":"#ddeeff","bounds":{"x":5,"y":45,"w":25,"h":15}
+            },
+            {
+                "id":"ellipse","createdAt":0,"type":"shape","kind":"ellipse","style":style,
+                "fill":null,"bounds":{"x":35,"y":45,"w":25,"h":15}
+            },
+            {
+                "id":"number","createdAt":0,"type":"numberline","style":style,
+                "from":{"x":10,"y":75},"length":70,"min":-2,"max":2,
+                "tickStep":1,"labelStep":1,
+                "marks":[{"value":1,"kind":"closed"}]
+            },
+            {
+                "id":"graph","createdAt":0,"type":"graph",
+                "bounds":{"x":5,"y":95,"w":60,"h":45},
+                "xRange":[-2,2],"yRange":[-2,2],"gridStep":1,
+                "showAxes":true,"showGrid":true,
+                "functions":[{
+                    "id":"f","expr":"x","kind":"explicit","color":"#cc0000",
+                    "width":1,"dash":"solid","domain":null
+                }]
+            },
+            {
+                "id":"text","createdAt":0,"type":"text","at":{"x":5,"y":145},
+                "content":"y = x","latex":false,"fontSize":10,"color":"#000000"
+            },
+            {
+                "id":"angle","createdAt":0,"type":"angleMark",
+                "vertex":{"x":70,"y":170},"rayA":{"x":90,"y":170},"rayB":{"x":70,"y":150},
+                "degrees":-90,"color":"#000000","width":1,"showLabel":true
+            }
+        ]);
+        let doc = document(vec![annotated]);
+        validate_document(&doc).unwrap();
+        let image = render_page(&doc.pages[0], PageSource::Blank, None, None).unwrap();
+        let bytes = encode_pdf(&doc.pages, &[image]).unwrap();
+        assert_eq!(inspect_source_pdf(&bytes).unwrap(), 1);
+    }
+
+    #[test]
+    fn blank_and_slide_pages_encode_as_pdf_pages() {
+        let blank = page("blank", 0);
+        let mut slide = page("slide", 1);
+        slide["slide"] = json!({
+            "layout": "title",
+            "title": "Lesson",
+            "subtitle": "Functions",
+            "blocks": [{"id":"b1","kind":"callout","text":"Try it","tone":"tip"}],
+        });
+        let doc = document(vec![blank, slide]);
+        let sources = select_page_sources(&doc.pages).unwrap();
+        let images = doc
+            .pages
+            .iter()
+            .zip(sources)
+            .map(|(page, source)| render_page(page, source, None, None).unwrap())
+            .collect::<Vec<_>>();
+        let bytes = encode_pdf(&doc.pages, &images).unwrap();
+        assert_eq!(inspect_source_pdf(&bytes).unwrap(), 2);
+    }
+
+    #[test]
+    fn missing_source_file_is_typed_export_error() {
+        let error =
+            read_source_pdf(Path::new("/definitely/missing/eldraw-fixture.pdf")).unwrap_err();
+        assert!(matches!(error, AppError::Export(_)));
+        assert!(error.to_string().contains("cannot read source PDF"));
+    }
+
+    #[test]
+    fn corrupt_source_file_is_typed_pdf_error() {
+        let error = inspect_source_pdf(b"not a pdf").unwrap_err();
+        assert!(matches!(error, AppError::Pdf(_)));
+        assert!(error.to_string().contains("corrupt"));
+    }
+
+    #[test]
+    fn out_of_range_pdf_source_index_is_rejected() {
+        let mut pdf_page = page("pdf", 0);
+        pdf_page["pdfSourceIndex"] = json!(3);
+        let doc = document(vec![pdf_page]);
+        let sources = select_page_sources(&doc.pages).unwrap();
+        let fixture = fixture_pdf(1);
+        let count = inspect_source_pdf(&fixture).unwrap();
+        let error = validate_page_selection(&doc.pages, &sources, count).unwrap_err();
+        assert!(matches!(error, AppError::InvalidInput(_)));
+        assert!(error.to_string().contains("pdfSourceIndex 3"));
+    }
+
+    #[test]
+    fn zero_size_page_is_rejected() {
+        let mut blank = page("blank", 0);
+        blank["width"] = json!(0);
+        let error = validate_document(&document(vec![blank])).unwrap_err();
+        assert!(matches!(error, AppError::InvalidInput(_)));
+        assert!(error.to_string().contains("invalid page dimensions"));
+    }
+
+    #[test]
+    fn empty_document_is_rejected() {
+        let error = validate_document(&document(Vec::new())).unwrap_err();
+        assert!(matches!(error, AppError::InvalidInput(_)));
+        assert!(error.to_string().contains("empty document"));
+    }
+
+    #[test]
+    fn failed_atomic_write_leaves_no_partial_output() {
+        let dir = TempDir::new().unwrap();
+        let output = dir.path().join("notes.pdf");
+        let error = atomic_write(&output, |file| {
+            file.write_all(b"partial")?;
+            Err(std::io::Error::other("injected failure"))
+        })
+        .unwrap_err();
+        assert!(matches!(error, AppError::Export(_)));
+        assert!(!output.exists());
+        assert_eq!(fs::read_dir(dir.path()).unwrap().count(), 0);
+    }
+
+    #[test]
+    fn failed_replacement_preserves_existing_output() {
+        let dir = TempDir::new().unwrap();
+        let output = dir.path().join("notes.pdf");
+        fs::write(&output, b"original").unwrap();
+        atomic_write(&output, |file| {
+            file.write_all(b"replacement")?;
+            Err(std::io::Error::other("injected failure"))
+        })
+        .unwrap_err();
+        assert_eq!(fs::read(&output).unwrap(), b"original");
+    }
+
+    #[test]
+    fn dimension_and_area_caps_are_enforced() {
+        let dimension = pixel_size(f64::from(MAX_PIXEL_DIMENSION), 10.0).unwrap_err();
+        assert!(matches!(dimension, AppError::ResourceLimit(_)));
+        let area = pixel_size(4096.0, 4096.0).unwrap_err();
+        assert!(matches!(area, AppError::ResourceLimit(_)));
+    }
+
+    #[test]
+    fn page_count_cap_is_enforced() {
+        let pages = (0..=MAX_PAGE_COUNT)
+            .map(|index| page("blank", index))
+            .collect();
+        let error = validate_document(&document(pages)).unwrap_err();
+        assert!(matches!(error, AppError::ResourceLimit(_)));
+    }
+
+    #[test]
+    fn programmatic_fixture_pdf_has_requested_page_count() {
+        let bytes = fixture_pdf(3);
+        assert_eq!(inspect_source_pdf(&bytes).unwrap(), 3);
+    }
+
+    #[test]
+    fn source_page_rasterizes_when_pdfium_binary_is_present() {
+        let library_name = Pdfium::pdfium_platform_library_name();
+        let library = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("pdfium")
+            .join(library_name);
+        if !library.exists() {
+            eprintln!("pdfium binary is not installed; source raster smoke test skipped");
+            return;
+        }
+        let bindings = Pdfium::bind_to_library(&library).expect("bind fixture pdfium");
+        let engine = Pdfium::new(bindings);
+        let fixture_page: Page = serde_json::from_value(page("blank", 0)).expect("fixture page");
+        let mut fixture_image = RgbaImage::from_pixel(200, 400, Rgba([0, 0, 255, 255]));
+        for pixel in fixture_image.rows_mut().take(200).flatten() {
+            *pixel = Rgba([255, 0, 0, 255]);
+        }
+        let bytes = encode_pdf(&[fixture_page], &[fixture_image]).expect("fixture PDF");
+        let document = load_pdfium_document(&engine, &bytes).expect("load fixture PDF");
+        let image = render_source_page(
+            &document,
+            0,
+            PixelSize {
+                width: 200,
+                height: 400,
+            },
+            100.0,
+            200.0,
+        )
+        .expect("render fixture PDF");
+        assert_eq!(image.dimensions(), (200, 400));
+        assert!(image.get_pixel(100, 50).0[0] > 200, "top must stay red");
+        assert!(
+            image.get_pixel(100, 350).0[2] > 200,
+            "bottom must stay blue"
+        );
+    }
+
+    #[test]
+    fn output_path_rejects_relative_and_root_paths() {
+        let relative = validate_output_path(Path::new("/source.pdf"), Path::new("out.pdf"));
+        assert!(matches!(relative, Err(AppError::InvalidOutputPath(_))));
+        let root = validate_output_path(Path::new("/source.pdf"), Path::new("/out.pdf"));
+        assert!(matches!(root, Err(AppError::InvalidOutputPath(_))));
+    }
+
+    #[test]
+    fn read_only_existing_output_is_rejected() {
+        let dir = TempDir::new().unwrap();
+        let output = dir.path().join("notes.pdf");
+        fs::write(&output, b"old").unwrap();
+        let mut permissions = fs::metadata(&output).unwrap().permissions();
+        permissions.set_readonly(true);
+        fs::set_permissions(&output, permissions).unwrap();
+        let error = validate_output_path(&dir.path().join("source.pdf"), &output).unwrap_err();
+        assert!(matches!(error, AppError::InvalidOutputPath(_)));
+    }
 }

--- a/src-tauri/src/export.rs
+++ b/src-tauri/src/export.rs
@@ -34,8 +34,8 @@ use crate::model::{
     AngleMarkObject, Bounds, DashStyle, DrawableObject, EldrawDocument, GraphFunction,
     GraphFunctionKind, GraphObject, LineObject, NumberLineMarkKind, NumberLineObject, Page,
     PageKind, PartialSlideTheme, ShapeKind, ShapeObject, Slide, SlideAlign, SlideBlock,
-    SlideCalloutTone, SlideLayoutKind, SlideListMarker, SlideTheme, StrokeObject, StrokeStyle,
-    StrokeTool, TextObject,
+    SlideCalloutTone, SlideDiagramNodeShape, SlideLayoutKind, SlideListMarker,
+    SlideNumberLineBlock, SlideTheme, StrokeObject, StrokeStyle, StrokeTool, TextObject,
 };
 use crate::state::pdfium;
 
@@ -1262,6 +1262,85 @@ fn draw_angle_mark(canvas: &mut Canvas, mark: &AngleMarkObject) -> AppResult<()>
     Ok(())
 }
 
+fn draw_ellipse_outline(
+    canvas: &mut Canvas,
+    cx: f64,
+    cy: f64,
+    rx: f64,
+    ry: f64,
+    width: f64,
+    color: Color,
+) {
+    if !(rx.is_finite() && ry.is_finite()) || rx <= 0.0 || ry <= 0.0 {
+        return;
+    }
+    let steps = 72usize;
+    let mut previous = (cx + rx, cy);
+    for i in 1..=steps {
+        let angle = std::f64::consts::TAU * i as f64 / steps as f64;
+        let current = (cx + rx * angle.cos(), cy + ry * angle.sin());
+        canvas.segment(previous, current, width, color, false, DashStyle::Solid);
+        previous = current;
+    }
+}
+
+/// Ticks and value labels for a slide number line.
+///
+/// The step values come from an untrusted sidecar, so the emitted count is
+/// capped rather than trusting `(max - min) / step` to be sane.
+fn draw_number_line_ticks(
+    canvas: &mut Canvas,
+    block: &SlideNumberLineBlock,
+    to_x: &dyn Fn(f64) -> f64,
+    axis_y: f64,
+    color: Color,
+    theme: &SlideTheme,
+) -> usize {
+    const MAX_TICKS: usize = 400;
+    let mut drawn = 0usize;
+    let tick_half = canvas.pt(3.0);
+
+    if block.tick_step.is_finite() && block.tick_step > 0.0 {
+        let mut value = (block.min / block.tick_step).ceil() * block.tick_step;
+        while value <= block.max && drawn < MAX_TICKS {
+            let tx = to_x(value);
+            canvas.segment(
+                (tx, axis_y - tick_half),
+                (tx, axis_y + tick_half),
+                1.0,
+                color,
+                false,
+                DashStyle::Solid,
+            );
+            value += block.tick_step;
+            drawn += 1;
+        }
+    }
+
+    if block.label_step.is_finite() && block.label_step > 0.0 {
+        let mut labelled = 0usize;
+        let mut value = (block.min / block.label_step).ceil() * block.label_step;
+        while value <= block.max && labelled < MAX_TICKS {
+            let label = if value.fract().abs() < 1e-9 {
+                format!("{}", value.round() as i64)
+            } else {
+                format!("{value:.2}")
+            };
+            canvas.text(
+                &label,
+                to_x(value) - canvas.pt(4.0),
+                axis_y + tick_half + canvas.pt(3.0),
+                theme.body_size * 0.75,
+                color,
+            );
+            value += block.label_step;
+            labelled += 1;
+        }
+    }
+
+    drawn
+}
+
 fn draw_circle_outline(
     canvas: &mut Canvas,
     cx: f64,
@@ -1399,6 +1478,9 @@ fn block_margin(block: &SlideBlock) -> f64 {
         SlideBlock::Graph(block) => block.base.margin_top,
         SlideBlock::Callout(block) => block.base.margin_top,
         SlideBlock::Image(block) => block.base.margin_top,
+        SlideBlock::Mapping(block) => block.base.margin_top,
+        SlideBlock::Diagram(block) => block.base.margin_top,
+        SlideBlock::Numberline(block) => block.base.margin_top,
         SlideBlock::Spacer(block) => block.base.margin_top,
     }
     .unwrap_or(10.0)
@@ -1584,6 +1666,213 @@ fn render_slide_block(
                 theme.body_size * 0.75,
                 text_color,
             );
+            Ok(y + height)
+        }
+        SlideBlock::Mapping(block) => {
+            let height = canvas.pt(block.height.max(24.0));
+            let accent = parse_color(&theme.accent)?;
+            let label_size = theme.body_size * 0.85;
+            let oval_w = width * 0.28;
+            let oval_h = (height - canvas.pt(label_size * 1.6)).max(canvas.pt(12.0));
+            let left_cx = x + oval_w * 0.6;
+            let right_cx = x + width - oval_w * 0.6;
+            let cy = y + oval_h / 2.0;
+
+            draw_ellipse_outline(canvas, left_cx, cy, oval_w / 2.0, oval_h / 2.0, 1.5, accent);
+            draw_ellipse_outline(
+                canvas,
+                right_cx,
+                cy,
+                oval_w / 2.0,
+                oval_h / 2.0,
+                1.5,
+                text_color,
+            );
+
+            let item_y = |index: usize, count: usize| -> f64 {
+                if count == 0 {
+                    return cy;
+                }
+                cy - oval_h / 2.0 + oval_h * (index as f64 + 1.0) / (count as f64 + 1.0)
+            };
+
+            for (i, label) in block.left.iter().enumerate() {
+                canvas.text(
+                    label,
+                    left_cx - oval_w * 0.2,
+                    item_y(i, block.left.len()),
+                    theme.body_size,
+                    text_color,
+                );
+            }
+            for (i, label) in block.right.iter().enumerate() {
+                canvas.text(
+                    label,
+                    right_cx - oval_w * 0.2,
+                    item_y(i, block.right.len()),
+                    theme.body_size,
+                    text_color,
+                );
+            }
+            // Indices are validated on the frontend, but sidecars are untrusted.
+            for pair in &block.pairs {
+                if pair.from >= block.left.len() || pair.to >= block.right.len() {
+                    continue;
+                }
+                let from = (left_cx + oval_w / 2.0, item_y(pair.from, block.left.len()));
+                let to = (right_cx - oval_w / 2.0, item_y(pair.to, block.right.len()));
+                canvas.segment(from, to, 1.0, text_color, false, DashStyle::Solid);
+                canvas.arrowhead(to, from, canvas.pt(4.0), text_color);
+            }
+
+            canvas.text(
+                &block.left_label,
+                left_cx - oval_w / 2.0,
+                y + oval_h + canvas.pt(4.0),
+                label_size,
+                text_color,
+            );
+            canvas.text(
+                &block.right_label,
+                right_cx - oval_w / 2.0,
+                y + oval_h + canvas.pt(4.0),
+                label_size,
+                text_color,
+            );
+            Ok(y + height)
+        }
+        SlideBlock::Diagram(block) => {
+            let height = canvas.pt(block.height.max(24.0));
+            let accent = parse_color(&theme.accent)?;
+            let clamp01 = |v: f64| {
+                if v.is_finite() {
+                    v.clamp(0.0, 1.0)
+                } else {
+                    0.0
+                }
+            };
+            let node_box = |node: &crate::model::SlideDiagramNode| -> (f64, f64, f64, f64) {
+                let nw = node.w.filter(|v| v.is_finite() && *v > 0.0).unwrap_or(0.22) * width;
+                let nh = node.h.filter(|v| v.is_finite() && *v > 0.0).unwrap_or(0.22) * height;
+                let cx = x + clamp01(node.x) * width;
+                let cy = y + clamp01(node.y) * height;
+                (cx - nw / 2.0, cy - nh / 2.0, nw, nh)
+            };
+
+            for node in &block.nodes {
+                let (bx, by, bw, bh) = node_box(node);
+                if !matches!(node.shape, Some(SlideDiagramNodeShape::Plain)) {
+                    for (from, to) in [
+                        ((bx, by), (bx + bw, by)),
+                        ((bx + bw, by), (bx + bw, by + bh)),
+                        ((bx + bw, by + bh), (bx, by + bh)),
+                        ((bx, by + bh), (bx, by)),
+                    ] {
+                        canvas.segment(from, to, 1.2, accent, false, DashStyle::Solid);
+                    }
+                }
+                canvas.text(
+                    &node.text,
+                    bx + canvas.pt(4.0),
+                    by + bh / 2.0,
+                    theme.body_size,
+                    text_color,
+                );
+            }
+
+            for edge in &block.edges {
+                if edge.from == edge.to {
+                    continue;
+                }
+                let Some(from) = block.nodes.iter().find(|n| n.id == edge.from) else {
+                    continue;
+                };
+                let Some(to) = block.nodes.iter().find(|n| n.id == edge.to) else {
+                    continue;
+                };
+                let (fx, fy, fw, fh) = node_box(from);
+                let (tx, ty, _, th) = node_box(to);
+                let start = (fx + fw, fy + fh / 2.0);
+                let end = (tx, ty + th / 2.0);
+                canvas.segment(start, end, 1.0, text_color, false, DashStyle::Solid);
+                canvas.arrowhead(end, start, canvas.pt(4.0), text_color);
+                if let Some(label) = &edge.label {
+                    canvas.text(
+                        label,
+                        f64::midpoint(start.0, end.0),
+                        f64::midpoint(start.1, end.1) - canvas.pt(6.0),
+                        theme.body_size * 0.8,
+                        text_color,
+                    );
+                }
+            }
+            Ok(y + height)
+        }
+        SlideBlock::Numberline(block) => {
+            let height = canvas.pt(block.height.max(16.0));
+            let axis_y = y + height / 2.0;
+            let span = block.max - block.min;
+            if !span.is_finite() || span <= 0.0 {
+                return Ok(y + height);
+            }
+            let to_x = |value: f64| x + ((value - block.min) / span).clamp(0.0, 1.0) * width;
+
+            canvas.segment(
+                (x, axis_y),
+                (x + width, axis_y),
+                1.2,
+                text_color,
+                false,
+                DashStyle::Solid,
+            );
+            canvas.arrowhead((x + width, axis_y), (x, axis_y), canvas.pt(5.0), text_color);
+            canvas.arrowhead((x, axis_y), (x + width, axis_y), canvas.pt(5.0), text_color);
+
+            // Cap the tick count so an untrusted step can't drive an unbounded loop.
+            let ticks = draw_number_line_ticks(canvas, block, &to_x, axis_y, text_color, theme);
+            let _ = ticks;
+            for mark in &block.marks {
+                if !mark.value.is_finite() || mark.value < block.min || mark.value > block.max {
+                    continue;
+                }
+                let mx = to_x(mark.value);
+                let radius = canvas.pt(3.5);
+                match mark.kind {
+                    NumberLineMarkKind::Closed => {
+                        canvas.circle(mx, axis_y, radius, text_color, false);
+                    }
+                    NumberLineMarkKind::Open => {
+                        draw_circle_outline(canvas, mx, axis_y, radius, 1.2, text_color);
+                    }
+                    NumberLineMarkKind::ArrowLeft => {
+                        canvas.segment(
+                            (mx, axis_y),
+                            (x, axis_y),
+                            1.6,
+                            text_color,
+                            false,
+                            DashStyle::Solid,
+                        );
+                        canvas.arrowhead((x, axis_y), (mx, axis_y), canvas.pt(5.0), text_color);
+                    }
+                    NumberLineMarkKind::ArrowRight => {
+                        canvas.segment(
+                            (mx, axis_y),
+                            (x + width, axis_y),
+                            1.6,
+                            text_color,
+                            false,
+                            DashStyle::Solid,
+                        );
+                        canvas.arrowhead(
+                            (x + width, axis_y),
+                            (mx, axis_y),
+                            canvas.pt(5.0),
+                            text_color,
+                        );
+                    }
+                }
+            }
             Ok(y + height)
         }
         SlideBlock::Spacer(block) => Ok(y + canvas.pt(block.height.max(0.0))),
@@ -1983,6 +2272,68 @@ mod tests {
             vec![PageSource::Pdf(2), PageSource::Pdf(0), PageSource::Pdf(2)]
         );
         validate_page_selection(&doc.pages, &select_page_sources(&doc.pages).unwrap(), 3).unwrap();
+    }
+
+    #[test]
+    fn every_slide_block_kind_renders() {
+        let mut slide = page("slide", 0);
+        slide["slide"] = json!({
+            "layout": "content",
+            "title": "All blocks",
+            "blocks": [
+                {"id":"b1","kind":"text","text":"Body"},
+                {"id":"b2","kind":"list","items":[{"text":"one","level":0},{"text":"sub","level":1}],
+                 "marker":"decimal","markerByLevel":["decimal","alpha","roman"]},
+                {"id":"b3","kind":"definitions","items":[{"term":"Term","text":"Meaning"}]},
+                {"id":"b4","kind":"table","header":["h"],"rows":[["r"]],"headerOrientation":"column"},
+                {"id":"b5","kind":"math","latex":"x^2","display":true},
+                {"id":"b6","kind":"callout","text":"Tip","tone":"tip"},
+                {"id":"b7","kind":"mapping","leftLabel":"In","rightLabel":"Out",
+                 "left":["1","2"],"right":["3"],
+                 "pairs":[{"from":0,"to":0},{"from":9,"to":9}],"height":80},
+                {"id":"b8","kind":"diagram",
+                 "nodes":[{"id":"n1","text":"x","x":0.2,"y":0.5,"shape":"box"},
+                          {"id":"n2","text":"2x","x":0.8,"y":0.5,"shape":"plain"}],
+                 "edges":[{"from":"n1","to":"n2","label":"double"},
+                          {"from":"n1","to":"n1"},
+                          {"from":"ghost","to":"n2"}],
+                 "height":80},
+                {"id":"b9","kind":"numberline","min":-5,"max":5,"tickStep":1,"labelStep":5,
+                 "marks":[{"value":0,"kind":"closed"},{"value":2,"kind":"open"},
+                          {"value":-3,"kind":"arrow-left"},{"value":99,"kind":"closed"}],
+                 "height":60},
+                {"id":"b10","kind":"spacer","height":20}
+            ],
+        });
+        let doc = document(vec![slide]);
+        validate_document(&doc).unwrap();
+        let sources = select_page_sources(&doc.pages).unwrap();
+        let image = render_page(&doc.pages[0], sources[0], None, None).unwrap();
+        assert_eq!(image.dimensions(), (200, 400));
+    }
+
+    /// A degenerate number line must not drive an unbounded tick loop or panic.
+    #[test]
+    fn degenerate_number_line_block_is_safe() {
+        for (min, max, tick, label) in [
+            (0.0, 0.0, 1.0, 1.0),
+            (10.0, -10.0, 1.0, 1.0),
+            (-1.0, 1.0, 0.0, 0.0),
+            (-1.0, 1.0, -5.0, -5.0),
+            (-1000.0, 1000.0, 0.000_001, 0.000_001),
+        ] {
+            let mut slide = page("slide", 0);
+            slide["slide"] = json!({
+                "layout": "content",
+                "title": "Edge",
+                "blocks": [{"id":"n","kind":"numberline","min":min,"max":max,
+                            "tickStep":tick,"labelStep":label,"marks":[],"height":40}],
+            });
+            let doc = document(vec![slide]);
+            validate_document(&doc).unwrap();
+            let sources = select_page_sources(&doc.pages).unwrap();
+            assert!(render_page(&doc.pages[0], sources[0], None, None).is_ok());
+        }
     }
 
     #[test]

--- a/src-tauri/src/export.rs
+++ b/src-tauri/src/export.rs
@@ -46,6 +46,7 @@ const MAX_PIXEL_AREA: u64 = 32 * 1024 * 1024;
 const MAX_OBJECTS_PER_PAGE: usize = 100_000;
 const MAX_POINTS_PER_STROKE: usize = 1_000_000;
 const MAX_SOURCE_BYTES: u64 = 512 * 1024 * 1024;
+const MAX_TICKS: usize = 10_000;
 const MAX_GRAPH_SAMPLES: usize = 2048;
 const JPEG_QUALITY: u8 = 92;
 
@@ -191,7 +192,13 @@ impl Canvas {
         if !distance.is_finite() || width <= 0.0 {
             return;
         }
-        let steps = distance.ceil().max(1.0) as usize;
+        // Coordinates are finite but unbounded, so a segment can be far longer
+        // than the canvas. Anything beyond the canvas diagonal is invisible;
+        // capping keeps rasterization proportional to what can actually be seen.
+        let max_steps = (u64::from(self.width()) + u64::from(self.height()))
+            .saturating_mul(4)
+            .max(1);
+        let steps = distance.ceil().max(1.0).min(max_steps as f64) as usize;
         let dash_length = (width * 3.0).max(1.0);
         for i in 0..=steps {
             let t = i as f64 / steps as f64;
@@ -940,8 +947,14 @@ fn values_in_range(min: f64, max: f64, step: f64) -> Vec<f64> {
         return Vec::new();
     }
     let first = (min / step).ceil() * step;
-    let raw_count = ((max - first) / step).floor().max(0.0) as usize + 1;
-    let count = raw_count.min(10_000);
+    if !first.is_finite() {
+        return Vec::new();
+    }
+    // Clamp in f64 before casting: a denormal step makes this quotient
+    // infinite, and `f64::INFINITY as usize` saturates to `usize::MAX`, so
+    // adding 1 afterwards would overflow.
+    let spans = ((max - first) / step).floor().clamp(0.0, MAX_TICKS as f64) as usize;
+    let count = spans.saturating_add(1).min(MAX_TICKS);
     (0..count).map(|i| first + i as f64 * step).collect()
 }
 
@@ -1296,13 +1309,13 @@ fn draw_number_line_ticks(
     color: Color,
     theme: &SlideTheme,
 ) -> usize {
-    const MAX_TICKS: usize = 400;
+    const MAX_SLIDE_TICKS: usize = 400;
     let mut drawn = 0usize;
     let tick_half = canvas.pt(3.0);
 
     if block.tick_step.is_finite() && block.tick_step > 0.0 {
         let mut value = (block.min / block.tick_step).ceil() * block.tick_step;
-        while value <= block.max && drawn < MAX_TICKS {
+        while value <= block.max && drawn < MAX_SLIDE_TICKS {
             let tx = to_x(value);
             canvas.segment(
                 (tx, axis_y - tick_half),
@@ -1320,7 +1333,7 @@ fn draw_number_line_ticks(
     if block.label_step.is_finite() && block.label_step > 0.0 {
         let mut labelled = 0usize;
         let mut value = (block.min / block.label_step).ceil() * block.label_step;
-        while value <= block.max && labelled < MAX_TICKS {
+        while value <= block.max && labelled < MAX_SLIDE_TICKS {
             let label = if value.fract().abs() < 1e-9 {
                 format!("{}", value.round() as i64)
             } else {
@@ -2272,6 +2285,55 @@ mod tests {
             vec![PageSource::Pdf(2), PageSource::Pdf(0), PageSource::Pdf(2)]
         );
         validate_page_selection(&doc.pages, &select_page_sources(&doc.pages).unwrap(), 3).unwrap();
+    }
+
+    /// A denormal step makes `(max - first) / step` infinite; casting that to
+    /// usize saturates, so the count must be clamped before any arithmetic.
+    #[test]
+    fn tiny_step_does_not_overflow_tick_count() {
+        for step in [5e-324_f64, 1e-300, f64::MIN_POSITIVE] {
+            let values = values_in_range(0.0, 1.0, step);
+            assert!(
+                values.len() <= 10_000,
+                "unbounded tick count for step {step}"
+            );
+        }
+    }
+
+    /// Coordinates are finite but unbounded, so a segment far larger than the
+    /// canvas must not drive an effectively infinite rasterization loop.
+    #[test]
+    fn oversized_segment_is_bounded() {
+        let mut canvas = Canvas::new(
+            PixelSize {
+                width: 64,
+                height: 64,
+            },
+            Color {
+                r: 255,
+                g: 255,
+                b: 255,
+                a: 255,
+            },
+        );
+        let start = std::time::Instant::now();
+        canvas.segment(
+            (0.0, 0.0),
+            (1e10, 0.0),
+            2.0,
+            Color {
+                r: 0,
+                g: 0,
+                b: 0,
+                a: 255,
+            },
+            false,
+            DashStyle::Solid,
+        );
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(2),
+            "segment rasterization is not bounded by canvas size"
+        );
     }
 
     #[test]

--- a/src-tauri/src/model.rs
+++ b/src-tauri/src/model.rs
@@ -338,7 +338,83 @@ pub enum SlideBlock {
     Graph(SlideGraphBlock),
     Callout(SlideCalloutBlock),
     Image(SlideImageBlock),
+    Mapping(SlideMappingBlock),
+    Diagram(SlideDiagramBlock),
+    Numberline(SlideNumberLineBlock),
     Spacer(SlideSpacerBlock),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SlideMappingPair {
+    pub from: usize,
+    pub to: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SlideMappingBlock {
+    #[serde(flatten)]
+    pub base: SlideBlockBase,
+    pub left_label: String,
+    pub right_label: String,
+    pub left: Vec<String>,
+    pub right: Vec<String>,
+    pub pairs: Vec<SlideMappingPair>,
+    pub height: f64,
+    pub caption: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SlideDiagramNodeShape {
+    Box,
+    Plain,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SlideDiagramNode {
+    pub id: String,
+    pub text: String,
+    pub x: f64,
+    pub y: f64,
+    pub w: Option<f64>,
+    pub h: Option<f64>,
+    pub shape: Option<SlideDiagramNodeShape>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SlideDiagramEdge {
+    pub from: String,
+    pub to: String,
+    pub label: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SlideDiagramBlock {
+    #[serde(flatten)]
+    pub base: SlideBlockBase,
+    pub nodes: Vec<SlideDiagramNode>,
+    pub edges: Vec<SlideDiagramEdge>,
+    pub height: f64,
+    pub caption: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SlideNumberLineBlock {
+    #[serde(flatten)]
+    pub base: SlideBlockBase,
+    pub min: f64,
+    pub max: f64,
+    pub tick_step: f64,
+    pub label_step: f64,
+    pub marks: Vec<NumberLineMark>,
+    pub height: f64,
+    pub caption: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -361,6 +437,7 @@ pub struct SlideListBlock {
     pub base: SlideBlockBase,
     pub items: Vec<SlideListItem>,
     pub marker: SlideListMarker,
+    pub marker_by_level: Option<Vec<SlideListMarker>>,
     pub font_size: Option<f64>,
 }
 
@@ -369,6 +446,8 @@ pub struct SlideListBlock {
 pub enum SlideListMarker {
     Bullet,
     Decimal,
+    Alpha,
+    Roman,
     None,
 }
 
@@ -403,8 +482,16 @@ pub struct SlideTableBlock {
     pub caption: Option<String>,
     pub header: Vec<String>,
     pub rows: Vec<Vec<String>>,
+    pub header_orientation: Option<SlideTableHeaderOrientation>,
     pub font_size: Option<f64>,
     pub column_weights: Option<Vec<f64>>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SlideTableHeaderOrientation {
+    Row,
+    Column,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -490,4 +577,32 @@ pub enum SlideAlign {
     Left,
     Center,
     Right,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The frontend is the source of truth for the slide schema. Any block kind
+    /// or field it can emit must deserialize here, or `save_sidecar` rejects
+    /// the whole document at the IPC boundary and the user's work is lost.
+    #[test]
+    fn deserializes_every_slide_block_kind_the_frontend_can_emit() {
+        let json = r#"{
+          "layout":"content","title":"T","blocks":[
+            {"id":"a","kind":"mapping","leftLabel":"In","rightLabel":"Out",
+             "left":["1"],"right":["2"],"pairs":[{"from":0,"to":0}],"height":200},
+            {"id":"b","kind":"diagram",
+             "nodes":[{"id":"n1","text":"x","x":0.1,"y":0.5}],"edges":[],"height":150},
+            {"id":"c","kind":"numberline","min":-10,"max":10,
+             "tickStep":1,"labelStep":5,"marks":[],"height":80},
+            {"id":"d","kind":"list","items":[{"text":"i","level":0}],
+             "marker":"alpha","markerByLevel":["decimal","alpha","roman"]},
+            {"id":"e","kind":"table","header":["h"],"rows":[["r"]],
+             "headerOrientation":"column"}
+          ]}"#;
+        let parsed = serde_json::from_str::<Slide>(json);
+        assert!(parsed.is_ok(), "deserialization failed: {:?}", parsed.err());
+        assert_eq!(parsed.unwrap().blocks.len(), 5);
+    }
 }

--- a/src-tauri/src/model.rs
+++ b/src-tauri/src/model.rs
@@ -173,6 +173,18 @@ pub struct GraphObject {
     pub show_axes: bool,
     pub show_grid: bool,
     pub functions: Vec<GraphFunction>,
+    pub parameters: Option<Vec<GraphParameter>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GraphParameter {
+    pub name: String,
+    pub value: f64,
+    pub min: f64,
+    pub max: f64,
+    pub step: f64,
+    pub show_chip: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -604,5 +616,27 @@ mod tests {
         let parsed = serde_json::from_str::<Slide>(json);
         assert!(parsed.is_ok(), "deserialization failed: {:?}", parsed.err());
         assert_eq!(parsed.unwrap().blocks.len(), 5);
+    }
+
+    #[test]
+    fn graph_parameters_round_trip_through_the_sidecar_model() {
+        let json = r##"{
+          "type":"graph","id":"g1","createdAt":1,
+          "bounds":{"x":10,"y":20,"w":300,"h":200},
+          "xRange":[-10,10],"yRange":[-5,5],"gridStep":1,
+          "showAxes":true,"showGrid":true,
+          "functions":[{
+            "id":"f1","expr":"a*sin(x)","kind":"explicit",
+            "color":"#1e88e5","width":2,"dash":"solid","domain":null
+          }],
+          "parameters":[{
+            "name":"a","value":1.3,"min":-5,"max":5,"step":0.1,"showChip":true
+          }]
+        }"##;
+        let parsed: DrawableObject = serde_json::from_str(json).expect("graph should deserialize");
+        let encoded = serde_json::to_value(parsed).expect("graph should serialize");
+        assert_eq!(encoded["parameters"][0]["name"], "a");
+        assert_eq!(encoded["parameters"][0]["value"], 1.3);
+        assert_eq!(encoded["parameters"][0]["showChip"], true);
     }
 }

--- a/src-tauri/src/model.rs
+++ b/src-tauri/src/model.rs
@@ -1,8 +1,8 @@
-//! Serialization-compatible mirrors of the TS types in `src/lib/types.ts`.
-//! Keep this file in sync with the TS source of truth.
+//! Serialization-compatible mirrors of `src/lib/types.ts`.
 //!
-//! All structs use `rename_all = "camelCase"` so Rust's `snake_case` field
-//! names serialize as the `camelCase` keys the frontend expects.
+//! Coordinates and dimensions are PDF points with a top-left origin.
+
+#![allow(clippy::struct_field_names)]
 
 use serde::{Deserialize, Serialize};
 
@@ -28,7 +28,466 @@ pub struct EldrawDocument {
     pub version: u32,
     pub pdf_hash: String,
     pub pdf_path: Option<String>,
-    pub pages: Vec<serde_json::Value>,
+    pub pages: Vec<Page>,
     pub palettes: Vec<serde_json::Value>,
     pub prefs: serde_json::Value,
+    pub slide_theme: Option<SlideTheme>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Page {
+    pub page_index: usize,
+    #[serde(rename = "type")]
+    pub kind: PageKind,
+    pub inserted_after_pdf_page: Option<usize>,
+    pub pdf_source_index: Option<usize>,
+    pub width: f64,
+    pub height: f64,
+    pub background: Option<String>,
+    pub slide: Option<Slide>,
+    pub objects: Vec<DrawableObject>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PageKind {
+    Pdf,
+    Blank,
+    Slide,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum DrawableObject {
+    #[serde(rename = "stroke")]
+    Stroke(StrokeObject),
+    #[serde(rename = "line")]
+    Line(LineObject),
+    #[serde(rename = "shape")]
+    Shape(ShapeObject),
+    #[serde(rename = "numberline")]
+    NumberLine(NumberLineObject),
+    #[serde(rename = "graph")]
+    Graph(GraphObject),
+    #[serde(rename = "text")]
+    Text(TextObject),
+    #[serde(rename = "angleMark")]
+    AngleMark(AngleMarkObject),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ObjectBase {
+    pub id: String,
+    pub created_at: f64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StrokeObject {
+    #[serde(flatten)]
+    pub base: ObjectBase,
+    pub tool: StrokeTool,
+    pub style: StrokeStyle,
+    pub points: Vec<Point>,
+    pub streamline: Option<f64>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StrokeTool {
+    Pen,
+    Highlighter,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LineObject {
+    #[serde(flatten)]
+    pub base: ObjectBase,
+    pub style: StrokeStyle,
+    pub from: Coordinate,
+    pub to: Coordinate,
+    pub arrow: ArrowEnds,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ShapeObject {
+    #[serde(flatten)]
+    pub base: ObjectBase,
+    pub kind: ShapeKind,
+    pub style: StrokeStyle,
+    pub fill: Option<String>,
+    pub bounds: Bounds,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ShapeKind {
+    Rect,
+    Ellipse,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NumberLineObject {
+    #[serde(flatten)]
+    pub base: ObjectBase,
+    pub style: StrokeStyle,
+    pub from: Coordinate,
+    pub length: f64,
+    pub min: f64,
+    pub max: f64,
+    pub tick_step: f64,
+    pub label_step: f64,
+    pub marks: Vec<NumberLineMark>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NumberLineMark {
+    pub value: f64,
+    pub kind: NumberLineMarkKind,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum NumberLineMarkKind {
+    Open,
+    Closed,
+    ArrowLeft,
+    ArrowRight,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GraphObject {
+    #[serde(flatten)]
+    pub base: ObjectBase,
+    pub bounds: Bounds,
+    pub x_range: [f64; 2],
+    pub y_range: [f64; 2],
+    pub grid_step: f64,
+    pub show_axes: bool,
+    pub show_grid: bool,
+    pub functions: Vec<GraphFunction>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GraphFunction {
+    pub id: String,
+    pub expr: String,
+    pub kind: GraphFunctionKind,
+    pub color: String,
+    pub width: f64,
+    pub dash: DashStyle,
+    pub domain: Option<[f64; 2]>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum GraphFunctionKind {
+    Explicit,
+    Implicit,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TextObject {
+    #[serde(flatten)]
+    pub base: ObjectBase,
+    pub at: Coordinate,
+    pub content: String,
+    pub latex: bool,
+    pub math_mode: Option<TextMathMode>,
+    pub font_size: f64,
+    pub color: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TextMathMode {
+    Plain,
+    Latex,
+    Mixed,
+    Auto,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AngleMarkObject {
+    #[serde(flatten)]
+    pub base: ObjectBase,
+    pub vertex: Coordinate,
+    pub ray_a: Coordinate,
+    pub ray_b: Coordinate,
+    pub degrees: f64,
+    pub color: String,
+    pub width: f64,
+    pub show_label: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StrokeStyle {
+    pub color: String,
+    pub width: f64,
+    pub dash: DashStyle,
+    pub opacity: f64,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DashStyle {
+    Solid,
+    Dashed,
+    Dotted,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Point {
+    pub x: f64,
+    pub y: f64,
+    pub pressure: f64,
+    pub t: f64,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Coordinate {
+    pub x: f64,
+    pub y: f64,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Bounds {
+    pub x: f64,
+    pub y: f64,
+    pub w: f64,
+    pub h: f64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArrowEnds {
+    pub start: bool,
+    pub end: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Slide {
+    pub layout: SlideLayoutKind,
+    pub title: String,
+    pub subtitle: Option<String>,
+    pub blocks: Vec<SlideBlock>,
+    pub aside: Option<Vec<SlideCalloutBlock>>,
+    pub column_count: Option<usize>,
+    pub theme: Option<PartialSlideTheme>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SlideLayoutKind {
+    Title,
+    Content,
+    Columns,
+    Grid,
+    Blank,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SlideTheme {
+    pub font_family: String,
+    pub background: String,
+    pub title_color: String,
+    pub text_color: String,
+    pub accent: String,
+    pub title_size: f64,
+    pub heading_size: f64,
+    pub body_size: f64,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PartialSlideTheme {
+    pub font_family: Option<String>,
+    pub background: Option<String>,
+    pub title_color: Option<String>,
+    pub text_color: Option<String>,
+    pub accent: Option<String>,
+    pub title_size: Option<f64>,
+    pub heading_size: Option<f64>,
+    pub body_size: Option<f64>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum SlideBlock {
+    Text(SlideTextBlock),
+    List(SlideListBlock),
+    Definitions(SlideDefinitionsBlock),
+    Table(SlideTableBlock),
+    Math(SlideMathBlock),
+    Graph(SlideGraphBlock),
+    Callout(SlideCalloutBlock),
+    Image(SlideImageBlock),
+    Spacer(SlideSpacerBlock),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SlideTextBlock {
+    #[serde(flatten)]
+    pub base: SlideBlockBase,
+    pub text: String,
+    pub align: Option<SlideAlign>,
+    pub font_size: Option<f64>,
+    pub bold: Option<bool>,
+    pub italic: Option<bool>,
+    pub color: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SlideListBlock {
+    #[serde(flatten)]
+    pub base: SlideBlockBase,
+    pub items: Vec<SlideListItem>,
+    pub marker: SlideListMarker,
+    pub font_size: Option<f64>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SlideListMarker {
+    Bullet,
+    Decimal,
+    None,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SlideListItem {
+    pub text: String,
+    pub level: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SlideDefinitionsBlock {
+    #[serde(flatten)]
+    pub base: SlideBlockBase,
+    pub items: Vec<SlideDefinition>,
+    pub font_size: Option<f64>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SlideDefinition {
+    pub term: String,
+    pub text: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SlideTableBlock {
+    #[serde(flatten)]
+    pub base: SlideBlockBase,
+    pub caption: Option<String>,
+    pub header: Vec<String>,
+    pub rows: Vec<Vec<String>>,
+    pub font_size: Option<f64>,
+    pub column_weights: Option<Vec<f64>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SlideMathBlock {
+    #[serde(flatten)]
+    pub base: SlideBlockBase,
+    pub latex: String,
+    pub display: bool,
+    pub align: Option<SlideAlign>,
+    pub font_size: Option<f64>,
+    pub color: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SlideGraphBlock {
+    #[serde(flatten)]
+    pub base: SlideBlockBase,
+    pub graph: SlideGraphSpec,
+    pub height: f64,
+    pub caption: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SlideGraphSpec {
+    pub x_range: [f64; 2],
+    pub y_range: [f64; 2],
+    pub grid_step: f64,
+    pub show_axes: bool,
+    pub show_grid: bool,
+    pub functions: Vec<GraphFunction>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SlideCalloutBlock {
+    #[serde(flatten)]
+    pub base: SlideBlockBase,
+    pub text: String,
+    pub tone: SlideCalloutTone,
+    pub font_size: Option<f64>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SlideCalloutTone {
+    Tip,
+    Warn,
+    Note,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SlideImageBlock {
+    #[serde(flatten)]
+    pub base: SlideBlockBase,
+    pub src: String,
+    pub alt: String,
+    pub height: f64,
+    pub align: Option<SlideAlign>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SlideSpacerBlock {
+    #[serde(flatten)]
+    pub base: SlideBlockBase,
+    pub height: f64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SlideBlockBase {
+    pub id: String,
+    pub margin_top: Option<f64>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SlideAlign {
+    Left,
+    Center,
+    Right,
 }

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -4,17 +4,18 @@
 //! Lock file:               `"{pdf_path}.eldraw.lock"`.
 //! Writes go via `"{pdf_path}.eldraw.json.tmp"` + rename for atomicity.
 
-use std::fs::{self, OpenOptions};
+use std::collections::HashMap;
+use std::fs::{self, File, OpenOptions, TryLockError};
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
-
-use sysinfo::{Pid, System};
 
 use crate::error::{AppError, AppResult};
 use crate::model::EldrawDocument;
 
 const SUPPORTED_VERSION: u32 = 1;
+static HELD_LOCKS: OnceLock<Mutex<HashMap<PathBuf, File>>> = OnceLock::new();
 
 fn sidecar_path(pdf_path: &str) -> PathBuf {
     PathBuf::from(format!("{pdf_path}.eldraw.json"))
@@ -68,15 +69,6 @@ pub fn save_sidecar_impl(pdf_path: &str, doc: &EldrawDocument) -> AppResult<()> 
     Ok(())
 }
 
-fn pid_alive(pid: u32) -> bool {
-    let mut sys = System::new();
-    sys.refresh_processes(
-        sysinfo::ProcessesToUpdate::Some(&[Pid::from_u32(pid)]),
-        true,
-    );
-    sys.process(Pid::from_u32(pid)).is_some()
-}
-
 fn iso_now() -> String {
     let secs = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -84,61 +76,51 @@ fn iso_now() -> String {
     format!("{secs}")
 }
 
-fn parse_lock_pid(contents: &str) -> Option<u32> {
-    contents
-        .lines()
-        .next()
-        .and_then(|l| l.trim().parse::<u32>().ok())
+fn held_locks() -> &'static Mutex<HashMap<PathBuf, File>> {
+    HELD_LOCKS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
 pub fn acquire_lock_impl(pdf_path: &str) -> AppResult<bool> {
     let path = lock_path(pdf_path);
     ensure_parent(&path)?;
     let body = format!("{}\n{}\n", std::process::id(), iso_now());
+    let mut locks = held_locks()
+        .lock()
+        .map_err(|_| std::io::Error::other("lock registry poisoned"))?;
+    if locks.contains_key(&path) {
+        return Ok(true);
+    }
 
-    match OpenOptions::new().write(true).create_new(true).open(&path) {
-        Ok(mut f) => {
-            f.write_all(body.as_bytes())?;
+    let mut file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&path)?;
+    match file.try_lock() {
+        Ok(()) => {
+            file.set_len(0)?;
+            file.write_all(body.as_bytes())?;
+            file.sync_data()?;
+            // OS locks live as long as their file handle, so retain it until release.
+            locks.insert(path, file);
             Ok(true)
         }
-        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-            let contents = fs::read_to_string(&path).unwrap_or_default();
-            if let Some(existing_pid) = parse_lock_pid(&contents) {
-                if existing_pid != std::process::id() && pid_alive(existing_pid) {
-                    return Ok(false);
-                }
-            }
-            // Stale (or our own) lock: reclaim by overwriting atomically via
-            // remove + create_new so no other process can sneak in.
-            let _ = fs::remove_file(&path);
-            match OpenOptions::new().write(true).create_new(true).open(&path) {
-                Ok(mut f) => {
-                    f.write_all(body.as_bytes())?;
-                    Ok(true)
-                }
-                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(false),
-                Err(e) => Err(e.into()),
-            }
-        }
-        Err(e) => Err(e.into()),
+        Err(TryLockError::WouldBlock) => Ok(false),
+        Err(TryLockError::Error(error)) => Err(error.into()),
     }
 }
 
 pub fn release_lock_impl(pdf_path: &str) -> AppResult<()> {
     let path = lock_path(pdf_path);
-    let contents = match fs::read_to_string(&path) {
-        Ok(c) => c,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-        Err(e) => return Err(e.into()),
-    };
-    match parse_lock_pid(&contents) {
-        Some(pid) if pid == std::process::id() => match fs::remove_file(&path) {
-            Ok(()) => Ok(()),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
-            Err(e) => Err(e.into()),
-        },
-        _ => Ok(()),
+    let mut locks = held_locks()
+        .lock()
+        .map_err(|_| std::io::Error::other("lock registry poisoned"))?;
+    if let Some(file) = locks.remove(&path) {
+        file.unlock()?;
     }
+    // Keep the path: deleting after unlock could unlink a lock another process just acquired.
+    Ok(())
 }
 
 #[tauri::command]
@@ -165,6 +147,9 @@ pub async fn release_lock(pdf_path: String) -> AppResult<()> {
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::process::{Child, Command, Stdio};
+    use std::thread;
+    use std::time::{Duration, Instant};
     use tempfile::TempDir;
 
     fn sample_doc() -> EldrawDocument {
@@ -230,10 +215,10 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let pdf = pdf_str(&dir, "doc.pdf");
         assert!(acquire_lock_impl(&pdf).unwrap());
-        // Same-process re-acquire should succeed (we treat our own PID as reclaimable).
+        // Same-process re-acquire is idempotent.
         assert!(acquire_lock_impl(&pdf).unwrap());
         release_lock_impl(&pdf).unwrap();
-        assert!(!lock_path(&pdf).exists());
+        assert!(lock_path(&pdf).exists());
         assert!(acquire_lock_impl(&pdf).unwrap());
         release_lock_impl(&pdf).unwrap();
     }
@@ -248,27 +233,143 @@ mod tests {
         fs::write(lock_path(&pdf), format!("{fake_pid}\nstale\n")).unwrap();
         assert!(acquire_lock_impl(&pdf).unwrap());
         let contents = fs::read_to_string(lock_path(&pdf)).unwrap();
-        let pid = parse_lock_pid(&contents).unwrap();
+        let pid = contents.lines().next().unwrap().parse::<u32>().unwrap();
         assert_eq!(pid, std::process::id());
         release_lock_impl(&pdf).unwrap();
     }
 
-    #[cfg(unix)]
     #[test]
-    fn live_foreign_pid_blocks_lock() {
+    fn stale_lock_race_child() {
+        let Ok(pdf) = std::env::var("ELDRAW_LOCK_RACE_PDF") else {
+            return;
+        };
+        let ready = PathBuf::from(std::env::var("ELDRAW_LOCK_RACE_READY").unwrap());
+        let start = PathBuf::from(std::env::var("ELDRAW_LOCK_RACE_START").unwrap());
+        let finish = PathBuf::from(std::env::var("ELDRAW_LOCK_RACE_FINISH").unwrap());
+        let winner = PathBuf::from(std::env::var("ELDRAW_LOCK_RACE_WINNER").unwrap());
+
+        fs::write(&ready, []).unwrap();
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !start.exists() {
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for race start"
+            );
+            thread::sleep(Duration::from_millis(1));
+        }
+
+        if acquire_lock_impl(&pdf).unwrap() {
+            fs::write(&winner, []).unwrap();
+            let deadline = Instant::now() + Duration::from_secs(10);
+            while !finish.exists() {
+                assert!(
+                    Instant::now() < deadline,
+                    "timed out waiting for race finish"
+                );
+                thread::sleep(Duration::from_millis(1));
+            }
+            release_lock_impl(&pdf).unwrap();
+        }
+    }
+
+    #[test]
+    fn stale_lock_reclaim_has_exactly_one_winner() {
+        const CONTENDERS: usize = 12;
+
+        let dir = TempDir::new().unwrap();
+        let pdf = pdf_str(&dir, "race.pdf");
+        let fake_pid: u32 = 4_000_000_000;
+        fs::write(lock_path(&pdf), format!("{fake_pid}\nstale\n")).unwrap();
+
+        let start = dir.path().join("start");
+        let finish = dir.path().join("finish");
+        let test_binary = std::env::current_exe().unwrap();
+        let mut children: Vec<(Child, PathBuf)> = Vec::with_capacity(CONTENDERS);
+
+        for index in 0..CONTENDERS {
+            let ready = dir.path().join(format!("ready-{index}"));
+            let winner = dir.path().join(format!("winner-{index}"));
+            let child = Command::new(&test_binary)
+                .args(["--exact", "storage::tests::stale_lock_race_child"])
+                .env("ELDRAW_LOCK_RACE_PDF", &pdf)
+                .env("ELDRAW_LOCK_RACE_READY", &ready)
+                .env("ELDRAW_LOCK_RACE_START", &start)
+                .env("ELDRAW_LOCK_RACE_FINISH", &finish)
+                .env("ELDRAW_LOCK_RACE_WINNER", &winner)
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .unwrap();
+            children.push((child, winner));
+
+            let deadline = Instant::now() + Duration::from_secs(10);
+            while !ready.exists() {
+                assert!(
+                    Instant::now() < deadline,
+                    "child {index} did not become ready"
+                );
+                thread::sleep(Duration::from_millis(1));
+            }
+        }
+
+        fs::write(&start, []).unwrap();
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            let mut completed = 0;
+            for (child, winner) in &mut children {
+                if winner.exists() || child.try_wait().unwrap().is_some() {
+                    completed += 1;
+                }
+            }
+            if completed == CONTENDERS {
+                break;
+            }
+            assert!(Instant::now() < deadline, "lock contenders did not finish");
+            thread::sleep(Duration::from_millis(1));
+        }
+
+        let winners = children
+            .iter()
+            .filter(|(_, winner)| winner.exists())
+            .count();
+        fs::write(&finish, []).unwrap();
+        for (mut child, _) in children {
+            assert!(child.wait().unwrap().success());
+        }
+
+        assert_eq!(winners, 1, "only one process may reclaim a stale lock");
+    }
+
+    #[test]
+    fn live_foreign_process_lock_blocks_acquisition() {
         let dir = TempDir::new().unwrap();
         let pdf = pdf_str(&dir, "doc.pdf");
-        // Spawn a child we know is alive, write its PID into the lock, then
-        // try to acquire.
-        let mut child = std::process::Command::new("sleep")
-            .arg("30")
+        let ready = dir.path().join("ready");
+        let start = dir.path().join("start");
+        let finish = dir.path().join("finish");
+        let winner = dir.path().join("winner");
+        fs::write(&start, []).unwrap();
+
+        let mut child = Command::new(std::env::current_exe().unwrap())
+            .args(["--exact", "storage::tests::stale_lock_race_child"])
+            .env("ELDRAW_LOCK_RACE_PDF", &pdf)
+            .env("ELDRAW_LOCK_RACE_READY", &ready)
+            .env("ELDRAW_LOCK_RACE_START", &start)
+            .env("ELDRAW_LOCK_RACE_FINISH", &finish)
+            .env("ELDRAW_LOCK_RACE_WINNER", &winner)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
             .spawn()
-            .expect("spawn sleep");
-        fs::write(lock_path(&pdf), format!("{}\nx\n", child.id())).unwrap();
-        let result = acquire_lock_impl(&pdf).unwrap();
-        let _ = child.kill();
-        let _ = child.wait();
-        assert!(!result, "expected acquire to fail while foreign PID alive");
-        let _ = fs::remove_file(lock_path(&pdf));
+            .unwrap();
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !winner.exists() {
+            assert!(Instant::now() < deadline, "child did not acquire lock");
+            thread::sleep(Duration::from_millis(1));
+        }
+
+        assert!(!acquire_lock_impl(&pdf).unwrap());
+
+        fs::write(&finish, []).unwrap();
+        assert!(child.wait().unwrap().success());
     }
 }

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -168,16 +168,17 @@ mod tests {
     use tempfile::TempDir;
 
     fn sample_doc() -> EldrawDocument {
-        EldrawDocument {
-            version: 1,
-            pdf_hash: "abc123".into(),
-            pdf_path: Some("/tmp/foo.pdf".into()),
-            pages: vec![
-                json!({"pageIndex": 0, "type": "pdf", "width": 612.0, "height": 792.0, "objects": [], "insertedAfterPdfPage": null}),
+        serde_json::from_value(json!({
+            "version": 1,
+            "pdfHash": "abc123",
+            "pdfPath": "/example/foo.pdf",
+            "pages": [
+                {"pageIndex": 0, "type": "pdf", "pdfSourceIndex": 0, "width": 612.0, "height": 792.0, "objects": [], "insertedAfterPdfPage": null}
             ],
-            palettes: vec![],
-            prefs: json!({}),
-        }
+            "palettes": [],
+            "prefs": {},
+        }))
+        .unwrap()
     }
 
     fn pdf_str(dir: &TempDir, name: &str) -> String {

--- a/src/lib/app/exportPdfDialog.ts
+++ b/src/lib/app/exportPdfDialog.ts
@@ -9,6 +9,16 @@ export async function exportAnnotatedPdfDialog(): Promise<void> {
     window.alert('Open a document before exporting.');
     return;
   }
+  // Rendering pdf pages needs the source file. Catching this here gives a
+  // actionable message instead of a low-level "cannot read source PDF".
+  const needsSource = doc.pages.some((page) => page.type === 'pdf');
+  if (needsSource && !doc.pdfPath) {
+    window.alert(
+      'This document has PDF pages but its source file is not available.\n\n' +
+        'Re-open the original PDF, then export again.',
+    );
+    return;
+  }
   const outPath = await save({
     filters: [{ name: 'PDF', extensions: ['pdf'] }],
     defaultPath: suggestedFilename(doc.pdfPath),

--- a/src/lib/app/exportPdfDialog.ts
+++ b/src/lib/app/exportPdfDialog.ts
@@ -1,0 +1,32 @@
+import { save } from '@tauri-apps/plugin-dialog';
+import { get } from 'svelte/store';
+import { currentDocument } from '$lib/store/document';
+import { exportFlattenedPdf } from '$lib/ipc';
+
+export async function exportAnnotatedPdfDialog(): Promise<void> {
+  const doc = get(currentDocument);
+  if (!doc) {
+    window.alert('Open a document before exporting.');
+    return;
+  }
+  const outPath = await save({
+    filters: [{ name: 'PDF', extensions: ['pdf'] }],
+    defaultPath: suggestedFilename(doc.pdfPath),
+  });
+  if (outPath === null) return;
+
+  try {
+    await exportFlattenedPdf(doc.pdfPath ?? '', doc, outPath);
+    window.alert(`Annotated PDF exported to:\n${outPath}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    window.alert(`Could not export annotated PDF:\n${message}`);
+  }
+}
+
+function suggestedFilename(pdfPath: string | null): string {
+  if (!pdfPath) return 'annotated.pdf';
+  const filename = pdfPath.split(/[\\/]/).pop() ?? 'document.pdf';
+  const stem = filename.toLowerCase().endsWith('.pdf') ? filename.slice(0, -4) : filename;
+  return `${stem}-annotated.pdf`;
+}

--- a/src/lib/app/pageNav.ts
+++ b/src/lib/app/pageNav.ts
@@ -1,0 +1,31 @@
+/**
+ * Page navigation targets for structural page operations.
+ *
+ * These take the page total *after* the operation has been applied, so callers
+ * must not try to predict it by adjusting a stale count — reading the
+ * authoritative total from the document store avoids an off-by-one that
+ * depends on when derived state happens to recompute.
+ */
+
+/** Page to show after duplicating `sourceIndex`; the copy sits just after it. */
+export function pageIndexAfterDuplicate(sourceIndex: number, totalAfter: number): number {
+  if (totalAfter <= 0) return 0;
+  return Math.max(0, Math.min(totalAfter - 1, sourceIndex + 1));
+}
+
+/**
+ * Page to show after deleting `deletedIndex`.
+ *
+ * Deleting a page before the current one shifts it down by one so the same
+ * content stays in view. Deleting the current page steps back to the previous
+ * one. Deleting a later page leaves the position untouched.
+ */
+export function pageIndexAfterDelete(
+  deletedIndex: number,
+  currentIndex: number,
+  totalAfter: number,
+): number {
+  if (totalAfter <= 0) return 0;
+  const target = currentIndex >= deletedIndex ? currentIndex - 1 : currentIndex;
+  return Math.max(0, Math.min(totalAfter - 1, target));
+}

--- a/src/lib/app/presenterBridge.ts
+++ b/src/lib/app/presenterBridge.ts
@@ -1,8 +1,30 @@
 import { derived, get } from 'svelte/store';
 import { currentDocument } from '$lib/store/document';
+import { graphPreview } from '$lib/store/graphPreview';
 import { viewportStore } from '$lib/store/viewport';
 import { presenterSync } from '$lib/ipc/presenter';
 import { warn } from '$lib/log';
+import type { EldrawDocument } from '$lib/types';
+
+function documentWithGraphPreview(doc: EldrawDocument | null): EldrawDocument | null {
+  const preview = get(graphPreview);
+  if (!doc || !preview) return doc;
+  const page = doc.pages[preview.pageIndex];
+  if (!page || !page.objects.some((object) => object.id === preview.graph.id)) return doc;
+  return {
+    ...doc,
+    pages: doc.pages.map((candidate, index) =>
+      index === preview.pageIndex
+        ? {
+            ...candidate,
+            objects: candidate.objects.map((object) =>
+              object.id === preview.graph.id ? preview.graph : object,
+            ),
+          }
+        : candidate,
+    ),
+  };
+}
 
 /**
  * Start mirroring document + current page to the presenter window. Returns
@@ -28,7 +50,7 @@ export function startPresenterBridge(): () => void {
     try {
       while (!stopped) {
         pushPending = false;
-        const doc = get(currentDocument);
+        const doc = documentWithGraphPreview(get(currentDocument));
         const view = get(viewportStore);
         try {
           await presenterSync({
@@ -51,10 +73,12 @@ export function startPresenterBridge(): () => void {
   void push();
   const unsubDoc = currentDocument.subscribe(() => void push());
   const unsubPage = pageIndexStore.subscribe(() => void push());
+  const unsubGraphPreview = graphPreview.subscribe(() => void push());
 
   return () => {
     stopped = true;
     unsubDoc();
     unsubPage();
+    unsubGraphPreview();
   };
 }

--- a/src/lib/app/shortcuts.ts
+++ b/src/lib/app/shortcuts.ts
@@ -84,14 +84,34 @@ export const shortcuts: Action<HTMLElement> = () => {
 
   function handleKeyUp(event: KeyboardEvent): void {
     if (event.key === ' ') {
-      spaceHeld = false;
-      viewport.setPanMode(false);
+      releaseSpace();
     }
+  }
+
+  /**
+   * Space-hold pan is driven by keydown/keyup, so a keyup delivered to another
+   * window would otherwise leave pan mode latched on. Reset it whenever this
+   * window stops receiving key events.
+   */
+  function releaseSpace(): void {
+    if (!spaceHeld) return;
+    spaceHeld = false;
+    viewport.setPanMode(false);
+  }
+
+  function handleWindowBlur(): void {
+    releaseSpace();
+  }
+
+  function handleVisibilityChange(): void {
+    if (document.visibilityState === 'hidden') releaseSpace();
   }
 
   if (typeof window !== 'undefined') {
     window.addEventListener('keydown', handleKeyDown);
     window.addEventListener('keyup', handleKeyUp);
+    window.addEventListener('blur', handleWindowBlur);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
   }
 
   return {
@@ -100,6 +120,8 @@ export const shortcuts: Action<HTMLElement> = () => {
       if (typeof window !== 'undefined') {
         window.removeEventListener('keydown', handleKeyDown);
         window.removeEventListener('keyup', handleKeyUp);
+        window.removeEventListener('blur', handleWindowBlur);
+        document.removeEventListener('visibilitychange', handleVisibilityChange);
       }
     },
   };

--- a/src/lib/canvas/GraphLayer.svelte
+++ b/src/lib/canvas/GraphLayer.svelte
@@ -1,6 +1,14 @@
 <script lang="ts">
-  import type { GraphObject } from '$lib/types';
-  import { parseExpression, parseExpressionXY } from '$lib/graph/parser';
+  import type { GraphFunction, GraphObject, GraphParameter } from '$lib/types';
+  import {
+    parseExpression,
+    parseExpressionWithParams,
+    parseExpressionXY,
+    parseExpressionXYWithParams,
+    type ParameterizedFn,
+    type ParameterizedFnXY,
+  } from '$lib/graph/parser';
+  import { clampParameter } from '$lib/graph/parameters';
   import { plotFunction } from '$lib/graph/plotter';
   import { marchingSquares, stitchSegments } from '$lib/graph/implicit';
   import { drawGraphFrame } from '$lib/graph/render';
@@ -22,6 +30,14 @@
 
   const MAX_SAMPLES = 2048;
   const IMPLICIT_MAX_RES = 256;
+  const explicitCache = new Map<
+    string,
+    { expr: string; parameterNames: string; compiled: ParameterizedFn }
+  >();
+  const implicitCache = new Map<
+    string,
+    { expr: string; parameterNames: string; compiled: ParameterizedFnXY }
+  >();
 
   const resolvedTheme = $derived(
     themeOverride ??
@@ -35,6 +51,102 @@
     if (d === 'dashed') return [strokeWidth * 4, strokeWidth * 3];
     if (d === 'dotted') return [strokeWidth, strokeWidth * 2];
     return [];
+  }
+
+  function formatParameterValue(value: number): string {
+    return Number(value.toPrecision(8)).toString();
+  }
+
+  function drawParameterChips(
+    ctx: CanvasRenderingContext2D,
+    parameters: readonly GraphParameter[],
+    rect: { x: number; y: number; w: number; h: number },
+    theme: GraphTheme,
+  ): void {
+    const visible = parameters.filter((parameter) => parameter.showChip);
+    if (visible.length === 0) return;
+
+    const paddingX = 6;
+    const chipHeight = Math.max(18, theme.labelFontSize + 8);
+    const gap = 4;
+    let y = rect.y + 8;
+
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(rect.x, rect.y, rect.w, rect.h);
+    ctx.clip();
+    ctx.font = `${Math.max(10, theme.labelFontSize)}px ${theme.labelFontFamily}`;
+    ctx.textBaseline = 'middle';
+    ctx.textAlign = 'left';
+
+    for (const parameter of visible) {
+      if (y + chipHeight > rect.y + rect.h - 4) break;
+      const label = `${parameter.name} = ${formatParameterValue(parameter.value)}`;
+      const chipWidth = ctx.measureText(label).width + paddingX * 2;
+      const x = rect.x + 8;
+
+      ctx.globalAlpha = 0.92;
+      ctx.fillStyle = theme.background;
+      ctx.fillRect(x, y, chipWidth, chipHeight);
+      ctx.globalAlpha = 1;
+      ctx.strokeStyle = theme.frameEnabled ? theme.frameColor : theme.axisColor;
+      ctx.lineWidth = 1;
+      ctx.strokeRect(x + 0.5, y + 0.5, chipWidth - 1, chipHeight - 1);
+      ctx.fillStyle = theme.labelColor;
+      ctx.fillText(label, x + paddingX, y + chipHeight / 2);
+      y += chipHeight + gap;
+    }
+    ctx.restore();
+  }
+
+  function parameterNamesKey(parameters: readonly GraphParameter[]): string {
+    return parameters.map((parameter) => parameter.name).join('\u0000');
+  }
+
+  function parameterizedExplicit(
+    graphId: string,
+    fn: GraphFunction,
+    parameters: readonly GraphParameter[],
+  ): ParameterizedFn | null {
+    const key = `${graphId}\u0000${fn.id}`;
+    const names = parameterNamesKey(parameters);
+    let cached = explicitCache.get(key);
+    if (!cached || cached.expr !== fn.expr || cached.parameterNames !== names) {
+      const result = parseExpressionWithParams(fn.expr, parameters);
+      if (!result.ok) {
+        explicitCache.delete(key);
+        return null;
+      }
+      cached = { expr: fn.expr, parameterNames: names, compiled: result.compiled };
+      explicitCache.set(key, cached);
+    }
+    for (const parameter of parameters) {
+      cached.compiled.setParameter(parameter.name, parameter.value);
+    }
+    return cached.compiled;
+  }
+
+  function parameterizedImplicit(
+    graphId: string,
+    fn: GraphFunction,
+    parameters: readonly GraphParameter[],
+  ): ParameterizedFnXY | null {
+    const key = `${graphId}\u0000${fn.id}`;
+    const names = parameterNamesKey(parameters);
+    let cached = implicitCache.get(key);
+    if (!cached || cached.expr !== fn.expr || cached.parameterNames !== names) {
+      const result = parseExpressionXYWithParams(fn.expr, parameters);
+      if (!result.ok) {
+        implicitCache.delete(key);
+        return null;
+      }
+      cached = { expr: fn.expr, parameterNames: names, compiled: result.compiled };
+      implicitCache.set(key, cached);
+    }
+    for (const parameter of parameters) {
+      cached.compiled.setParameter(parameter.name, parameter.value);
+    }
+    return cached.compiled;
   }
 
   function drawGraph(ctx: CanvasRenderingContext2D, g: GraphObject, theme: GraphTheme) {
@@ -68,6 +180,9 @@
 
     const samples = Math.min(MAX_SAMPLES, Math.max(64, Math.ceil(pw)));
     const implicitRes = Math.min(IMPLICIT_MAX_RES, Math.max(32, Math.ceil(pw / 4)));
+    const parameters = g.parameters?.length
+      ? g.parameters.map((parameter) => clampParameter(parameter))
+      : null;
     for (const fn of g.functions) {
       ctx.strokeStyle = fn.color;
       ctx.lineWidth = fn.width;
@@ -76,9 +191,14 @@
       ctx.lineCap = 'round';
 
       if (fn.kind === 'implicit') {
-        const r = parseExpressionXY(fn.expr);
-        if (!r.ok) continue;
-        const segs = marchingSquares(r.fn, {
+        const compiledFn = parameters
+          ? parameterizedImplicit(g.id, fn, parameters)?.fn
+          : (() => {
+              const result = parseExpressionXY(fn.expr);
+              return result.ok ? result.fn : null;
+            })();
+        if (!compiledFn) continue;
+        const segs = marchingSquares(compiledFn, {
           xRange: g.xRange,
           yRange: g.yRange,
           resolution: implicitRes,
@@ -97,9 +217,14 @@
         continue;
       }
 
-      const result = parseExpression(fn.expr);
-      if (!result.ok) continue;
-      const segments = plotFunction(result.fn, {
+      const compiledFn = parameters
+        ? parameterizedExplicit(g.id, fn, parameters)?.fn
+        : (() => {
+            const result = parseExpression(fn.expr);
+            return result.ok ? result.fn : null;
+          })();
+      if (!compiledFn) continue;
+      const segments = plotFunction(compiledFn, {
         xRange: g.xRange,
         yRange: g.yRange,
         samples,
@@ -117,6 +242,9 @@
     }
 
     ctx.restore();
+    if (parameters) {
+      drawParameterChips(ctx, parameters, { x: px, y: py, w: pw, h: ph }, theme);
+    }
   }
 
   function redraw() {

--- a/src/lib/canvas/GraphLayer.svelte
+++ b/src/lib/canvas/GraphLayer.svelte
@@ -8,6 +8,7 @@
     type ParameterizedFn,
     type ParameterizedFnXY,
   } from '$lib/graph/parser';
+  import { graphFnCacheKey, liveCacheKeys, pruneCache } from '$lib/graph/compileCache';
   import { clampParameter } from '$lib/graph/parameters';
   import { plotFunction } from '$lib/graph/plotter';
   import { marchingSquares, stitchSegments } from '$lib/graph/implicit';
@@ -108,7 +109,7 @@
     fn: GraphFunction,
     parameters: readonly GraphParameter[],
   ): ParameterizedFn | null {
-    const key = `${graphId}\u0000${fn.id}`;
+    const key = graphFnCacheKey(graphId, fn.id);
     const names = parameterNamesKey(parameters);
     let cached = explicitCache.get(key);
     if (!cached || cached.expr !== fn.expr || cached.parameterNames !== names) {
@@ -131,7 +132,7 @@
     fn: GraphFunction,
     parameters: readonly GraphParameter[],
   ): ParameterizedFnXY | null {
-    const key = `${graphId}\u0000${fn.id}`;
+    const key = graphFnCacheKey(graphId, fn.id);
     const names = parameterNamesKey(parameters);
     let cached = implicitCache.get(key);
     if (!cached || cached.expr !== fn.expr || cached.parameterNames !== names) {
@@ -247,10 +248,22 @@
     }
   }
 
+  /**
+   * Drop compiled entries for graphs and functions that no longer exist.
+   * The caches are keyed per function, so without this they would retain every
+   * expression ever compiled for the lifetime of the page.
+   */
+  function pruneCaches() {
+    const live = liveCacheKeys(graphs);
+    pruneCache(explicitCache, live);
+    pruneCache(implicitCache, live);
+  }
+
   function redraw() {
     if (!canvas) return;
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
+    pruneCaches();
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     const theme = resolvedTheme;
     for (const g of graphs) drawGraph(ctx, g, theme);

--- a/src/lib/canvas/TextEditor.svelte
+++ b/src/lib/canvas/TextEditor.svelte
@@ -1,21 +1,30 @@
 <script lang="ts">
   import { onMount, untrack } from 'svelte';
-  import { renderLatex } from '$lib/text/latex';
+  import type { TextMathMode } from '$lib/types';
+  import { renderMixed } from '$lib/text/render';
 
   interface Props {
     initialContent: string;
     initialLatex: boolean;
+    initialMathMode?: TextMathMode;
     initialFontSize: number;
     initialColor: string;
     screenX: number;
     screenY: number;
-    onok: (result: { content: string; latex: boolean; fontSize: number; color: string }) => void;
+    onok: (result: {
+      content: string;
+      latex: boolean;
+      mathMode: TextMathMode;
+      fontSize: number;
+      color: string;
+    }) => void;
     oncancel: () => void;
   }
 
   let {
     initialContent,
     initialLatex,
+    initialMathMode = initialLatex ? 'latex' : 'plain',
     initialFontSize,
     initialColor,
     screenX,
@@ -25,14 +34,14 @@
   }: Props = $props();
 
   let content = $state(untrack(() => initialContent));
-  let latex = $state(untrack(() => initialLatex));
+  let mode = $state<TextMathMode>(untrack(() => initialMathMode));
   let fontSize = $state(untrack(() => initialFontSize));
   let color = $state(untrack(() => initialColor));
   let textarea: HTMLTextAreaElement | null = $state(null);
 
   const preview = $derived.by(() => {
-    if (!latex || content.length === 0) return null;
-    return renderLatex(content);
+    if (content.length === 0) return null;
+    return renderMixed(content, mode);
   });
 
   onMount(() => {
@@ -41,7 +50,7 @@
   });
 
   function commit() {
-    onok({ content, latex, fontSize, color });
+    onok({ content, latex: mode === 'latex', mathMode: mode, fontSize, color });
   }
 
   function onKeyDown(event: KeyboardEvent) {
@@ -70,33 +79,44 @@
     bind:value={content}
     class="content"
     rows="3"
-    placeholder={latex ? 'e.g. x^2 + y^2 = r^2' : 'Enter text…'}
+    placeholder={mode === 'plain' ? 'Enter text…' : 'e.g. The slope of y = 3x - 1 is 3'}
     style="font-size: {fontSize}px; color: {color};"
   ></textarea>
 
-  {#if latex && preview}
+  {#if preview}
     <div
       class="preview"
-      class:errored={!preview.ok}
+      class:errored={preview.errored}
       aria-live="polite"
-      style={preview.ok
-        ? `font-size: ${fontSize}px; color: ${color};`
-        : `font-size: ${fontSize}px;`}
+      style="font-size: {fontSize}px; color: {color};"
     >
-      {#if preview.ok}
-        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-        <span>{@html preview.html}</span>
-      {:else}
-        <span class="raw">{content}</span>
-        <span class="err">{preview.error}</span>
-      {/if}
+      {#each preview.runs as run}
+        {#if run.kind === 'text'}
+          <span>{run.value}</span>
+        {:else}
+          <span class:display={run.display} class:raw={run.errored}>
+            <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+            {@html run.html}
+          </span>
+        {/if}
+      {/each}
+      {#each preview.runs as run}
+        {#if run.kind === 'math' && run.error}
+          <span class="err">{run.error}</span>
+        {/if}
+      {/each}
     </div>
   {/if}
 
   <div class="row">
-    <label class="check">
-      <input type="checkbox" bind:checked={latex} />
-      LaTeX
+    <label class="mode">
+      Math
+      <select bind:value={mode} aria-label="Text math mode">
+        <option value="plain">Plain</option>
+        <option value="latex">LaTeX</option>
+        <option value="mixed">Delimited</option>
+        <option value="auto">Auto-detect</option>
+      </select>
     </label>
     <label class="size">
       Size
@@ -155,6 +175,7 @@
     border-radius: 4px;
     padding: 6px;
     overflow-x: auto;
+    white-space: pre;
   }
   .preview.errored {
     background: #2a1717;
@@ -169,6 +190,9 @@
   .preview .raw {
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   }
+  .preview .display {
+    display: block;
+  }
   .row {
     display: flex;
     gap: 10px;
@@ -182,6 +206,13 @@
   }
   .row input[type='number'] {
     width: 50px;
+    background: #1b1b1b;
+    color: #eee;
+    border: 1px solid #3a3a3a;
+    border-radius: 3px;
+    padding: 2px 4px;
+  }
+  .row select {
     background: #1b1b1b;
     color: #eee;
     border: 1px solid #3a3a3a;

--- a/src/lib/canvas/TextLayer.svelte
+++ b/src/lib/canvas/TextLayer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import type { TextObject } from '$lib/types';
-  import { renderLatex } from '$lib/text/latex';
+  import { textMathMode, type TextObject } from '$lib/types';
+  import { renderMixed, type MixedRender } from '$lib/text/render';
 
   interface Props {
     objects: TextObject[];
@@ -14,17 +14,14 @@
 
   interface Rendered {
     obj: TextObject;
-    html: string;
-    errored: boolean;
+    mode: ReturnType<typeof textMathMode>;
+    result: MixedRender;
   }
 
   const rendered = $derived<Rendered[]>(
     objects.map((obj) => {
-      if (!obj.latex) {
-        return { obj, html: '', errored: false };
-      }
-      const r = renderLatex(obj.content);
-      return { obj, html: r.html, errored: !r.ok };
+      const mode = textMathMode(obj);
+      return { obj, mode, result: renderMixed(obj.content, mode) };
     }),
   );
 
@@ -59,42 +56,42 @@
       <button
         type="button"
         class="text-obj text-button"
-        class:latex={o.latex}
-        class:errored={item.errored}
+        class:latex={item.mode === 'latex'}
+        class:errored={item.result.errored}
         style="left: {o.at.x * ptToPx}px; top: {o.at.y *
           ptToPx}px; color: {o.color}; font-size: {o.fontSize * ptToPx}px;"
         onclick={(e) => onPick(e, o)}
       >
-        {#if o.latex && !item.errored}
-          <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-          {@html item.html}
-        {:else if o.latex && item.errored}
-          <span class="raw">{o.content}</span>
-        {:else}
-          {o.content}
-        {/if}
+        {#each item.result.runs as run}
+          {#if run.kind === 'text'}
+            <span>{run.value}</span>
+          {:else}
+            <span class:display={run.display} class:raw={run.errored}>
+              <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+              {@html run.html}
+            </span>
+          {/if}
+        {/each}
       </button>
-    {:else if o.latex}
-      <div
-        class="text-obj latex"
-        class:errored={item.errored}
-        style="left: {o.at.x * ptToPx}px; top: {o.at.y *
-          ptToPx}px; color: {o.color}; font-size: {o.fontSize * ptToPx}px;"
-      >
-        {#if item.errored}
-          <span class="raw">{o.content}</span>
-        {:else}
-          <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-          {@html item.html}
-        {/if}
-      </div>
     {:else}
       <div
-        class="text-obj plain"
+        class="text-obj"
+        class:latex={item.mode === 'latex'}
+        class:plain={item.mode === 'plain'}
+        class:errored={item.result.errored}
         style="left: {o.at.x * ptToPx}px; top: {o.at.y *
           ptToPx}px; color: {o.color}; font-size: {o.fontSize * ptToPx}px;"
       >
-        {o.content}
+        {#each item.result.runs as run}
+          {#if run.kind === 'text'}
+            <span>{run.value}</span>
+          {:else}
+            <span class:display={run.display} class:raw={run.errored}>
+              <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+              {@html run.html}
+            </span>
+          {/if}
+        {/each}
       </div>
     {/if}
   {/each}
@@ -152,5 +149,8 @@
   .text-obj.errored .raw,
   .text-button.errored .raw {
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+  .text-obj .display {
+    display: block;
   }
 </style>

--- a/src/lib/command/commands.ts
+++ b/src/lib/command/commands.ts
@@ -22,6 +22,7 @@ import {
 } from '$lib/config/commands';
 import { settings } from '$lib/store/settings';
 import { openSlidesDialog } from '$lib/slides/dialog';
+import { slideCommands } from '$lib/slides/commands';
 import { exportAnnotatedPdfDialog } from '$lib/app/exportPdfDialog';
 
 export interface Command {
@@ -223,5 +224,6 @@ export function getCommands(): Command[] {
       title: 'Reset settings to defaults',
       run: triggerResetSettings,
     },
+    ...slideCommands,
   ];
 }

--- a/src/lib/command/commands.ts
+++ b/src/lib/command/commands.ts
@@ -22,6 +22,7 @@ import {
 } from '$lib/config/commands';
 import { settings } from '$lib/store/settings';
 import { openSlidesDialog } from '$lib/slides/dialog';
+import { exportAnnotatedPdfDialog } from '$lib/app/exportPdfDialog';
 
 export interface Command {
   id: string;
@@ -192,6 +193,11 @@ export function getCommands(): Command[] {
       id: 'file.openFromSlides',
       title: 'Open from Google Slides…',
       run: openSlidesDialog,
+    },
+    {
+      id: 'file.exportAnnotatedPdf',
+      title: 'Export annotated PDF…',
+      run: () => void exportAnnotatedPdfDialog(),
     },
     {
       id: 'config.export',

--- a/src/lib/graph/GraphEditor.svelte
+++ b/src/lib/graph/GraphEditor.svelte
@@ -1,29 +1,56 @@
 <script lang="ts">
-  import type { GraphFunction, GraphFunctionKind, GraphObject } from '$lib/types';
-  import { parseExpression, parseExpressionXY } from '$lib/graph/parser';
+  import { onDestroy } from 'svelte';
+  import type { GraphFunction, GraphFunctionKind, GraphObject, GraphParameter } from '$lib/types';
+  import { parseExpressionWithParams, parseExpressionXYWithParams } from '$lib/graph/parser';
+  import { clampParameter, parametersForGraph } from '$lib/graph/parameters';
+  import { createRafBatcher } from '$lib/canvas/inkBatch';
   import { createGraphFunction } from './graphObject';
 
   interface Props {
     graph: GraphObject;
     onUpdate: (patch: Partial<GraphObject>) => void;
+    onPreview?: (patch: Partial<GraphObject>) => void;
     onDelete: () => void;
     onClose: () => void;
   }
 
-  let { graph, onUpdate, onDelete, onClose }: Props = $props();
+  let { graph, onUpdate, onPreview = () => {}, onDelete, onClose }: Props = $props();
+
+  let previewParameters = $state<GraphParameter[] | null>(null);
+  const persistedParameters = $derived(parametersForGraph(graph));
+  const displayedParameters = $derived(previewParameters ?? persistedParameters);
+  const persistedParameterSignature = $derived(
+    `${graph.id}:${JSON.stringify(graph.parameters ?? [])}`,
+  );
+
+  $effect(() => {
+    void persistedParameterSignature;
+    previewParameters = null;
+  });
+
+  const previewBatcher = createRafBatcher<GraphParameter[]>((batches) => {
+    const latest = batches[batches.length - 1];
+    if (latest) onPreview({ parameters: latest.map((parameter) => ({ ...parameter })) });
+  });
+
+  onDestroy(() => previewBatcher.cancel());
+
+  function applyFunctions(functions: GraphFunction[]): void {
+    const parameters = parametersForGraph({ ...graph, functions });
+    previewParameters = null;
+    onUpdate({ functions, parameters });
+  }
 
   function updateFunction(id: string, patch: Partial<GraphFunction>): void {
-    onUpdate({
-      functions: graph.functions.map((f) => (f.id === id ? { ...f, ...patch } : f)),
-    });
+    applyFunctions(graph.functions.map((f) => (f.id === id ? { ...f, ...patch } : f)));
   }
 
   function removeFunction(id: string): void {
-    onUpdate({ functions: graph.functions.filter((f) => f.id !== id) });
+    applyFunctions(graph.functions.filter((f) => f.id !== id));
   }
 
   function addFunction(): void {
-    onUpdate({ functions: [...graph.functions, createGraphFunction()] });
+    applyFunctions([...graph.functions, createGraphFunction()]);
   }
 
   function setRange(axis: 'x' | 'y', which: 0 | 1, value: number): void {
@@ -41,9 +68,39 @@
     onUpdate({ gridStep: value });
   }
 
-  function exprError(expr: string, kind: GraphFunctionKind): string | null {
-    const r = kind === 'implicit' ? parseExpressionXY(expr) : parseExpression(expr);
+  function exprError(
+    expr: string,
+    kind: GraphFunctionKind,
+    parameters: readonly GraphParameter[],
+  ): string | null {
+    const r =
+      kind === 'implicit'
+        ? parseExpressionXYWithParams(expr, parameters)
+        : parseExpressionWithParams(expr, parameters);
     return r.ok ? null : r.error;
+  }
+
+  function parameterWithPatch(
+    name: string,
+    patch: Partial<Omit<GraphParameter, 'name'>>,
+  ): GraphParameter[] {
+    return displayedParameters.map((parameter) =>
+      parameter.name === name ? clampParameter({ ...parameter, ...patch }) : { ...parameter },
+    );
+  }
+
+  function previewParameterValue(name: string, value: number): void {
+    if (!Number.isFinite(value)) return;
+    const next = parameterWithPatch(name, { value });
+    previewParameters = next;
+    previewBatcher.push(next);
+  }
+
+  function commitParameter(name: string, patch: Partial<Omit<GraphParameter, 'name'>>): void {
+    const next = parameterWithPatch(name, patch);
+    previewParameters = next;
+    previewBatcher.flushNow();
+    onUpdate({ parameters: next });
   }
 </script>
 
@@ -124,7 +181,7 @@
     <h4 class="section-title">Functions</h4>
     {#each graph.functions as fn (fn.id)}
       {@const kind = (fn.kind ?? 'explicit') as GraphFunctionKind}
-      {@const err = exprError(fn.expr, kind)}
+      {@const err = exprError(fn.expr, kind, displayedParameters)}
       <div class="fn">
         <input
           type="color"
@@ -172,6 +229,113 @@
     <button type="button" class="add" onclick={addFunction}>+ add function</button>
   </section>
 
+  {#if displayedParameters.length > 0}
+    <section class="parameters">
+      <h4 class="section-title">Parameters</h4>
+      {#each displayedParameters as parameter (parameter.name)}
+        <div class="parameter">
+          <div class="parameter-head">
+            <span class="parameter-name">{parameter.name}</span>
+            <label class="value-field">
+              <span class="sr-only">{parameter.name} value</span>
+              <input
+                type="number"
+                step={parameter.step}
+                min={parameter.min}
+                max={parameter.max}
+                value={parameter.value}
+                aria-label={`${parameter.name} value`}
+                onchange={(e) =>
+                  commitParameter(parameter.name, {
+                    value: Number((e.currentTarget as HTMLInputElement).value),
+                  })}
+              />
+            </label>
+            <label class="chip-toggle">
+              <input
+                type="checkbox"
+                checked={parameter.showChip === true}
+                aria-label={`Show ${parameter.name} value on graph`}
+                onchange={(e) =>
+                  commitParameter(parameter.name, {
+                    showChip: (e.currentTarget as HTMLInputElement).checked,
+                  })}
+              />
+              chip
+            </label>
+          </div>
+
+          <label class="slider-label">
+            <span class="sr-only">{parameter.name} slider</span>
+            <input
+              type="range"
+              min={parameter.min}
+              max={parameter.max}
+              step={parameter.step}
+              value={parameter.value}
+              aria-label={`${parameter.name} slider`}
+              oninput={(e) =>
+                previewParameterValue(
+                  parameter.name,
+                  Number((e.currentTarget as HTMLInputElement).value),
+                )}
+              onchange={(e) =>
+                commitParameter(parameter.name, {
+                  value: Number((e.currentTarget as HTMLInputElement).value),
+                })}
+            />
+          </label>
+
+          <details>
+            <summary>range settings</summary>
+            <div class="parameter-settings">
+              <label>
+                min
+                <input
+                  type="number"
+                  step="any"
+                  value={parameter.min}
+                  aria-label={`${parameter.name} minimum`}
+                  onchange={(e) =>
+                    commitParameter(parameter.name, {
+                      min: Number((e.currentTarget as HTMLInputElement).value),
+                    })}
+                />
+              </label>
+              <label>
+                max
+                <input
+                  type="number"
+                  step="any"
+                  value={parameter.max}
+                  aria-label={`${parameter.name} maximum`}
+                  onchange={(e) =>
+                    commitParameter(parameter.name, {
+                      max: Number((e.currentTarget as HTMLInputElement).value),
+                    })}
+                />
+              </label>
+              <label>
+                step
+                <input
+                  type="number"
+                  step="any"
+                  min="0"
+                  value={parameter.step}
+                  aria-label={`${parameter.name} step`}
+                  onchange={(e) =>
+                    commitParameter(parameter.name, {
+                      step: Number((e.currentTarget as HTMLInputElement).value),
+                    })}
+                />
+              </label>
+            </div>
+          </details>
+        </div>
+      {/each}
+    </section>
+  {/if}
+
   <footer class="foot">
     <button type="button" class="delete" onclick={onDelete}>Delete graph</button>
   </footer>
@@ -185,7 +349,7 @@
     border-radius: 8px;
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.55);
     padding: 10px;
-    width: 280px;
+    width: 300px;
     display: flex;
     flex-direction: column;
     gap: 8px;
@@ -247,6 +411,88 @@
     display: flex;
     flex-direction: column;
     gap: 6px;
+  }
+  .parameters {
+    display: flex;
+    flex-direction: column;
+    gap: 7px;
+    border-top: 1px solid #383838;
+    padding-top: 8px;
+  }
+  .parameter {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    background: #202020;
+    border: 1px solid #353535;
+    border-radius: 5px;
+    padding: 6px;
+  }
+  .parameter-head {
+    display: grid;
+    grid-template-columns: 24px 1fr auto;
+    align-items: center;
+    gap: 6px;
+  }
+  .parameter-name {
+    color: #f0f0f0;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-weight: 600;
+  }
+  .value-field input,
+  .parameter-settings input {
+    box-sizing: border-box;
+    width: 100%;
+    background: #171717;
+    color: #eee;
+    border: 1px solid #3a3a3a;
+    border-radius: 3px;
+    padding: 2px 4px;
+  }
+  .chip-toggle {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+    color: #bbb;
+  }
+  .slider-label,
+  .slider-label input {
+    display: block;
+    width: 100%;
+  }
+  .slider-label input {
+    accent-color: #64a6e8;
+  }
+  .parameter details {
+    color: #aaa;
+  }
+  .parameter summary {
+    cursor: pointer;
+    font-size: 10px;
+  }
+  .parameter-settings {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 5px;
+    padding-top: 5px;
+  }
+  .parameter-settings label {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    color: #aaa;
+    font-size: 10px;
+  }
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
   .fn {
     display: grid;

--- a/src/lib/graph/compileCache.ts
+++ b/src/lib/graph/compileCache.ts
@@ -1,0 +1,36 @@
+/**
+ * Keys and retention policy for compiled graph expressions.
+ *
+ * Compilation is cached per function so dragging a parameter re-samples
+ * without re-parsing. The cache therefore has to be pruned when graphs or
+ * functions go away, or it retains every expression ever compiled.
+ */
+
+export function graphFnCacheKey(graphId: string, fnId: string): string {
+  return `${graphId}\u0000${fnId}`;
+}
+
+export interface CacheableGraph {
+  id: string;
+  functions: readonly { id: string }[];
+}
+
+/** Keys for every function currently present across the given graphs. */
+export function liveCacheKeys(graphs: readonly CacheableGraph[]): Set<string> {
+  const live = new Set<string>();
+  for (const graph of graphs) {
+    for (const fn of graph.functions) live.add(graphFnCacheKey(graph.id, fn.id));
+  }
+  return live;
+}
+
+/** Drop entries whose key is not in `live`. Returns the number removed. */
+export function pruneCache(cache: Map<string, unknown>, live: ReadonlySet<string>): number {
+  let removed = 0;
+  for (const key of [...cache.keys()]) {
+    if (live.has(key)) continue;
+    cache.delete(key);
+    removed += 1;
+  }
+  return removed;
+}

--- a/src/lib/graph/parameters.ts
+++ b/src/lib/graph/parameters.ts
@@ -1,0 +1,63 @@
+import type { GraphObject, GraphParameter } from '$lib/types';
+import { freeVariables } from './parser';
+
+export const DEFAULT_PARAMETER: Omit<GraphParameter, 'name'> = {
+  value: 1,
+  min: -5,
+  max: 5,
+  step: 0.1,
+};
+
+export function mergeParameters(
+  existing: readonly GraphParameter[] | undefined,
+  names: readonly string[],
+): GraphParameter[] {
+  const byName = new Map<string, GraphParameter>();
+  for (const parameter of existing ?? []) {
+    if (!byName.has(parameter.name)) byName.set(parameter.name, parameter);
+  }
+
+  const seen = new Set<string>();
+  const merged: GraphParameter[] = [];
+  for (const name of names) {
+    if (seen.has(name)) continue;
+    seen.add(name);
+    const parameter = byName.get(name);
+    merged.push(parameter ? { ...parameter } : { name, ...DEFAULT_PARAMETER });
+  }
+  return merged;
+}
+
+export function parametersForGraph(graph: GraphObject): GraphParameter[] {
+  const names: string[] = [];
+  const seen = new Set<string>();
+  for (const fn of graph.functions) {
+    const reserved = fn.kind === 'implicit' ? ['x', 'y'] : ['x'];
+    for (const name of freeVariables(fn.expr, reserved)) {
+      if (seen.has(name)) continue;
+      seen.add(name);
+      names.push(name);
+    }
+  }
+  return mergeParameters(graph.parameters, names).map(clampParameter);
+}
+
+export function clampParameter(parameter: GraphParameter): GraphParameter {
+  let min = Number.isFinite(parameter.min) ? parameter.min : DEFAULT_PARAMETER.min;
+  let max = Number.isFinite(parameter.max) ? parameter.max : DEFAULT_PARAMETER.max;
+  if (min > max) [min, max] = [max, min];
+
+  const step =
+    Number.isFinite(parameter.step) && parameter.step > 0 ? parameter.step : DEFAULT_PARAMETER.step;
+  const candidate = Number.isFinite(parameter.value) ? parameter.value : DEFAULT_PARAMETER.value;
+  const value = Math.min(max, Math.max(min, candidate));
+
+  return {
+    name: parameter.name,
+    value,
+    min,
+    max,
+    step,
+    ...(typeof parameter.showChip === 'boolean' ? { showChip: parameter.showChip } : {}),
+  };
+}

--- a/src/lib/graph/parser.ts
+++ b/src/lib/graph/parser.ts
@@ -6,7 +6,7 @@
  *   expr   := term (('+' | '-') term)*
  *   term   := unary (('*' | '/') unary)*
  *   unary  := ('+' | '-') unary | factor
- *   factor := primary ('^' factor)?         // right-associative and tighter
+ *   factor := primary ('^' unary)?          // right-associative and tighter
  *                                           // than unary minus so `-2^2 == -4`.
  *   primary := number | ident | call | '(' expr ')'
  *   call   := ident '(' expr ')'
@@ -193,7 +193,7 @@ function parseFactor(c: Cursor): NodeFn {
   const t = peek(c);
   if (t && t.k === 'op' && t.v === '^') {
     consume(c);
-    const exp = parseFactor(c);
+    const exp = parseUnary(c);
     return (v) => Math.pow(base(v), exp(v));
   }
   return base;

--- a/src/lib/graph/parser.ts
+++ b/src/lib/graph/parser.ts
@@ -20,11 +20,33 @@
  * constant `e`; write `2*10^3` instead of `2e3`.
  */
 
+import type { GraphParameter } from '$lib/types';
+
 export type CompiledFn = (x: number) => number;
 export type CompiledFnXY = (x: number, y: number) => number;
 
 export type ParseResult = { ok: true; fn: CompiledFn } | { ok: false; error: string };
 export type ParseResultXY = { ok: true; fn: CompiledFnXY } | { ok: false; error: string };
+
+export interface ParameterizedFn {
+  fn: CompiledFn;
+  setParameter(name: string, value: number): void;
+  parameterNames: readonly string[];
+}
+
+export interface ParameterizedFnXY {
+  fn: CompiledFnXY;
+  setParameter(name: string, value: number): void;
+  parameterNames: readonly string[];
+}
+
+export type ParameterizedResult =
+  | { ok: true; compiled: ParameterizedFn }
+  | { ok: false; error: string };
+
+export type ParameterizedResultXY =
+  | { ok: true; compiled: ParameterizedFnXY }
+  | { ok: false; error: string };
 
 type BinOp = '+' | '-' | '*' | '/' | '^';
 
@@ -131,6 +153,40 @@ function tokenize(src: string): Tok[] {
     throw new ParseError(`unexpected character '${c}' at position ${i}`);
   }
   return tokens;
+}
+
+/**
+ * Return free parameter identifiers in first-appearance order. Tokenization
+ * failures produce an empty list so partially typed input is always safe.
+ */
+export function freeVariables(src: string, reserved: readonly string[]): string[] {
+  try {
+    const tokens = tokenize(src);
+    const reservedNames = new Set(reserved);
+    const seen = new Set<string>();
+    const names: string[] = [];
+    for (let i = 0; i < tokens.length; i += 1) {
+      const token = tokens[i];
+      if (token.k !== 'ident') continue;
+      const name = token.v;
+      const next = tokens[i + 1];
+      if (
+        (next?.k === 'lp' && next.pos > token.pos) ||
+        Object.hasOwn(FUNCTIONS, name) ||
+        Object.hasOwn(CONSTANTS, name) ||
+        reservedNames.has(name) ||
+        seen.has(name)
+      ) {
+        continue;
+      }
+      seen.add(name);
+      names.push(name);
+    }
+    return names;
+  } catch (err) {
+    if (err instanceof ParseError) return [];
+    throw err;
+  }
 }
 
 interface Cursor {
@@ -280,6 +336,95 @@ export function parseExpressionXY(src: string): ParseResultXY {
         buf[0] = x;
         buf[1] = y;
         return node(buf);
+      },
+    };
+  } catch (err) {
+    if (err instanceof ParseError) return { ok: false, error: err.message };
+    throw err;
+  }
+}
+
+function parameterLayout(
+  params: readonly GraphParameter[],
+  reserved: readonly string[],
+): {
+  varIndex: Record<string, number>;
+  parameterIndex: Map<string, number>;
+  parameterNames: string[];
+  buffer: number[];
+} {
+  const varIndex = Object.create(null) as Record<string, number>;
+  const parameterIndex = new Map<string, number>();
+  const parameterNames: string[] = [];
+  const buffer = new Array<number>(reserved.length).fill(0);
+
+  for (let i = 0; i < reserved.length; i += 1) {
+    varIndex[reserved[i]] = i;
+  }
+  for (const parameter of params) {
+    if (
+      parameterIndex.has(parameter.name) ||
+      reserved.includes(parameter.name) ||
+      Object.hasOwn(CONSTANTS, parameter.name)
+    ) {
+      continue;
+    }
+    const index = buffer.length;
+    varIndex[parameter.name] = index;
+    parameterIndex.set(parameter.name, index);
+    parameterNames.push(parameter.name);
+    buffer.push(parameter.value);
+  }
+  return { varIndex, parameterIndex, parameterNames, buffer };
+}
+
+export function parseExpressionWithParams(
+  src: string,
+  params: readonly GraphParameter[],
+): ParameterizedResult {
+  try {
+    const layout = parameterLayout(params, ['x']);
+    const node = compile(src, layout.varIndex, false);
+    return {
+      ok: true,
+      compiled: {
+        parameterNames: layout.parameterNames,
+        setParameter(name, value) {
+          const index = layout.parameterIndex.get(name);
+          if (index !== undefined) layout.buffer[index] = value;
+        },
+        fn(x) {
+          layout.buffer[0] = x;
+          return node(layout.buffer);
+        },
+      },
+    };
+  } catch (err) {
+    if (err instanceof ParseError) return { ok: false, error: err.message };
+    throw err;
+  }
+}
+
+export function parseExpressionXYWithParams(
+  src: string,
+  params: readonly GraphParameter[],
+): ParameterizedResultXY {
+  try {
+    const layout = parameterLayout(params, ['x', 'y']);
+    const node = compile(src, layout.varIndex, true);
+    return {
+      ok: true,
+      compiled: {
+        parameterNames: layout.parameterNames,
+        setParameter(name, value) {
+          const index = layout.parameterIndex.get(name);
+          if (index !== undefined) layout.buffer[index] = value;
+        },
+        fn(x, y) {
+          layout.buffer[0] = x;
+          layout.buffer[1] = y;
+          return node(layout.buffer);
+        },
       },
     };
   } catch (err) {

--- a/src/lib/select/ops.ts
+++ b/src/lib/select/ops.ts
@@ -59,11 +59,6 @@ export function commitDelete(pageIndex: number, ids: ReadonlySet<ObjectId>): voi
   documentStore.removeObjects(pageIndex, [...ids]);
 }
 
-/**
- * Z-order mutation: remove then re-add in the new order. This is currently
- * two history entries because the existing command set has no single
- * reorder op; undoing a reorder takes two undos.
- */
 export function reorderSelection(
   pageIndex: number,
   ids: ReadonlySet<ObjectId>,
@@ -73,11 +68,7 @@ export function reorderSelection(
   if (!current) return;
   const next = reorderArray(current, ids, direction);
   if (arraysEqualById(current, next)) return;
-  documentStore.removeObjects(
-    pageIndex,
-    current.map((o) => o.id),
-  );
-  for (const obj of next) documentStore.addObject(pageIndex, obj);
+  documentStore.reorderObjects(pageIndex, next);
 }
 
 function arraysEqualById(a: AnyObject[], b: AnyObject[]): boolean {

--- a/src/lib/session/player.ts
+++ b/src/lib/session/player.ts
@@ -91,6 +91,22 @@ export function replayStateAt(
         }
         break;
       }
+      case 'graph.paramChange': {
+        const arr = byPage.get(ev.page);
+        if (arr) {
+          byPage.set(
+            ev.page,
+            arr.map((object) => {
+              if (object.type !== 'graph' || object.id !== ev.graphId) return object;
+              const parameters = object.parameters?.map((parameter) =>
+                parameter.name === ev.name ? { ...parameter, value: ev.value } : parameter,
+              );
+              return parameters ? { ...object, parameters } : object;
+            }),
+          );
+        }
+        break;
+      }
     }
   }
 

--- a/src/lib/session/recorder.ts
+++ b/src/lib/session/recorder.ts
@@ -102,6 +102,18 @@ export function createRecorder(deps: RecorderDeps = browserDeps()) {
     pushSessionEvent({ kind: 'pageChange', t: currentElapsed(), page: lastPage });
   }
 
+  function recordGraphParameter(page: number, graphId: string, name: string, value: number): void {
+    if (get(state).status !== 'recording' || !Number.isFinite(value)) return;
+    pushSessionEvent({
+      kind: 'graph.paramChange',
+      t: currentElapsed(),
+      page,
+      graphId,
+      name,
+      value,
+    });
+  }
+
   async function start(pdfPath: string, nameHint?: string): Promise<void> {
     if (get(state).status !== 'idle' && get(state).status !== 'error') {
       throw new Error('recorder busy');
@@ -276,6 +288,7 @@ export function createRecorder(deps: RecorderDeps = browserDeps()) {
     pause,
     resume,
     stop,
+    recordGraphParameter,
     snapshot(): RecorderState {
       return get(state);
     },

--- a/src/lib/session/types.ts
+++ b/src/lib/session/types.ts
@@ -5,6 +5,14 @@ export type SessionEvent =
   | { kind: 'objectAdd'; t: number; page: number; obj: AnyObject }
   | { kind: 'objectDel'; t: number; page: number; ids: ObjectId[] }
   | { kind: 'objectUpdate'; t: number; page: number; id: ObjectId; after: AnyObject }
+  | {
+      kind: 'graph.paramChange';
+      t: number;
+      page: number;
+      graphId: ObjectId;
+      name: string;
+      value: number;
+    }
   | { kind: 'pageChange'; t: number; page: number };
 
 export interface SessionMeta {

--- a/src/lib/sidebar/ThumbnailStrip.svelte
+++ b/src/lib/sidebar/ThumbnailStrip.svelte
@@ -48,15 +48,21 @@
 
   /**
    * Slide previews are drawn locally rather than going through the pdfium
-   * cache. Keyed by the slide object identity, which is stable because the
-   * document store replaces slides immutably on every edit.
+   * cache.
+   *
+   * Keyed by the slide object itself, not by page index: indices are
+   * reassigned on insert, delete, and reorder, so an index key would both miss
+   * and retain entries for pages that no longer exist. A WeakMap also lets
+   * previews for discarded slides be collected instead of growing without
+   * bound over a long session.
    */
-  const slideThumbs = new Map<number, { slide: unknown; theme: SlideTheme; url: string }>();
+  const slideThumbs = new WeakMap<object, { theme: SlideTheme; size: string; url: string }>();
 
   function slideThumbUrl(page: Page, width: number, height: number): string | null {
     if (page.type !== 'slide' || !page.slide || width <= 0 || height <= 0) return null;
-    const cached = slideThumbs.get(page.pageIndex);
-    if (cached && cached.slide === page.slide && cached.theme === slideTheme) return cached.url;
+    const size = `${Math.round(width)}x${Math.round(height)}`;
+    const cached = slideThumbs.get(page.slide);
+    if (cached && cached.theme === slideTheme && cached.size === size) return cached.url;
 
     const canvas = document.createElement('canvas');
     canvas.width = Math.max(1, Math.round(width));
@@ -72,7 +78,7 @@
       canvas.width / page.width,
     );
     const url = canvas.toDataURL();
-    slideThumbs.set(page.pageIndex, { slide: page.slide, theme: slideTheme, url });
+    slideThumbs.set(page.slide, { theme: slideTheme, size, url });
     return url;
   }
 

--- a/src/lib/sidebar/ThumbnailStrip.svelte
+++ b/src/lib/sidebar/ThumbnailStrip.svelte
@@ -12,6 +12,7 @@
   } from '$lib/pdf/thumbnails';
   import { drawAnnotationOverlay, thumbnailPixelSize } from '$lib/pdf/thumbnailComposite';
   import { documentStore } from '$lib/store/document';
+  import { defaultSlideTheme, renderSlideBackground } from '$lib/slides';
   import { thumbnailSize } from './thumbnailSize';
 
   interface Props {
@@ -40,6 +41,36 @@
   }: Props = $props();
 
   const canDelete = $derived(pages.length > 1);
+
+  /**
+   * Slide previews are drawn locally rather than going through the pdfium
+   * cache. Keyed by the slide object identity, which is stable because the
+   * document store replaces slides immutably on every edit.
+   */
+  const slideThumbs = new Map<number, { slide: unknown; url: string }>();
+
+  function slideThumbUrl(page: Page, width: number, height: number): string | null {
+    if (page.type !== 'slide' || !page.slide || width <= 0 || height <= 0) return null;
+    const cached = slideThumbs.get(page.pageIndex);
+    if (cached && cached.slide === page.slide) return cached.url;
+
+    const canvas = document.createElement('canvas');
+    canvas.width = Math.max(1, Math.round(width));
+    canvas.height = Math.max(1, Math.round(height));
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return null;
+    renderSlideBackground(
+      ctx,
+      page.slide,
+      defaultSlideTheme,
+      canvas.width,
+      canvas.height,
+      canvas.width / page.width,
+    );
+    const url = canvas.toDataURL();
+    slideThumbs.set(page.pageIndex, { slide: page.slide, url });
+    return url;
+  }
 
   let previewUrls = $state(new Map<number, string>());
   const compositedUrls = new Map<number, string>();
@@ -278,6 +309,7 @@
     {#each pages as page, i (page.pageIndex)}
       {@const size = thumbnailSize(page.width, page.height, maxWidth)}
       {@const url = previewFor(page)}
+      {@const preview = page.type === 'slide' ? slideThumbUrl(page, size.width, size.height) : url}
       <li class="row" class:active={i === currentIndex}>
         <button
           type="button"
@@ -290,8 +322,8 @@
             class="preview"
             class:blank={page.type === 'blank'}
             use:observe={page}
-            style="width: {size.width}px; height: {size.height}px;{url
-              ? ` background-image: url('${url}');`
+            style="width: {size.width}px; height: {size.height}px;{preview
+              ? ` background-image: url('${preview}');`
               : ''}"
             style:background-color={page.type === 'blank'
               ? (page.background ?? undefined)

--- a/src/lib/sidebar/ThumbnailStrip.svelte
+++ b/src/lib/sidebar/ThumbnailStrip.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onDestroy, untrack } from 'svelte';
   import type { Page } from '$lib/types';
+  import type { SlideTheme } from '$lib/types';
   import {
     bumpPageGeneration,
     DEFAULT_MAX_DIM,
@@ -26,6 +27,8 @@
     maxWidth?: number;
     /** Stable identifier for the loaded PDF; thumbnail cache is scoped to it. */
     docKey?: string | null;
+    /** Deck theme, so slide previews match the main view for themed decks. */
+    slideTheme?: SlideTheme;
   }
 
   const {
@@ -38,6 +41,7 @@
     onhide,
     maxWidth = 140,
     docKey = null,
+    slideTheme = defaultSlideTheme,
   }: Props = $props();
 
   const canDelete = $derived(pages.length > 1);
@@ -47,12 +51,12 @@
    * cache. Keyed by the slide object identity, which is stable because the
    * document store replaces slides immutably on every edit.
    */
-  const slideThumbs = new Map<number, { slide: unknown; url: string }>();
+  const slideThumbs = new Map<number, { slide: unknown; theme: SlideTheme; url: string }>();
 
   function slideThumbUrl(page: Page, width: number, height: number): string | null {
     if (page.type !== 'slide' || !page.slide || width <= 0 || height <= 0) return null;
     const cached = slideThumbs.get(page.pageIndex);
-    if (cached && cached.slide === page.slide) return cached.url;
+    if (cached && cached.slide === page.slide && cached.theme === slideTheme) return cached.url;
 
     const canvas = document.createElement('canvas');
     canvas.width = Math.max(1, Math.round(width));
@@ -62,13 +66,13 @@
     renderSlideBackground(
       ctx,
       page.slide,
-      defaultSlideTheme,
+      slideTheme,
       canvas.width,
       canvas.height,
       canvas.width / page.width,
     );
     const url = canvas.toDataURL();
-    slideThumbs.set(page.pageIndex, { slide: page.slide, url });
+    slideThumbs.set(page.pageIndex, { slide: page.slide, theme: slideTheme, url });
     return url;
   }
 

--- a/src/lib/slides/commands.ts
+++ b/src/lib/slides/commands.ts
@@ -1,0 +1,31 @@
+import type { Command } from '$lib/command/commands';
+
+export type SlideCommandAction =
+  | 'new'
+  | 'new-from-template'
+  | 'edit'
+  | 'duplicate'
+  | 'change-layout'
+  | 'delete';
+
+export const SLIDE_COMMAND_EVENT = 'eldraw:slide-command';
+
+export function dispatchSlideCommand(action: SlideCommandAction): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(
+    new CustomEvent<SlideCommandAction>(SLIDE_COMMAND_EVENT, { detail: action }),
+  );
+}
+
+function command(id: string, title: string, action: SlideCommandAction): Command {
+  return { id, title, run: () => dispatchSlideCommand(action) };
+}
+
+export const slideCommands: Command[] = [
+  command('slide.new', 'New slide', 'new'),
+  command('slide.newFromTemplate', 'New slide from template…', 'new-from-template'),
+  command('slide.edit', 'Edit slide', 'edit'),
+  command('slide.duplicate', 'Duplicate slide', 'duplicate'),
+  command('slide.changeLayout', 'Change slide layout', 'change-layout'),
+  command('slide.delete', 'Delete slide', 'delete'),
+];

--- a/src/lib/slides/deck.ts
+++ b/src/lib/slides/deck.ts
@@ -1,0 +1,429 @@
+import { isSafeHexColor } from '$lib/color';
+import type {
+  GraphFunction,
+  Slide,
+  SlideAlign,
+  SlideBlock,
+  SlideCalloutBlock,
+  SlideCalloutTone,
+  SlideGraphSpec,
+  SlideLayoutKind,
+  SlideTheme,
+} from '$lib/types';
+
+const layouts: readonly SlideLayoutKind[] = ['title', 'content', 'columns', 'grid', 'blank'];
+const aligns: readonly SlideAlign[] = ['left', 'center', 'right'];
+const calloutTones: readonly SlideCalloutTone[] = ['tip', 'warn', 'note'];
+const imageDataUrl = /^data:image\/(?:png|jpeg|gif|webp);base64,[A-Za-z0-9+/]*={0,2}$/;
+const safeFontFamily = /^[A-Za-z0-9][A-Za-z0-9 _,.-]{0,199}$/;
+
+function newId(): string {
+  try {
+    return globalThis.crypto.randomUUID();
+  } catch {
+    return `slide-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  }
+}
+
+function cloneValue<T>(value: T): T {
+  if (Array.isArray(value)) return value.map((item) => cloneValue(item)) as T;
+  if (value !== null && typeof value === 'object') {
+    const copy: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(value)) copy[key] = cloneValue(item);
+    return copy as T;
+  }
+  return value;
+}
+
+function objectValue(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function stringValue(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function finiteNumber(value: unknown, fallback: number, min: number, max: number): number {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.min(max, Math.max(min, value))
+    : fallback;
+}
+
+function optionalNumber(value: unknown, min: number, max: number): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.min(max, Math.max(min, value))
+    : undefined;
+}
+
+function tupleRange(value: unknown, fallback: [number, number]): [number, number] {
+  if (!Array.isArray(value) || value.length < 2) return [...fallback];
+  const low = value[0];
+  const high = value[1];
+  if (
+    typeof low !== 'number' ||
+    typeof high !== 'number' ||
+    !Number.isFinite(low) ||
+    !Number.isFinite(high) ||
+    low >= high
+  ) {
+    return [...fallback];
+  }
+  const clampedLow = Math.min(1_000_000, Math.max(-1_000_000, low));
+  const clampedHigh = Math.min(1_000_000, Math.max(-1_000_000, high));
+  return clampedLow < clampedHigh ? [clampedLow, clampedHigh] : [...fallback];
+}
+
+function optionalAlign(value: unknown): SlideAlign | undefined {
+  return aligns.includes(value as SlideAlign) ? (value as SlideAlign) : undefined;
+}
+
+function optionalColor(value: unknown): string | undefined {
+  return isSafeHexColor(value) ? value : undefined;
+}
+
+function uniqueId(value: unknown, usedIds: Set<string>): string {
+  const supplied = typeof value === 'string' && value.length > 0 ? value : null;
+  const base = supplied !== null && !usedIds.has(supplied) ? supplied : newId();
+  let id = base;
+  let suffix = 2;
+  while (usedIds.has(id)) {
+    id = `${base}-${suffix}`;
+    suffix += 1;
+  }
+  usedIds.add(id);
+  return id;
+}
+
+function withBase(
+  block: Record<string, unknown>,
+  usedIds: Set<string>,
+): { id: string; marginTop?: number } {
+  const id = uniqueId(block.id, usedIds);
+  const marginTop = optionalNumber(block.marginTop, 0, 2_000);
+  return marginTop === undefined ? { id } : { id, marginTop };
+}
+
+function sanitizeGraphFunction(value: unknown, usedIds: Set<string>): GraphFunction | null {
+  const input = objectValue(value);
+  if (!input) return null;
+  const id = uniqueId(input.id, usedIds);
+  const color = optionalColor(input.color) ?? '#2563eb';
+  const kind = input.kind === 'implicit' ? 'implicit' : 'explicit';
+  const dash =
+    input.dash === 'dashed' || input.dash === 'dotted' || input.dash === 'solid'
+      ? input.dash
+      : 'solid';
+  const domain =
+    input.domain === null
+      ? null
+      : Array.isArray(input.domain)
+        ? tupleRange(input.domain, [-10, 10])
+        : null;
+  return {
+    id,
+    expr: stringValue(input.expr),
+    kind,
+    color,
+    width: finiteNumber(input.width, 2, 0.1, 20),
+    dash,
+    domain,
+  };
+}
+
+function sanitizeGraph(value: unknown): SlideGraphSpec {
+  const input = objectValue(value) ?? {};
+  const functionIds = new Set<string>();
+  const functions = Array.isArray(input.functions)
+    ? input.functions
+        .map((fn) => sanitizeGraphFunction(fn, functionIds))
+        .filter((fn): fn is GraphFunction => fn !== null)
+    : [];
+  return {
+    xRange: tupleRange(input.xRange, [-10, 10]),
+    yRange: tupleRange(input.yRange, [-10, 10]),
+    gridStep: finiteNumber(input.gridStep, 1, 0, 1_000),
+    showAxes: typeof input.showAxes === 'boolean' ? input.showAxes : true,
+    showGrid: typeof input.showGrid === 'boolean' ? input.showGrid : true,
+    functions,
+  };
+}
+
+function sanitizeCallout(input: Record<string, unknown>, usedIds: Set<string>): SlideCalloutBlock {
+  const tone = calloutTones.includes(input.tone as SlideCalloutTone)
+    ? (input.tone as SlideCalloutTone)
+    : 'note';
+  const fontSize = optionalNumber(input.fontSize, 6, 240);
+  return {
+    ...withBase(input, usedIds),
+    kind: 'callout',
+    text: stringValue(input.text),
+    tone,
+    ...(fontSize === undefined ? {} : { fontSize }),
+  };
+}
+
+function sanitizeBlock(value: unknown, usedIds: Set<string>, asideOnly = false): SlideBlock | null {
+  const input = objectValue(value);
+  if (!input || typeof input.kind !== 'string') return null;
+  if (asideOnly && input.kind !== 'callout') return null;
+  const fontSize = optionalNumber(input.fontSize, 6, 240);
+  const align = optionalAlign(input.align);
+  const color = optionalColor(input.color);
+
+  switch (input.kind) {
+    case 'text':
+      return {
+        ...withBase(input, usedIds),
+        kind: 'text',
+        text: stringValue(input.text),
+        ...(align === undefined ? {} : { align }),
+        ...(fontSize === undefined ? {} : { fontSize }),
+        ...(typeof input.bold === 'boolean' ? { bold: input.bold } : {}),
+        ...(typeof input.italic === 'boolean' ? { italic: input.italic } : {}),
+        ...(color === undefined ? {} : { color }),
+      };
+    case 'list':
+      return {
+        ...withBase(input, usedIds),
+        kind: 'list',
+        items: Array.isArray(input.items)
+          ? input.items
+              .map(objectValue)
+              .filter((item): item is Record<string, unknown> => item !== null)
+              .map((item) => ({
+                text: stringValue(item.text),
+                level: Math.round(finiteNumber(item.level, 0, 0, 3)),
+              }))
+          : [],
+        marker: input.marker === 'decimal' || input.marker === 'none' ? input.marker : 'bullet',
+        ...(fontSize === undefined ? {} : { fontSize }),
+      };
+    case 'definitions':
+      return {
+        ...withBase(input, usedIds),
+        kind: 'definitions',
+        items: Array.isArray(input.items)
+          ? input.items
+              .map(objectValue)
+              .filter((item): item is Record<string, unknown> => item !== null)
+              .map((item) => ({
+                term: stringValue(item.term),
+                text: stringValue(item.text),
+              }))
+          : [],
+        ...(fontSize === undefined ? {} : { fontSize }),
+      };
+    case 'table': {
+      const header = Array.isArray(input.header)
+        ? input.header.map((cell) => stringValue(cell))
+        : [];
+      const rows = Array.isArray(input.rows)
+        ? input.rows.filter(Array.isArray).map((row) => row.map((cell) => stringValue(cell)))
+        : [];
+      const columnCount = Math.max(header.length, ...rows.map((row) => row.length), 0);
+      const pad = (row: string[]) => [
+        ...row,
+        ...Array.from({ length: columnCount - row.length }, () => ''),
+      ];
+      const weights =
+        Array.isArray(input.columnWeights) && input.columnWeights.length === columnCount
+          ? input.columnWeights.map((weight) => finiteNumber(weight, 1, 0.01, 100))
+          : undefined;
+      return {
+        ...withBase(input, usedIds),
+        kind: 'table',
+        ...(typeof input.caption === 'string' ? { caption: input.caption } : {}),
+        header: pad(header),
+        rows: rows.map(pad),
+        ...(fontSize === undefined ? {} : { fontSize }),
+        ...(weights === undefined ? {} : { columnWeights: weights }),
+      };
+    }
+    case 'math':
+      return {
+        ...withBase(input, usedIds),
+        kind: 'math',
+        latex: stringValue(input.latex),
+        display: typeof input.display === 'boolean' ? input.display : true,
+        ...(align === undefined ? {} : { align }),
+        ...(fontSize === undefined ? {} : { fontSize }),
+        ...(color === undefined ? {} : { color }),
+      };
+    case 'graph':
+      return {
+        ...withBase(input, usedIds),
+        kind: 'graph',
+        graph: sanitizeGraph(input.graph),
+        height: finiteNumber(input.height, 240, 1, 2_000),
+        ...(typeof input.caption === 'string' ? { caption: input.caption } : {}),
+      };
+    case 'callout':
+      return sanitizeCallout(input, usedIds);
+    case 'image':
+      if (typeof input.src !== 'string' || !imageDataUrl.test(input.src)) return null;
+      return {
+        ...withBase(input, usedIds),
+        kind: 'image',
+        src: input.src,
+        alt: stringValue(input.alt),
+        height: finiteNumber(input.height, 240, 1, 2_000),
+        ...(align === undefined ? {} : { align }),
+      };
+    case 'spacer':
+      return {
+        ...withBase(input, usedIds),
+        kind: 'spacer',
+        height: finiteNumber(input.height, 120, 1, 2_000),
+      };
+    default:
+      return null;
+  }
+}
+
+function sanitizeTheme(value: unknown): Partial<SlideTheme> | undefined {
+  const input = objectValue(value);
+  if (!input) return undefined;
+  const theme: Partial<SlideTheme> = {};
+  if (typeof input.fontFamily === 'string' && safeFontFamily.test(input.fontFamily)) {
+    theme.fontFamily = input.fontFamily;
+  }
+  for (const key of ['background', 'titleColor', 'textColor', 'accent'] as const) {
+    const color = optionalColor(input[key]);
+    if (color !== undefined) theme[key] = color;
+  }
+  for (const key of ['titleSize', 'headingSize', 'bodySize'] as const) {
+    const size = optionalNumber(input[key], 6, 240);
+    if (size !== undefined) theme[key] = size;
+  }
+  return Object.keys(theme).length === 0 ? undefined : theme;
+}
+
+export function createSlide(layout: SlideLayoutKind, title = ''): Slide {
+  return { layout, title, blocks: [] };
+}
+
+export function createBlock<K extends SlideBlock['kind']>(
+  kind: K,
+): Extract<SlideBlock, { kind: K }>;
+export function createBlock(kind: SlideBlock['kind']): SlideBlock {
+  const id = newId();
+  switch (kind) {
+    case 'text':
+      return { id, kind, text: 'Text', align: 'left' };
+    case 'list':
+      return { id, kind, marker: 'bullet', items: [{ text: 'List item', level: 0 }] };
+    case 'definitions':
+      return { id, kind, items: [{ term: 'Term', text: 'Add a description' }] };
+    case 'table':
+      return { id, kind, header: ['Heading'], rows: [['Value']] };
+    case 'math':
+      return { id, kind, latex: 'x = 0', display: true, align: 'center' };
+    case 'graph':
+      return {
+        id,
+        kind,
+        height: 240,
+        graph: {
+          xRange: [-10, 10],
+          yRange: [-10, 10],
+          gridStep: 1,
+          showAxes: true,
+          showGrid: true,
+          functions: [
+            {
+              id: newId(),
+              expr: 'x',
+              kind: 'explicit',
+              color: '#2563eb',
+              width: 2,
+              dash: 'solid',
+              domain: null,
+            },
+          ],
+        },
+      };
+    case 'callout':
+      return { id, kind, text: 'Add a note', tone: 'note' };
+    case 'image':
+      return { id, kind, src: 'data:image/png;base64,', alt: '', height: 240 };
+    case 'spacer':
+      return { id, kind, height: 120 };
+  }
+}
+
+export function addBlock(slide: Slide, block: SlideBlock, index = slide.blocks.length): Slide {
+  const next = cloneValue(slide);
+  const insertionIndex = Math.min(next.blocks.length, Math.max(0, Math.trunc(index)));
+  next.blocks.splice(insertionIndex, 0, cloneValue(block));
+  return next;
+}
+
+export function updateBlock(slide: Slide, blockId: string, patch: Partial<SlideBlock>): Slide {
+  const next = cloneValue(slide);
+  next.blocks = next.blocks.map((block) =>
+    block.id === blockId ? ({ ...block, ...cloneValue(patch), id: block.id } as SlideBlock) : block,
+  );
+  return next;
+}
+
+export function removeBlock(slide: Slide, blockId: string): Slide {
+  const next = cloneValue(slide);
+  next.blocks = next.blocks.filter((block) => block.id !== blockId);
+  return next;
+}
+
+export function moveBlock(slide: Slide, from: number, to: number): Slide {
+  const next = cloneValue(slide);
+  if (!Number.isInteger(from) || from < 0 || from >= next.blocks.length) return next;
+  const destination = Math.min(next.blocks.length - 1, Math.max(0, Math.trunc(to)));
+  if (destination === from) return next;
+  const [block] = next.blocks.splice(from, 1);
+  next.blocks.splice(destination, 0, block);
+  return next;
+}
+
+export function setLayout(slide: Slide, layout: SlideLayoutKind): Slide {
+  return { ...cloneValue(slide), layout };
+}
+
+/** Convert untrusted sidecar data into a bounded, render-safe slide. */
+export function sanitizeSlide(input: unknown): Slide | null {
+  try {
+    const source = objectValue(input);
+    if (!source) return null;
+    const layout = layouts.includes(source.layout as SlideLayoutKind)
+      ? (source.layout as SlideLayoutKind)
+      : 'content';
+    const usedIds = new Set<string>();
+    const blocks = Array.isArray(source.blocks)
+      ? source.blocks
+          .map((block) => sanitizeBlock(block, usedIds))
+          .filter((block): block is SlideBlock => block !== null)
+      : [];
+    const aside = Array.isArray(source.aside)
+      ? source.aside
+          .map((block) => sanitizeBlock(block, usedIds, true))
+          .filter((block): block is SlideCalloutBlock => block?.kind === 'callout')
+      : undefined;
+    const subtitle = optionalString(source.subtitle);
+    const columnCount = optionalNumber(source.columnCount, 1, 6);
+    const theme = sanitizeTheme(source.theme);
+    return {
+      layout,
+      title: stringValue(source.title),
+      blocks,
+      ...(subtitle === undefined ? {} : { subtitle }),
+      ...(aside === undefined ? {} : { aside }),
+      ...(columnCount === undefined ? {} : { columnCount: Math.round(columnCount) }),
+      ...(theme === undefined ? {} : { theme }),
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/slides/deck.ts
+++ b/src/lib/slides/deck.ts
@@ -29,6 +29,13 @@ const maxDiagramNodes = 100;
 const maxDiagramEdges = 500;
 const maxNumberLineMarks = 200;
 const maxNumberLineTicks = 1_000;
+const maxListItems = 500;
+const maxDefinitionItems = 200;
+const maxTableRows = 500;
+const maxTableColumns = 100;
+const maxGraphFunctions = 50;
+const maxSlideBlocks = 200;
+const maxSlideAsides = 10;
 
 function newId(): string {
   try {
@@ -158,6 +165,7 @@ function sanitizeGraph(value: unknown): SlideGraphSpec {
   const functionIds = new Set<string>();
   const functions = Array.isArray(input.functions)
     ? input.functions
+        .slice(0, maxGraphFunctions)
         .map((fn) => sanitizeGraphFunction(fn, functionIds))
         .filter((fn): fn is GraphFunction => fn !== null)
     : [];
@@ -273,6 +281,7 @@ function sanitizeBlock(value: unknown, usedIds: Set<string>, asideOnly = false):
         kind: 'list',
         items: Array.isArray(input.items)
           ? input.items
+              .slice(0, maxListItems)
               .map(objectValue)
               .filter((item): item is Record<string, unknown> => item !== null)
               .map((item) => ({
@@ -291,6 +300,7 @@ function sanitizeBlock(value: unknown, usedIds: Set<string>, asideOnly = false):
         kind: 'definitions',
         items: Array.isArray(input.items)
           ? input.items
+              .slice(0, maxDefinitionItems)
               .map(objectValue)
               .filter((item): item is Record<string, unknown> => item !== null)
               .map((item) => ({
@@ -302,10 +312,13 @@ function sanitizeBlock(value: unknown, usedIds: Set<string>, asideOnly = false):
       };
     case 'table': {
       const header = Array.isArray(input.header)
-        ? input.header.map((cell) => stringValue(cell))
+        ? input.header.slice(0, maxTableColumns).map((cell) => stringValue(cell))
         : [];
       const rows = Array.isArray(input.rows)
-        ? input.rows.filter(Array.isArray).map((row) => row.map((cell) => stringValue(cell)))
+        ? input.rows
+            .slice(0, maxTableRows)
+            .filter(Array.isArray)
+            .map((row) => row.slice(0, maxTableColumns).map((cell) => stringValue(cell)))
         : [];
       const columnCount = Math.max(header.length, ...rows.map((row) => row.length), 0);
       const pad = (row: string[]) => [
@@ -607,11 +620,13 @@ export function sanitizeSlide(input: unknown): Slide | null {
     const usedIds = new Set<string>();
     const blocks = Array.isArray(source.blocks)
       ? source.blocks
+          .slice(0, maxSlideBlocks)
           .map((block) => sanitizeBlock(block, usedIds))
           .filter((block): block is SlideBlock => block !== null)
       : [];
     const aside = Array.isArray(source.aside)
       ? source.aside
+          .slice(0, maxSlideAsides)
           .map((block) => sanitizeBlock(block, usedIds, true))
           .filter((block): block is SlideCalloutBlock => block?.kind === 'callout')
       : undefined;

--- a/src/lib/slides/deck.ts
+++ b/src/lib/slides/deck.ts
@@ -16,6 +16,8 @@ const aligns: readonly SlideAlign[] = ['left', 'center', 'right'];
 const calloutTones: readonly SlideCalloutTone[] = ['tip', 'warn', 'note'];
 const imageDataUrl = /^data:image\/(?:png|jpeg|gif|webp);base64,[A-Za-z0-9+/]*={0,2}$/;
 const safeFontFamily = /^[A-Za-z0-9][A-Za-z0-9 _,.-]{0,199}$/;
+const maxMappingElements = 100;
+const maxMappingPairs = 500;
 
 function newId(): string {
   try {
@@ -275,6 +277,41 @@ function sanitizeBlock(value: unknown, usedIds: Set<string>, asideOnly = false):
         height: finiteNumber(input.height, 240, 1, 2_000),
         ...(align === undefined ? {} : { align }),
       };
+    case 'mapping': {
+      const left = Array.isArray(input.left)
+        ? input.left.slice(0, maxMappingElements).map((item) => stringValue(item))
+        : [];
+      const right = Array.isArray(input.right)
+        ? input.right.slice(0, maxMappingElements).map((item) => stringValue(item))
+        : [];
+      const pairs = Array.isArray(input.pairs)
+        ? input.pairs
+            .slice(0, maxMappingPairs)
+            .map(objectValue)
+            .filter((pair): pair is Record<string, unknown> => pair !== null)
+            .filter(
+              (pair) =>
+                Number.isInteger(pair.from) &&
+                Number.isInteger(pair.to) &&
+                (pair.from as number) >= 0 &&
+                (pair.from as number) < left.length &&
+                (pair.to as number) >= 0 &&
+                (pair.to as number) < right.length,
+            )
+            .map((pair) => ({ from: pair.from as number, to: pair.to as number }))
+        : [];
+      return {
+        ...withBase(input, usedIds),
+        kind: 'mapping',
+        leftLabel: stringValue(input.leftLabel, 'Domain'),
+        rightLabel: stringValue(input.rightLabel, 'Range'),
+        left,
+        right,
+        pairs,
+        height: finiteNumber(input.height, 260, 1, 2_000),
+        ...(typeof input.caption === 'string' ? { caption: input.caption } : {}),
+      };
+    }
     case 'spacer':
       return {
         ...withBase(input, usedIds),
@@ -352,6 +389,20 @@ export function createBlock(kind: SlideBlock['kind']): SlideBlock {
       return { id, kind, text: 'Add a note', tone: 'note' };
     case 'image':
       return { id, kind, src: 'data:image/png;base64,', alt: '', height: 240 };
+    case 'mapping':
+      return {
+        id,
+        kind,
+        leftLabel: 'Domain',
+        rightLabel: 'Range',
+        left: ['Input 1', 'Input 2'],
+        right: ['Output 1', 'Output 2'],
+        pairs: [
+          { from: 0, to: 0 },
+          { from: 1, to: 1 },
+        ],
+        height: 260,
+      };
     case 'spacer':
       return { id, kind, height: 120 };
   }

--- a/src/lib/slides/deck.ts
+++ b/src/lib/slides/deck.ts
@@ -1,13 +1,17 @@
 import { isSafeHexColor } from '$lib/color';
 import type {
   GraphFunction,
+  NumberLineMark,
   Slide,
   SlideAlign,
   SlideBlock,
   SlideCalloutBlock,
   SlideCalloutTone,
+  SlideDiagramEdge,
+  SlideDiagramNode,
   SlideGraphSpec,
   SlideLayoutKind,
+  SlideListMarker,
   SlideTheme,
 } from '$lib/types';
 
@@ -18,6 +22,13 @@ const imageDataUrl = /^data:image\/(?:png|jpeg|gif|webp);base64,[A-Za-z0-9+/]*={
 const safeFontFamily = /^[A-Za-z0-9][A-Za-z0-9 _,.-]{0,199}$/;
 const maxMappingElements = 100;
 const maxMappingPairs = 500;
+const listMarkers: readonly SlideListMarker[] = ['bullet', 'decimal', 'alpha', 'roman', 'none'];
+const numberLineMarkKinds = ['open', 'closed', 'arrow-left', 'arrow-right'] as const;
+const maxMarkerLevels = 4;
+const maxDiagramNodes = 100;
+const maxDiagramEdges = 500;
+const maxNumberLineMarks = 200;
+const maxNumberLineTicks = 1_000;
 
 function newId(): string {
   try {
@@ -87,6 +98,10 @@ function optionalAlign(value: unknown): SlideAlign | undefined {
 
 function optionalColor(value: unknown): string | undefined {
   return isSafeHexColor(value) ? value : undefined;
+}
+
+function listMarker(value: unknown, fallback: SlideListMarker): SlideListMarker {
+  return listMarkers.includes(value as SlideListMarker) ? (value as SlideListMarker) : fallback;
 }
 
 function uniqueId(value: unknown, usedIds: Set<string>): string {
@@ -170,6 +185,64 @@ function sanitizeCallout(input: Record<string, unknown>, usedIds: Set<string>): 
   };
 }
 
+function sanitizeDiagramNode(value: unknown, usedIds: Set<string>): SlideDiagramNode | null {
+  const input = objectValue(value);
+  if (!input) return null;
+  const suppliedId = typeof input.id === 'string' ? input.id.trim() : '';
+  const id = uniqueId(suppliedId || undefined, usedIds);
+  const w = optionalNumber(input.w, 0.01, 1);
+  const h = optionalNumber(input.h, 0.01, 1);
+  const shape = input.shape === 'plain' || input.shape === 'box' ? input.shape : undefined;
+  return {
+    id,
+    text: stringValue(input.text),
+    x: finiteNumber(input.x, 0.5, 0, 1),
+    y: finiteNumber(input.y, 0.5, 0, 1),
+    ...(w === undefined ? {} : { w }),
+    ...(h === undefined ? {} : { h }),
+    ...(shape === undefined ? {} : { shape }),
+  };
+}
+
+function sanitizeDiagramEdges(value: unknown, nodeIds: Set<string>): SlideDiagramEdge[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .slice(0, maxDiagramEdges)
+    .map(objectValue)
+    .filter((edge): edge is Record<string, unknown> => edge !== null)
+    .filter(
+      (edge) =>
+        typeof edge.from === 'string' &&
+        typeof edge.to === 'string' &&
+        edge.from !== edge.to &&
+        nodeIds.has(edge.from) &&
+        nodeIds.has(edge.to),
+    )
+    .map((edge) => ({
+      from: edge.from as string,
+      to: edge.to as string,
+      ...(typeof edge.label === 'string' ? { label: edge.label } : {}),
+    }));
+}
+
+function sanitizeNumberLineMarks(value: unknown, min: number, max: number): NumberLineMark[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .slice(0, maxNumberLineMarks)
+    .map(objectValue)
+    .filter((mark): mark is Record<string, unknown> => mark !== null)
+    .filter(
+      (mark) =>
+        typeof mark.value === 'number' &&
+        Number.isFinite(mark.value) &&
+        numberLineMarkKinds.includes(mark.kind as (typeof numberLineMarkKinds)[number]),
+    )
+    .map((mark) => ({
+      value: Math.min(max, Math.max(min, mark.value as number)),
+      kind: mark.kind as NumberLineMark['kind'],
+    }));
+}
+
 function sanitizeBlock(value: unknown, usedIds: Set<string>, asideOnly = false): SlideBlock | null {
   const input = objectValue(value);
   if (!input || typeof input.kind !== 'string') return null;
@@ -190,7 +263,11 @@ function sanitizeBlock(value: unknown, usedIds: Set<string>, asideOnly = false):
         ...(typeof input.italic === 'boolean' ? { italic: input.italic } : {}),
         ...(color === undefined ? {} : { color }),
       };
-    case 'list':
+    case 'list': {
+      const marker = listMarker(input.marker, 'bullet');
+      const markerByLevel = Array.isArray(input.markerByLevel)
+        ? input.markerByLevel.slice(0, maxMarkerLevels).map((value) => listMarker(value, marker))
+        : undefined;
       return {
         ...withBase(input, usedIds),
         kind: 'list',
@@ -203,9 +280,11 @@ function sanitizeBlock(value: unknown, usedIds: Set<string>, asideOnly = false):
                 level: Math.round(finiteNumber(item.level, 0, 0, 3)),
               }))
           : [],
-        marker: input.marker === 'decimal' || input.marker === 'none' ? input.marker : 'bullet',
+        marker,
+        ...(markerByLevel === undefined ? {} : { markerByLevel }),
         ...(fontSize === undefined ? {} : { fontSize }),
       };
+    }
     case 'definitions':
       return {
         ...withBase(input, usedIds),
@@ -243,6 +322,7 @@ function sanitizeBlock(value: unknown, usedIds: Set<string>, asideOnly = false):
         ...(typeof input.caption === 'string' ? { caption: input.caption } : {}),
         header: pad(header),
         rows: rows.map(pad),
+        headerOrientation: input.headerOrientation === 'column' ? 'column' : 'row',
         ...(fontSize === undefined ? {} : { fontSize }),
         ...(weights === undefined ? {} : { columnWeights: weights }),
       };
@@ -312,6 +392,54 @@ function sanitizeBlock(value: unknown, usedIds: Set<string>, asideOnly = false):
         ...(typeof input.caption === 'string' ? { caption: input.caption } : {}),
       };
     }
+    case 'diagram': {
+      const nodeIds = new Set<string>();
+      const nodes = Array.isArray(input.nodes)
+        ? input.nodes
+            .slice(0, maxDiagramNodes)
+            .map((node) => sanitizeDiagramNode(node, nodeIds))
+            .filter((node): node is SlideDiagramNode => node !== null)
+        : [];
+      return {
+        ...withBase(input, usedIds),
+        kind: 'diagram',
+        nodes,
+        edges: sanitizeDiagramEdges(input.edges, new Set(nodes.map((node) => node.id))),
+        height: finiteNumber(input.height, 260, 1, 2_000),
+        ...(typeof input.caption === 'string' ? { caption: input.caption } : {}),
+      };
+    }
+    case 'numberline': {
+      let min = finiteNumber(input.min, -10, -1_000_000, 1_000_000);
+      let max = finiteNumber(input.max, 10, -1_000_000, 1_000_000);
+      if (min >= max) {
+        min = -10;
+        max = 10;
+      }
+      const range = max - min;
+      const minimumStep = range / maxNumberLineTicks;
+      const tickCandidate =
+        typeof input.tickStep === 'number' && Number.isFinite(input.tickStep)
+          ? input.tickStep
+          : Math.min(1, range);
+      const labelCandidate =
+        typeof input.labelStep === 'number' && Number.isFinite(input.labelStep)
+          ? input.labelStep
+          : Math.min(5, range);
+      const tickStep = Math.min(range, Math.max(minimumStep, tickCandidate));
+      const labelStep = Math.min(range, Math.max(minimumStep, labelCandidate));
+      return {
+        ...withBase(input, usedIds),
+        kind: 'numberline',
+        min,
+        max,
+        tickStep,
+        labelStep,
+        marks: sanitizeNumberLineMarks(input.marks, min, max),
+        height: finiteNumber(input.height, 160, 1, 2_000),
+        ...(typeof input.caption === 'string' ? { caption: input.caption } : {}),
+      };
+    }
     case 'spacer':
       return {
         ...withBase(input, usedIds),
@@ -358,7 +486,7 @@ export function createBlock(kind: SlideBlock['kind']): SlideBlock {
     case 'definitions':
       return { id, kind, items: [{ term: 'Term', text: 'Add a description' }] };
     case 'table':
-      return { id, kind, header: ['Heading'], rows: [['Value']] };
+      return { id, kind, header: ['Heading'], rows: [['Value']], headerOrientation: 'row' };
     case 'math':
       return { id, kind, latex: 'x = 0', display: true, align: 'center' };
     case 'graph':
@@ -402,6 +530,31 @@ export function createBlock(kind: SlideBlock['kind']): SlideBlock {
           { from: 1, to: 1 },
         ],
         height: 260,
+      };
+    case 'diagram': {
+      const first = newId();
+      const second = newId();
+      return {
+        id,
+        kind,
+        nodes: [
+          { id: first, text: 'Input', x: 0.2, y: 0.5, shape: 'plain' },
+          { id: second, text: 'Operation', x: 0.7, y: 0.5, shape: 'box' },
+        ],
+        edges: [{ from: first, to: second }],
+        height: 260,
+      };
+    }
+    case 'numberline':
+      return {
+        id,
+        kind,
+        min: -10,
+        max: 10,
+        tickStep: 1,
+        labelStep: 5,
+        marks: [],
+        height: 160,
       };
     case 'spacer':
       return { id, kind, height: 120 };

--- a/src/lib/slides/editor/SlideEditor.svelte
+++ b/src/lib/slides/editor/SlideEditor.svelte
@@ -1,14 +1,18 @@
 <script lang="ts">
   import type {
     GraphFunction,
+    NumberLineMarkKind,
     Slide,
     SlideAlign,
     SlideBlock,
     SlideCalloutBlock,
     SlideCalloutTone,
+    SlideDiagramBlock,
     SlideGraphBlock,
     SlideLayoutKind,
+    SlideListMarker,
     SlideMappingBlock,
+    SlideNumberLineBlock,
     SlideTableBlock,
   } from '$lib/types';
   import {
@@ -30,6 +34,7 @@
   let addKind = $state<SlideBlock['kind']>('text');
   let imageError = $state('');
   let mappingSelections = $state<Record<string, { from: number; to: number }>>({});
+  let diagramSelections = $state<Record<string, { from: string; to: string }>>({});
 
   const layouts: { value: SlideLayoutKind; label: string }[] = [
     { value: 'title', label: 'Title' },
@@ -49,7 +54,17 @@
     { value: 'callout', label: 'Callout' },
     { value: 'image', label: 'Image' },
     { value: 'mapping', label: 'Mapping diagram' },
+    { value: 'diagram', label: 'Node diagram' },
+    { value: 'numberline', label: 'Number line' },
     { value: 'spacer', label: 'Writing space' },
+  ];
+
+  const listMarkerOptions: { value: SlideListMarker; label: string }[] = [
+    { value: 'bullet', label: 'Bullet' },
+    { value: 'decimal', label: 'Decimal' },
+    { value: 'alpha', label: 'Alphabetic' },
+    { value: 'roman', label: 'Roman numeral' },
+    { value: 'none', label: 'None' },
   ];
 
   function cloneSlide(): Slide {
@@ -316,6 +331,168 @@
     });
   }
 
+  function setListMarkerLevel(
+    block: Extract<SlideBlock, { kind: 'list' }>,
+    index: number,
+    marker: SlideListMarker,
+  ): void {
+    const markerByLevel = [...(block.markerByLevel ?? [])];
+    markerByLevel[index] = marker;
+    onchange(updateBlock(slide, block.id, { markerByLevel }));
+  }
+
+  function removeListMarkerLevel(
+    block: Extract<SlideBlock, { kind: 'list' }>,
+    index: number,
+  ): void {
+    onchange(
+      updateBlock(slide, block.id, {
+        markerByLevel: (block.markerByLevel ?? []).filter(
+          (_, markerIndex) => markerIndex !== index,
+        ),
+      }),
+    );
+  }
+
+  function updateDiagram(block: SlideDiagramBlock, patch: Partial<SlideDiagramBlock>): void {
+    onchange(updateBlock(slide, block.id, patch));
+  }
+
+  function updateDiagramNode(
+    block: SlideDiagramBlock,
+    index: number,
+    patch: Partial<SlideDiagramBlock['nodes'][number]>,
+  ): void {
+    updateDiagram(block, {
+      nodes: block.nodes.map((node, nodeIndex) =>
+        nodeIndex === index ? { ...node, ...patch, id: node.id } : node,
+      ),
+    });
+  }
+
+  function renameDiagramNode(block: SlideDiagramBlock, index: number, value: string): void {
+    const id = value.trim();
+    const current = block.nodes[index];
+    if (
+      !current ||
+      id.length === 0 ||
+      block.nodes.some((node, i) => i !== index && node.id === id)
+    ) {
+      return;
+    }
+    updateDiagram(block, {
+      nodes: block.nodes.map((node, nodeIndex) => (nodeIndex === index ? { ...node, id } : node)),
+      edges: block.edges.map((edge) => ({
+        ...edge,
+        from: edge.from === current.id ? id : edge.from,
+        to: edge.to === current.id ? id : edge.to,
+      })),
+    });
+  }
+
+  function addDiagramNode(block: SlideDiagramBlock): void {
+    updateDiagram(block, {
+      nodes: [
+        ...block.nodes,
+        {
+          id: crypto.randomUUID(),
+          text: 'Node',
+          x: 0.5,
+          y: 0.5,
+          shape: 'box',
+        },
+      ],
+    });
+  }
+
+  function removeDiagramNode(block: SlideDiagramBlock, id: string): void {
+    updateDiagram(block, {
+      nodes: block.nodes.filter((node) => node.id !== id),
+      edges: block.edges.filter((edge) => edge.from !== id && edge.to !== id),
+    });
+  }
+
+  function setDiagramSelection(
+    block: SlideDiagramBlock,
+    endpoint: 'from' | 'to',
+    value: string,
+  ): void {
+    const current = diagramSelections[block.id] ?? {
+      from: block.nodes[0]?.id ?? '',
+      to: block.nodes[1]?.id ?? '',
+    };
+    diagramSelections[block.id] = { ...current, [endpoint]: value };
+  }
+
+  function addDiagramEdge(block: SlideDiagramBlock): void {
+    const defaults = { from: block.nodes[0]?.id ?? '', to: block.nodes[1]?.id ?? '' };
+    const selection = diagramSelections[block.id] ?? defaults;
+    if (
+      selection.from === selection.to ||
+      !block.nodes.some((node) => node.id === selection.from) ||
+      !block.nodes.some((node) => node.id === selection.to)
+    ) {
+      return;
+    }
+    updateDiagram(block, { edges: [...block.edges, { ...selection }] });
+  }
+
+  function removeDiagramEdge(block: SlideDiagramBlock, index: number): void {
+    updateDiagram(block, {
+      edges: block.edges.filter((_, edgeIndex) => edgeIndex !== index),
+    });
+  }
+
+  function updateNumberLine(
+    block: SlideNumberLineBlock,
+    patch: Partial<SlideNumberLineBlock>,
+  ): void {
+    onchange(updateBlock(slide, block.id, patch));
+  }
+
+  function setNumberLineBound(
+    block: SlideNumberLineBlock,
+    bound: 'min' | 'max',
+    value: number,
+  ): void {
+    if ((bound === 'min' && value >= block.max) || (bound === 'max' && value <= block.min)) return;
+    updateNumberLine(block, { [bound]: value });
+  }
+
+  function setNumberLineStep(
+    block: SlideNumberLineBlock,
+    step: 'tickStep' | 'labelStep',
+    value: number,
+  ): void {
+    const range = block.max - block.min;
+    updateNumberLine(block, {
+      [step]: Math.min(range, Math.max(range / 1_000, value)),
+    });
+  }
+
+  function updateNumberLineMark(
+    block: SlideNumberLineBlock,
+    index: number,
+    patch: Partial<SlideNumberLineBlock['marks'][number]>,
+  ): void {
+    updateNumberLine(block, {
+      marks: block.marks.map((mark, markIndex) =>
+        markIndex === index ? { ...mark, ...patch } : mark,
+      ),
+    });
+  }
+
+  function removeNumberLineMark(block: SlideNumberLineBlock, index: number): void {
+    updateNumberLine(block, {
+      marks: block.marks.filter((_, markIndex) => markIndex !== index),
+    });
+  }
+
+  function addNumberLineMark(block: SlideNumberLineBlock): void {
+    const value = block.min <= 0 && block.max >= 0 ? 0 : block.min;
+    updateNumberLine(block, { marks: [...block.marks, { value, kind: 'closed' }] });
+  }
+
   async function loadImage(
     block: Extract<SlideBlock, { kind: 'image' }>,
     file?: File,
@@ -534,18 +711,52 @@
                   onchange={(event) =>
                     onchange(
                       updateBlock(slide, block.id, {
-                        marker: (event.currentTarget as HTMLSelectElement).value as
-                          | 'bullet'
-                          | 'decimal'
-                          | 'none',
+                        marker: (event.currentTarget as HTMLSelectElement).value as SlideListMarker,
                       }),
                     )}
                 >
-                  <option value="bullet">Bullet</option>
-                  <option value="decimal">Decimal</option>
-                  <option value="none">None</option>
+                  {#each listMarkerOptions as marker (marker.value)}
+                    <option value={marker.value}>{marker.label}</option>
+                  {/each}
                 </select>
               </label>
+              <div class="wide marker-levels">
+                <span class="field-label">Markers by indent level</span>
+                {#each block.markerByLevel ?? [] as marker, markerIndex}
+                  <div class="marker-level">
+                    <label>
+                      Level {markerIndex + 1}
+                      <select
+                        value={marker}
+                        onchange={(event) =>
+                          setListMarkerLevel(
+                            block,
+                            markerIndex,
+                            (event.currentTarget as HTMLSelectElement).value as SlideListMarker,
+                          )}
+                      >
+                        {#each listMarkerOptions as option (option.value)}
+                          <option value={option.value}>{option.label}</option>
+                        {/each}
+                      </select>
+                    </label>
+                    <button
+                      type="button"
+                      class="danger"
+                      aria-label={`Remove marker override for level ${markerIndex + 1}`}
+                      onclick={() => removeListMarkerLevel(block, markerIndex)}>×</button
+                    >
+                  </div>
+                {/each}
+                <button
+                  type="button"
+                  class="add-small"
+                  disabled={(block.markerByLevel?.length ?? 0) >= 4}
+                  onclick={() =>
+                    setListMarkerLevel(block, block.markerByLevel?.length ?? 0, block.marker)}
+                  >+ level</button
+                >
+              </div>
               <div class="wide repeated">
                 {#each block.items as item, itemIndex}
                   <div class="item-row">
@@ -642,6 +853,23 @@
                 >
               </div>
             {:else if block.kind === 'table'}
+              <label>
+                Header orientation
+                <select
+                  value={block.headerOrientation ?? 'row'}
+                  onchange={(event) =>
+                    onchange(
+                      updateBlock(slide, block.id, {
+                        headerOrientation: (event.currentTarget as HTMLSelectElement).value as
+                          | 'row'
+                          | 'column',
+                      }),
+                    )}
+                >
+                  <option value="row">Top row</option>
+                  <option value="column">First column</option>
+                </select>
+              </label>
               <label class="wide">
                 Caption
                 <input
@@ -1174,6 +1402,302 @@
                     updateMapping(block, { height: numberValue(event, block.height) })}
                 />
               </label>
+            {:else if block.kind === 'diagram'}
+              <label class="wide">
+                Caption
+                <input
+                  type="text"
+                  value={block.caption ?? ''}
+                  oninput={(event) =>
+                    updateDiagram(block, {
+                      caption: (event.currentTarget as HTMLInputElement).value,
+                    })}
+                />
+              </label>
+              <div class="wide diagram-nodes">
+                <strong>Nodes</strong>
+                {#each block.nodes as node, nodeIndex (node.id)}
+                  <div class="diagram-node">
+                    <label>
+                      ID
+                      <input
+                        type="text"
+                        value={node.id}
+                        onchange={(event) =>
+                          renameDiagramNode(
+                            block,
+                            nodeIndex,
+                            (event.currentTarget as HTMLInputElement).value,
+                          )}
+                      />
+                    </label>
+                    <label>
+                      Text
+                      <input
+                        type="text"
+                        value={node.text}
+                        oninput={(event) =>
+                          updateDiagramNode(block, nodeIndex, {
+                            text: (event.currentTarget as HTMLInputElement).value,
+                          })}
+                      />
+                    </label>
+                    <label>
+                      Shape
+                      <select
+                        value={node.shape ?? 'box'}
+                        onchange={(event) =>
+                          updateDiagramNode(block, nodeIndex, {
+                            shape: (event.currentTarget as HTMLSelectElement).value as
+                              | 'box'
+                              | 'plain',
+                          })}
+                      >
+                        <option value="box">Box</option>
+                        <option value="plain">Plain</option>
+                      </select>
+                    </label>
+                    <label>
+                      x
+                      <input
+                        type="number"
+                        min="0"
+                        max="1"
+                        step="0.01"
+                        value={node.x}
+                        onchange={(event) =>
+                          updateDiagramNode(block, nodeIndex, {
+                            x: Math.min(1, Math.max(0, numberValue(event, node.x))),
+                          })}
+                      />
+                    </label>
+                    <label>
+                      y
+                      <input
+                        type="number"
+                        min="0"
+                        max="1"
+                        step="0.01"
+                        value={node.y}
+                        onchange={(event) =>
+                          updateDiagramNode(block, nodeIndex, {
+                            y: Math.min(1, Math.max(0, numberValue(event, node.y))),
+                          })}
+                      />
+                    </label>
+                    <button
+                      type="button"
+                      class="danger diagram-node-delete"
+                      aria-label={`Delete diagram node ${nodeIndex + 1}`}
+                      onclick={() => removeDiagramNode(block, node.id)}>Delete</button
+                    >
+                  </div>
+                {/each}
+                <button type="button" class="add-small" onclick={() => addDiagramNode(block)}
+                  >+ node</button
+                >
+              </div>
+              <div class="wide diagram-edges">
+                <strong>Edges</strong>
+                {#each block.edges as edge, edgeIndex}
+                  <div class="diagram-edge">
+                    <span>{edge.from} → {edge.to}</span>
+                    <input
+                      type="text"
+                      value={edge.label ?? ''}
+                      aria-label={`Edge ${edgeIndex + 1} label`}
+                      placeholder="Optional label"
+                      oninput={(event) =>
+                        updateDiagram(block, {
+                          edges: block.edges.map((candidate, index) =>
+                            index === edgeIndex
+                              ? {
+                                  ...candidate,
+                                  label: (event.currentTarget as HTMLInputElement).value,
+                                }
+                              : candidate,
+                          ),
+                        })}
+                    />
+                    <button
+                      type="button"
+                      class="danger"
+                      aria-label={`Delete edge ${edgeIndex + 1}`}
+                      onclick={() => removeDiagramEdge(block, edgeIndex)}>×</button
+                    >
+                  </div>
+                {/each}
+                <div class="new-diagram-edge">
+                  <label>
+                    From
+                    <select
+                      value={diagramSelections[block.id]?.from ?? block.nodes[0]?.id ?? ''}
+                      disabled={block.nodes.length < 2}
+                      onchange={(event) =>
+                        setDiagramSelection(
+                          block,
+                          'from',
+                          (event.currentTarget as HTMLSelectElement).value,
+                        )}
+                    >
+                      {#each block.nodes as node}
+                        <option value={node.id}>{node.text || node.id}</option>
+                      {/each}
+                    </select>
+                  </label>
+                  <label>
+                    To
+                    <select
+                      value={diagramSelections[block.id]?.to ?? block.nodes[1]?.id ?? ''}
+                      disabled={block.nodes.length < 2}
+                      onchange={(event) =>
+                        setDiagramSelection(
+                          block,
+                          'to',
+                          (event.currentTarget as HTMLSelectElement).value,
+                        )}
+                    >
+                      {#each block.nodes as node}
+                        <option value={node.id}>{node.text || node.id}</option>
+                      {/each}
+                    </select>
+                  </label>
+                  <button
+                    type="button"
+                    disabled={block.nodes.length < 2 ||
+                      (diagramSelections[block.id]?.from ?? block.nodes[0]?.id) ===
+                        (diagramSelections[block.id]?.to ?? block.nodes[1]?.id)}
+                    onclick={() => addDiagramEdge(block)}>+ edge</button
+                  >
+                </div>
+              </div>
+              <label>
+                Height
+                <input
+                  type="number"
+                  min="1"
+                  max="2000"
+                  value={block.height}
+                  onchange={(event) =>
+                    updateDiagram(block, { height: numberValue(event, block.height) })}
+                />
+              </label>
+            {:else if block.kind === 'numberline'}
+              <label class="wide">
+                Caption
+                <input
+                  type="text"
+                  value={block.caption ?? ''}
+                  oninput={(event) =>
+                    updateNumberLine(block, {
+                      caption: (event.currentTarget as HTMLInputElement).value,
+                    })}
+                />
+              </label>
+              <div class="wide numberline-settings">
+                <label>
+                  Minimum
+                  <input
+                    type="number"
+                    step="any"
+                    value={block.min}
+                    onchange={(event) =>
+                      setNumberLineBound(block, 'min', numberValue(event, block.min))}
+                  />
+                </label>
+                <label>
+                  Maximum
+                  <input
+                    type="number"
+                    step="any"
+                    value={block.max}
+                    onchange={(event) =>
+                      setNumberLineBound(block, 'max', numberValue(event, block.max))}
+                  />
+                </label>
+                <label>
+                  Tick step
+                  <input
+                    type="number"
+                    min="0.000001"
+                    step="any"
+                    value={block.tickStep}
+                    onchange={(event) =>
+                      setNumberLineStep(block, 'tickStep', numberValue(event, block.tickStep))}
+                  />
+                </label>
+                <label>
+                  Label step
+                  <input
+                    type="number"
+                    min="0.000001"
+                    step="any"
+                    value={block.labelStep}
+                    onchange={(event) =>
+                      setNumberLineStep(block, 'labelStep', numberValue(event, block.labelStep))}
+                  />
+                </label>
+                <label>
+                  Height
+                  <input
+                    type="number"
+                    min="1"
+                    max="2000"
+                    value={block.height}
+                    onchange={(event) =>
+                      updateNumberLine(block, {
+                        height: Math.max(1, numberValue(event, block.height)),
+                      })}
+                  />
+                </label>
+              </div>
+              <div class="wide numberline-marks">
+                <strong>Marks</strong>
+                {#each block.marks as mark, markIndex}
+                  <div class="numberline-mark">
+                    <label>
+                      Value
+                      <input
+                        type="number"
+                        step="any"
+                        value={mark.value}
+                        onchange={(event) =>
+                          updateNumberLineMark(block, markIndex, {
+                            value: Math.min(
+                              block.max,
+                              Math.max(block.min, numberValue(event, mark.value)),
+                            ),
+                          })}
+                      />
+                    </label>
+                    <label>
+                      Kind
+                      <select
+                        value={mark.kind}
+                        onchange={(event) =>
+                          updateNumberLineMark(block, markIndex, {
+                            kind: (event.currentTarget as HTMLSelectElement)
+                              .value as NumberLineMarkKind,
+                          })}
+                      >
+                        <option value="open">Open circle</option>
+                        <option value="closed">Closed circle</option>
+                        <option value="arrow-left">Left arrow</option>
+                        <option value="arrow-right">Right arrow</option>
+                      </select>
+                    </label>
+                    <button
+                      type="button"
+                      class="danger"
+                      aria-label={`Delete number-line mark ${markIndex + 1}`}
+                      onclick={() => removeNumberLineMark(block, markIndex)}>×</button
+                    >
+                  </div>
+                {/each}
+                <button type="button" class="add-small" onclick={() => addNumberLineMark(block)}
+                  >+ mark</button
+                >
+              </div>
             {:else if block.kind === 'spacer'}
               <label>
                 Writing-space height
@@ -1471,6 +1995,66 @@
     display: grid;
     grid-template-columns: 28px 78px minmax(0, 1fr) 25px;
     gap: 4px;
+  }
+  .marker-levels,
+  .diagram-nodes,
+  .diagram-edges,
+  .numberline-marks {
+    display: grid;
+    gap: 5px;
+  }
+  .field-label,
+  .diagram-nodes > strong,
+  .diagram-edges > strong,
+  .numberline-marks > strong {
+    color: #bbb;
+    font-size: 11px;
+  }
+  .marker-level {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 25px;
+    gap: 4px;
+    align-items: end;
+  }
+  .diagram-node {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 5px;
+    padding: 6px;
+    border: 1px solid #363636;
+    border-radius: 4px;
+  }
+  .diagram-node-delete {
+    align-self: end;
+  }
+  .diagram-edge {
+    display: grid;
+    grid-template-columns: minmax(90px, auto) minmax(0, 1fr) 25px;
+    gap: 5px;
+    align-items: center;
+  }
+  .diagram-edge span {
+    overflow: hidden;
+    color: #aaa;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .new-diagram-edge {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
+    gap: 5px;
+    align-items: end;
+  }
+  .numberline-settings {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 5px;
+  }
+  .numberline-mark {
+    display: grid;
+    grid-template-columns: minmax(0, 0.8fr) minmax(0, 1.2fr) 25px;
+    gap: 5px;
+    align-items: end;
   }
   .mapping-columns {
     display: grid;

--- a/src/lib/slides/editor/SlideEditor.svelte
+++ b/src/lib/slides/editor/SlideEditor.svelte
@@ -1,0 +1,1199 @@
+<script lang="ts">
+  import type {
+    GraphFunction,
+    Slide,
+    SlideAlign,
+    SlideBlock,
+    SlideCalloutBlock,
+    SlideCalloutTone,
+    SlideGraphBlock,
+    SlideLayoutKind,
+    SlideTableBlock,
+  } from '$lib/types';
+  import {
+    addBlock,
+    createBlock,
+    moveBlock,
+    removeBlock,
+    setLayout,
+    updateBlock,
+  } from '$lib/slides/deck';
+
+  interface Props {
+    slide: Slide;
+    onchange: (next: Slide) => void;
+    onclose: () => void;
+  }
+
+  let { slide, onchange, onclose }: Props = $props();
+  let addKind = $state<SlideBlock['kind']>('text');
+  let imageError = $state('');
+
+  const layouts: { value: SlideLayoutKind; label: string }[] = [
+    { value: 'title', label: 'Title' },
+    { value: 'content', label: 'Content' },
+    { value: 'columns', label: 'Columns' },
+    { value: 'grid', label: 'Grid' },
+    { value: 'blank', label: 'Blank' },
+  ];
+
+  const blockKinds: { value: SlideBlock['kind']; label: string }[] = [
+    { value: 'text', label: 'Text' },
+    { value: 'list', label: 'List' },
+    { value: 'definitions', label: 'Definitions' },
+    { value: 'table', label: 'Table' },
+    { value: 'math', label: 'Math' },
+    { value: 'graph', label: 'Graph' },
+    { value: 'callout', label: 'Callout' },
+    { value: 'image', label: 'Image' },
+    { value: 'spacer', label: 'Writing space' },
+  ];
+
+  function cloneSlide(): Slide {
+    return structuredClone(slide);
+  }
+
+  function updateSlide(patch: Partial<Slide>): void {
+    onchange({ ...cloneSlide(), ...structuredClone(patch) });
+  }
+
+  function numberValue(event: Event, fallback: number): number {
+    const value = Number((event.currentTarget as HTMLInputElement).value);
+    return Number.isFinite(value) ? value : fallback;
+  }
+
+  function addSelectedBlock(): void {
+    onchange(addBlock(slide, createBlock(addKind)));
+  }
+
+  function duplicateBlock(block: SlideBlock, index: number): void {
+    const copy = structuredClone(block);
+    copy.id = crypto.randomUUID();
+    if (copy.kind === 'graph') {
+      copy.graph.functions = copy.graph.functions.map((fn) => ({
+        ...fn,
+        id: crypto.randomUUID(),
+      }));
+    }
+    onchange(addBlock(slide, copy, index + 1));
+  }
+
+  function focusBlock(index: number): void {
+    requestAnimationFrame(() => {
+      const buttons = document.querySelectorAll<HTMLButtonElement>('[data-slide-block-focus]');
+      buttons[index]?.focus();
+    });
+  }
+
+  function handleBlockKey(event: KeyboardEvent, index: number): void {
+    if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return;
+    event.preventDefault();
+    const destination = event.key === 'ArrowUp' ? index - 1 : index + 1;
+    if (destination < 0 || destination >= slide.blocks.length) return;
+    if (event.altKey) onchange(moveBlock(slide, index, destination));
+    focusBlock(destination);
+  }
+
+  function setListItem(
+    block: Extract<SlideBlock, { kind: 'list' }>,
+    index: number,
+    patch: Partial<(typeof block.items)[number]>,
+  ): void {
+    const items = block.items.map((item, itemIndex) =>
+      itemIndex === index ? { ...item, ...patch } : item,
+    );
+    onchange(updateBlock(slide, block.id, { items }));
+  }
+
+  function removeListItem(block: Extract<SlideBlock, { kind: 'list' }>, index: number): void {
+    onchange(
+      updateBlock(slide, block.id, {
+        items: block.items.filter((_, itemIndex) => itemIndex !== index),
+      }),
+    );
+  }
+
+  function setDefinition(
+    block: Extract<SlideBlock, { kind: 'definitions' }>,
+    index: number,
+    patch: Partial<(typeof block.items)[number]>,
+  ): void {
+    onchange(
+      updateBlock(slide, block.id, {
+        items: block.items.map((item, itemIndex) =>
+          itemIndex === index ? { ...item, ...patch } : item,
+        ),
+      }),
+    );
+  }
+
+  function setTableCell(
+    block: SlideTableBlock,
+    rowIndex: number,
+    columnIndex: number,
+    value: string,
+  ): void {
+    const rows = block.rows.map((row, index) =>
+      index === rowIndex ? row.map((cell, col) => (col === columnIndex ? value : cell)) : row,
+    );
+    onchange(updateBlock(slide, block.id, { rows }));
+  }
+
+  function addTableColumn(block: SlideTableBlock): void {
+    onchange(
+      updateBlock(slide, block.id, {
+        header: [...block.header, 'Heading'],
+        rows: block.rows.map((row) => [...row, '']),
+      }),
+    );
+  }
+
+  function removeTableColumn(block: SlideTableBlock): void {
+    if (block.header.length <= 1) return;
+    onchange(
+      updateBlock(slide, block.id, {
+        header: block.header.slice(0, -1),
+        rows: block.rows.map((row) => row.slice(0, -1)),
+      }),
+    );
+  }
+
+  function addTableRow(block: SlideTableBlock): void {
+    onchange(
+      updateBlock(slide, block.id, {
+        rows: [...block.rows, Array.from({ length: block.header.length }, () => '')],
+      }),
+    );
+  }
+
+  function removeTableRow(block: SlideTableBlock, index: number): void {
+    onchange(
+      updateBlock(slide, block.id, {
+        rows: block.rows.filter((_, rowIndex) => rowIndex !== index),
+      }),
+    );
+  }
+
+  function updateGraph(block: SlideGraphBlock, patch: Partial<SlideGraphBlock['graph']>): void {
+    onchange(updateBlock(slide, block.id, { graph: { ...block.graph, ...patch } }));
+  }
+
+  function updateGraphFunction(
+    block: SlideGraphBlock,
+    id: string,
+    patch: Partial<GraphFunction>,
+  ): void {
+    updateGraph(block, {
+      functions: block.graph.functions.map((fn) => (fn.id === id ? { ...fn, ...patch } : fn)),
+    });
+  }
+
+  function addGraphFunction(block: SlideGraphBlock): void {
+    updateGraph(block, {
+      functions: [
+        ...block.graph.functions,
+        {
+          id: crypto.randomUUID(),
+          expr: 'x',
+          kind: 'explicit',
+          color: '#2563eb',
+          width: 2,
+          dash: 'solid',
+          domain: null,
+        },
+      ],
+    });
+  }
+
+  function removeGraphFunction(block: SlideGraphBlock, id: string): void {
+    updateGraph(block, {
+      functions: block.graph.functions.filter((candidate) => candidate.id !== id),
+    });
+  }
+
+  function setGraphRange(
+    block: SlideGraphBlock,
+    axis: 'xRange' | 'yRange',
+    index: 0 | 1,
+    value: number,
+  ): void {
+    const range = [...block.graph[axis]] as [number, number];
+    range[index] = value;
+    if (range[0] >= range[1]) return;
+    updateGraph(block, { [axis]: range });
+  }
+
+  async function loadImage(
+    block: Extract<SlideBlock, { kind: 'image' }>,
+    file?: File,
+  ): Promise<void> {
+    if (!file) return;
+    imageError = '';
+    if (!['image/png', 'image/jpeg', 'image/gif', 'image/webp'].includes(file.type)) {
+      imageError = 'Choose a PNG, JPEG, GIF, or WebP image.';
+      return;
+    }
+    try {
+      const src = await new Promise<string>((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () =>
+          typeof reader.result === 'string'
+            ? resolve(reader.result)
+            : reject(new Error('Image reader returned non-text data'));
+        reader.onerror = () => reject(reader.error ?? new Error('Could not read image'));
+        reader.readAsDataURL(file);
+      });
+      onchange(updateBlock(slide, block.id, { src, alt: block.alt || file.name }));
+    } catch (error) {
+      imageError = error instanceof Error ? error.message : 'Could not read image.';
+    }
+  }
+
+  function updateAside(index: number, patch: Partial<SlideCalloutBlock>): void {
+    const next = cloneSlide();
+    next.aside = (next.aside ?? []).map((callout, calloutIndex) =>
+      calloutIndex === index ? { ...callout, ...patch, id: callout.id } : callout,
+    );
+    onchange(next);
+  }
+
+  function removeAside(index: number): void {
+    const next = cloneSlide();
+    next.aside = (next.aside ?? []).filter((_, calloutIndex) => calloutIndex !== index);
+    onchange(next);
+  }
+
+  function addAside(): void {
+    const next = cloneSlide();
+    next.aside = [...(next.aside ?? []), createBlock('callout')];
+    onchange(next);
+  }
+</script>
+
+<aside class="editor" aria-label="Slide editor">
+  <header class="head">
+    <span class="editor-title">Slide editor</span>
+    <button type="button" class="close" aria-label="Close slide editor" onclick={onclose}>×</button>
+  </header>
+
+  <section class="slide-fields" aria-label="Slide settings">
+    <label>
+      Layout
+      <select
+        value={slide.layout}
+        onchange={(event) =>
+          onchange(
+            setLayout(slide, (event.currentTarget as HTMLSelectElement).value as SlideLayoutKind),
+          )}
+      >
+        {#each layouts as layout (layout.value)}
+          <option value={layout.value}>{layout.label}</option>
+        {/each}
+      </select>
+    </label>
+    {#if slide.layout === 'columns' || slide.layout === 'grid'}
+      <label>
+        Columns
+        <input
+          type="number"
+          min="1"
+          max="6"
+          value={slide.columnCount ?? 2}
+          onchange={(event) =>
+            updateSlide({
+              columnCount: Math.max(1, Math.min(6, numberValue(event, slide.columnCount ?? 2))),
+            })}
+        />
+      </label>
+    {/if}
+    <label class="wide">
+      Title
+      <input
+        type="text"
+        value={slide.title}
+        oninput={(event) => updateSlide({ title: (event.currentTarget as HTMLInputElement).value })}
+      />
+    </label>
+    <label class="wide">
+      Subtitle
+      <input
+        type="text"
+        value={slide.subtitle ?? ''}
+        oninput={(event) =>
+          updateSlide({ subtitle: (event.currentTarget as HTMLInputElement).value })}
+      />
+    </label>
+  </section>
+
+  <section class="blocks-section" aria-labelledby="blocks-heading">
+    <h2 id="blocks-heading">Blocks</h2>
+    <ol class="blocks">
+      {#each slide.blocks as block, index (block.id)}
+        <li class="block">
+          <div class="block-head">
+            <button
+              type="button"
+              class="block-focus"
+              data-slide-block-focus
+              aria-label={`${block.kind} block ${index + 1}. Use arrow keys to navigate or Alt plus arrow keys to move.`}
+              onkeydown={(event) => handleBlockKey(event, index)}
+            >
+              <span class="drag">↕</span>
+              <strong>{block.kind}</strong>
+            </button>
+            <div class="block-actions">
+              <button
+                type="button"
+                aria-label={`Move ${block.kind} block up`}
+                disabled={index === 0}
+                onclick={() => {
+                  onchange(moveBlock(slide, index, index - 1));
+                  focusBlock(index - 1);
+                }}>↑</button
+              >
+              <button
+                type="button"
+                aria-label={`Move ${block.kind} block down`}
+                disabled={index === slide.blocks.length - 1}
+                onclick={() => {
+                  onchange(moveBlock(slide, index, index + 1));
+                  focusBlock(index + 1);
+                }}>↓</button
+              >
+              <button
+                type="button"
+                aria-label={`Duplicate ${block.kind} block`}
+                onclick={() => duplicateBlock(block, index)}>⧉</button
+              >
+              <button
+                type="button"
+                class="danger"
+                aria-label={`Delete ${block.kind} block`}
+                onclick={() => onchange(removeBlock(slide, block.id))}>×</button
+              >
+            </div>
+          </div>
+
+          <div class="block-form">
+            {#if block.kind === 'text'}
+              <label class="wide">
+                Content
+                <textarea
+                  rows="3"
+                  value={block.text}
+                  oninput={(event) =>
+                    onchange(
+                      updateBlock(slide, block.id, {
+                        text: (event.currentTarget as HTMLTextAreaElement).value,
+                      }),
+                    )}
+                ></textarea>
+              </label>
+              <label>
+                Alignment
+                <select
+                  value={block.align ?? 'left'}
+                  onchange={(event) =>
+                    onchange(
+                      updateBlock(slide, block.id, {
+                        align: (event.currentTarget as HTMLSelectElement).value as SlideAlign,
+                      }),
+                    )}
+                >
+                  <option value="left">Left</option>
+                  <option value="center">Center</option>
+                  <option value="right">Right</option>
+                </select>
+              </label>
+              <label>
+                Size
+                <input
+                  type="number"
+                  min="6"
+                  max="240"
+                  value={block.fontSize ?? 24}
+                  onchange={(event) =>
+                    onchange(
+                      updateBlock(slide, block.id, {
+                        fontSize: numberValue(event, block.fontSize ?? 24),
+                      }),
+                    )}
+                />
+              </label>
+              <label class="check">
+                <input
+                  type="checkbox"
+                  checked={block.bold ?? false}
+                  onchange={(event) =>
+                    onchange(
+                      updateBlock(slide, block.id, {
+                        bold: (event.currentTarget as HTMLInputElement).checked,
+                      }),
+                    )}
+                />
+                Bold
+              </label>
+            {:else if block.kind === 'list'}
+              <label>
+                Marker
+                <select
+                  value={block.marker}
+                  onchange={(event) =>
+                    onchange(
+                      updateBlock(slide, block.id, {
+                        marker: (event.currentTarget as HTMLSelectElement).value as
+                          | 'bullet'
+                          | 'decimal'
+                          | 'none',
+                      }),
+                    )}
+                >
+                  <option value="bullet">Bullet</option>
+                  <option value="decimal">Decimal</option>
+                  <option value="none">None</option>
+                </select>
+              </label>
+              <div class="wide repeated">
+                {#each block.items as item, itemIndex}
+                  <div class="item-row">
+                    <input
+                      type="text"
+                      value={item.text}
+                      aria-label={`List item ${itemIndex + 1}`}
+                      oninput={(event) =>
+                        setListItem(block, itemIndex, {
+                          text: (event.currentTarget as HTMLInputElement).value,
+                        })}
+                    />
+                    <button
+                      type="button"
+                      aria-label={`Outdent list item ${itemIndex + 1}`}
+                      disabled={item.level <= 0}
+                      onclick={() =>
+                        setListItem(block, itemIndex, { level: Math.max(0, item.level - 1) })}
+                      >←</button
+                    >
+                    <button
+                      type="button"
+                      aria-label={`Indent list item ${itemIndex + 1}`}
+                      disabled={item.level >= 3}
+                      onclick={() =>
+                        setListItem(block, itemIndex, { level: Math.min(3, item.level + 1) })}
+                      >→</button
+                    >
+                    <button
+                      type="button"
+                      class="danger"
+                      aria-label={`Delete list item ${itemIndex + 1}`}
+                      onclick={() => removeListItem(block, itemIndex)}>×</button
+                    >
+                  </div>
+                {/each}
+                <button
+                  type="button"
+                  class="add-small"
+                  onclick={() =>
+                    onchange(
+                      updateBlock(slide, block.id, {
+                        items: [...block.items, { text: 'List item', level: 0 }],
+                      }),
+                    )}>+ item</button
+                >
+              </div>
+            {:else if block.kind === 'definitions'}
+              <div class="wide repeated">
+                {#each block.items as item, itemIndex}
+                  <div class="definition-row">
+                    <input
+                      type="text"
+                      value={item.term}
+                      aria-label={`Definition ${itemIndex + 1} term`}
+                      placeholder="Term"
+                      oninput={(event) =>
+                        setDefinition(block, itemIndex, {
+                          term: (event.currentTarget as HTMLInputElement).value,
+                        })}
+                    />
+                    <input
+                      type="text"
+                      value={item.text}
+                      aria-label={`Definition ${itemIndex + 1} description`}
+                      placeholder="Description"
+                      oninput={(event) =>
+                        setDefinition(block, itemIndex, {
+                          text: (event.currentTarget as HTMLInputElement).value,
+                        })}
+                    />
+                    <button
+                      type="button"
+                      class="danger"
+                      aria-label={`Delete definition ${itemIndex + 1}`}
+                      onclick={() =>
+                        onchange(
+                          updateBlock(slide, block.id, {
+                            items: block.items.filter((_, i) => i !== itemIndex),
+                          }),
+                        )}>×</button
+                    >
+                  </div>
+                {/each}
+                <button
+                  type="button"
+                  class="add-small"
+                  onclick={() =>
+                    onchange(
+                      updateBlock(slide, block.id, {
+                        items: [...block.items, { term: 'Key term', text: 'Add a description' }],
+                      }),
+                    )}>+ definition</button
+                >
+              </div>
+            {:else if block.kind === 'table'}
+              <label class="wide">
+                Caption
+                <input
+                  type="text"
+                  value={block.caption ?? ''}
+                  oninput={(event) =>
+                    onchange(
+                      updateBlock(slide, block.id, {
+                        caption: (event.currentTarget as HTMLInputElement).value,
+                      }),
+                    )}
+                />
+              </label>
+              <div class="wide table-wrap">
+                <div class="table-grid" style={`--columns: ${Math.max(1, block.header.length)}`}>
+                  {#each block.header as cell, columnIndex}
+                    <input
+                      class="header-cell"
+                      type="text"
+                      value={cell}
+                      aria-label={`Table header column ${columnIndex + 1}`}
+                      oninput={(event) =>
+                        onchange(
+                          updateBlock(slide, block.id, {
+                            header: block.header.map((header, index) =>
+                              index === columnIndex
+                                ? (event.currentTarget as HTMLInputElement).value
+                                : header,
+                            ),
+                          }),
+                        )}
+                    />
+                  {/each}
+                  {#each block.rows as row, rowIndex}
+                    {#each row as cell, columnIndex}
+                      <input
+                        type="text"
+                        value={cell}
+                        aria-label={`Table row ${rowIndex + 1}, column ${columnIndex + 1}`}
+                        oninput={(event) =>
+                          setTableCell(
+                            block,
+                            rowIndex,
+                            columnIndex,
+                            (event.currentTarget as HTMLInputElement).value,
+                          )}
+                      />
+                    {/each}
+                  {/each}
+                </div>
+                <div class="table-actions">
+                  <button type="button" onclick={() => addTableRow(block)}>+ row</button>
+                  <button
+                    type="button"
+                    disabled={block.rows.length === 0}
+                    onclick={() => removeTableRow(block, block.rows.length - 1)}>- row</button
+                  >
+                  <button type="button" onclick={() => addTableColumn(block)}>+ column</button>
+                  <button
+                    type="button"
+                    disabled={block.header.length <= 1}
+                    onclick={() => removeTableColumn(block)}>- column</button
+                  >
+                </div>
+              </div>
+            {:else if block.kind === 'math'}
+              <label class="wide">
+                LaTeX
+                <textarea
+                  rows="3"
+                  spellcheck="false"
+                  value={block.latex}
+                  oninput={(event) =>
+                    onchange(
+                      updateBlock(slide, block.id, {
+                        latex: (event.currentTarget as HTMLTextAreaElement).value,
+                      }),
+                    )}
+                ></textarea>
+              </label>
+              <label>
+                Alignment
+                <select
+                  value={block.align ?? 'center'}
+                  onchange={(event) =>
+                    onchange(
+                      updateBlock(slide, block.id, {
+                        align: (event.currentTarget as HTMLSelectElement).value as SlideAlign,
+                      }),
+                    )}
+                >
+                  <option value="left">Left</option>
+                  <option value="center">Center</option>
+                  <option value="right">Right</option>
+                </select>
+              </label>
+              <label>
+                Size
+                <input
+                  type="number"
+                  min="6"
+                  max="240"
+                  value={block.fontSize ?? 36}
+                  onchange={(event) =>
+                    onchange(
+                      updateBlock(slide, block.id, {
+                        fontSize: numberValue(event, block.fontSize ?? 36),
+                      }),
+                    )}
+                />
+              </label>
+            {:else if block.kind === 'callout'}
+              <label class="wide">
+                Text
+                <textarea
+                  rows="2"
+                  value={block.text}
+                  oninput={(event) =>
+                    onchange(
+                      updateBlock(slide, block.id, {
+                        text: (event.currentTarget as HTMLTextAreaElement).value,
+                      }),
+                    )}
+                ></textarea>
+              </label>
+              <label>
+                Tone
+                <select
+                  value={block.tone}
+                  onchange={(event) =>
+                    onchange(
+                      updateBlock(slide, block.id, {
+                        tone: (event.currentTarget as HTMLSelectElement).value as SlideCalloutTone,
+                      }),
+                    )}
+                >
+                  <option value="tip">Tip</option>
+                  <option value="note">Note</option>
+                  <option value="warn">Warning</option>
+                </select>
+              </label>
+            {:else if block.kind === 'graph'}
+              <label>
+                Height
+                <input
+                  type="number"
+                  min="1"
+                  max="2000"
+                  value={block.height}
+                  onchange={(event) =>
+                    onchange(
+                      updateBlock(slide, block.id, {
+                        height: numberValue(event, block.height),
+                      }),
+                    )}
+                />
+              </label>
+              <label class="wide">
+                Caption
+                <input
+                  type="text"
+                  value={block.caption ?? ''}
+                  oninput={(event) =>
+                    onchange(
+                      updateBlock(slide, block.id, {
+                        caption: (event.currentTarget as HTMLInputElement).value,
+                      }),
+                    )}
+                />
+              </label>
+              <div class="wide range-row">
+                <label>
+                  x min
+                  <input
+                    type="number"
+                    step="any"
+                    value={block.graph.xRange[0]}
+                    onchange={(event) =>
+                      setGraphRange(block, 'xRange', 0, numberValue(event, block.graph.xRange[0]))}
+                  />
+                </label>
+                <label>
+                  x max
+                  <input
+                    type="number"
+                    step="any"
+                    value={block.graph.xRange[1]}
+                    onchange={(event) =>
+                      setGraphRange(block, 'xRange', 1, numberValue(event, block.graph.xRange[1]))}
+                  />
+                </label>
+                <label>
+                  y min
+                  <input
+                    type="number"
+                    step="any"
+                    value={block.graph.yRange[0]}
+                    onchange={(event) =>
+                      setGraphRange(block, 'yRange', 0, numberValue(event, block.graph.yRange[0]))}
+                  />
+                </label>
+                <label>
+                  y max
+                  <input
+                    type="number"
+                    step="any"
+                    value={block.graph.yRange[1]}
+                    onchange={(event) =>
+                      setGraphRange(block, 'yRange', 1, numberValue(event, block.graph.yRange[1]))}
+                  />
+                </label>
+              </div>
+              <label class="check">
+                <input
+                  type="checkbox"
+                  checked={block.graph.showGrid}
+                  onchange={(event) =>
+                    updateGraph(block, {
+                      showGrid: (event.currentTarget as HTMLInputElement).checked,
+                    })}
+                />
+                Grid
+              </label>
+              <label class="check">
+                <input
+                  type="checkbox"
+                  checked={block.graph.showAxes}
+                  onchange={(event) =>
+                    updateGraph(block, {
+                      showAxes: (event.currentTarget as HTMLInputElement).checked,
+                    })}
+                />
+                Axes
+              </label>
+              <div class="wide repeated">
+                {#each block.graph.functions as fn, functionIndex (fn.id)}
+                  <div class="graph-function">
+                    <input
+                      type="color"
+                      value={fn.color}
+                      aria-label={`Expression ${functionIndex + 1} color`}
+                      onchange={(event) =>
+                        updateGraphFunction(block, fn.id, {
+                          color: (event.currentTarget as HTMLInputElement).value,
+                        })}
+                    />
+                    <select
+                      value={fn.kind}
+                      aria-label={`Expression ${functionIndex + 1} kind`}
+                      onchange={(event) =>
+                        updateGraphFunction(block, fn.id, {
+                          kind: (event.currentTarget as HTMLSelectElement).value as
+                            | 'explicit'
+                            | 'implicit',
+                        })}
+                    >
+                      <option value="explicit">y=</option>
+                      <option value="implicit">f(x,y)=0</option>
+                    </select>
+                    <input
+                      type="text"
+                      spellcheck="false"
+                      value={fn.expr}
+                      aria-label={`Expression ${functionIndex + 1}`}
+                      oninput={(event) =>
+                        updateGraphFunction(block, fn.id, {
+                          expr: (event.currentTarget as HTMLInputElement).value,
+                        })}
+                    />
+                    <button
+                      type="button"
+                      class="danger"
+                      aria-label={`Delete expression ${functionIndex + 1}`}
+                      onclick={() => removeGraphFunction(block, fn.id)}>×</button
+                    >
+                  </div>
+                {/each}
+                <button type="button" class="add-small" onclick={() => addGraphFunction(block)}
+                  >+ expression</button
+                >
+              </div>
+            {:else if block.kind === 'image'}
+              <label class="wide">
+                Image file
+                <input
+                  type="file"
+                  accept="image/png,image/jpeg,image/gif,image/webp"
+                  onchange={(event) =>
+                    void loadImage(block, (event.currentTarget as HTMLInputElement).files?.[0])}
+                />
+              </label>
+              <label class="wide">
+                Alternative text
+                <input
+                  type="text"
+                  value={block.alt}
+                  oninput={(event) =>
+                    onchange(
+                      updateBlock(slide, block.id, {
+                        alt: (event.currentTarget as HTMLInputElement).value,
+                      }),
+                    )}
+                />
+              </label>
+              <label>
+                Height
+                <input
+                  type="number"
+                  min="1"
+                  max="2000"
+                  value={block.height}
+                  onchange={(event) =>
+                    onchange(
+                      updateBlock(slide, block.id, {
+                        height: numberValue(event, block.height),
+                      }),
+                    )}
+                />
+              </label>
+              {#if imageError}
+                <p class="error" role="alert">{imageError}</p>
+              {/if}
+            {:else if block.kind === 'spacer'}
+              <label>
+                Writing-space height
+                <input
+                  type="number"
+                  min="1"
+                  max="2000"
+                  value={block.height}
+                  onchange={(event) =>
+                    onchange(
+                      updateBlock(slide, block.id, {
+                        height: numberValue(event, block.height),
+                      }),
+                    )}
+                />
+              </label>
+            {/if}
+          </div>
+        </li>
+      {:else}
+        <li class="empty">This slide has no blocks.</li>
+      {/each}
+    </ol>
+
+    <div class="add-block">
+      <label>
+        Block type
+        <select bind:value={addKind}>
+          {#each blockKinds as kind (kind.value)}
+            <option value={kind.value}>{kind.label}</option>
+          {/each}
+        </select>
+      </label>
+      <button type="button" class="primary" onclick={addSelectedBlock}>Add block</button>
+    </div>
+  </section>
+
+  <section class="aside-section" aria-labelledby="aside-heading">
+    <div class="section-head">
+      <h2 id="aside-heading">Corner callouts</h2>
+      <button type="button" class="add-small" onclick={addAside}>+ callout</button>
+    </div>
+    {#each slide.aside ?? [] as callout, index (callout.id)}
+      <div class="aside-row">
+        <input
+          type="text"
+          value={callout.text}
+          aria-label={`Corner callout ${index + 1} text`}
+          oninput={(event) =>
+            updateAside(index, { text: (event.currentTarget as HTMLInputElement).value })}
+        />
+        <select
+          value={callout.tone}
+          aria-label={`Corner callout ${index + 1} tone`}
+          onchange={(event) =>
+            updateAside(index, {
+              tone: (event.currentTarget as HTMLSelectElement).value as SlideCalloutTone,
+            })}
+        >
+          <option value="tip">Tip</option>
+          <option value="note">Note</option>
+          <option value="warn">Warning</option>
+        </select>
+        <button
+          type="button"
+          class="danger"
+          aria-label={`Delete corner callout ${index + 1}`}
+          onclick={() => removeAside(index)}>×</button
+        >
+      </div>
+    {/each}
+  </section>
+</aside>
+
+<style>
+  .editor {
+    width: min(440px, calc(100vw - 24px));
+    max-height: calc(100vh - 24px);
+    overflow: auto;
+    box-sizing: border-box;
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    background: #252525;
+    color: #e8e8e8;
+    border: 1px solid #1a1a1a;
+    border-radius: 8px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.55);
+    font-size: 12px;
+    pointer-events: auto;
+  }
+  .head,
+  .section-head,
+  .block-head,
+  .block-actions,
+  .add-block,
+  .table-actions {
+    display: flex;
+    align-items: center;
+  }
+  .head,
+  .section-head,
+  .block-head {
+    justify-content: space-between;
+  }
+  .editor-title,
+  h2 {
+    margin: 0;
+    color: #aaa;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+  button,
+  input,
+  select,
+  textarea {
+    font: inherit;
+  }
+  button {
+    min-height: 24px;
+    padding: 3px 7px;
+    background: #2a2a2a;
+    color: #ddd;
+    border: 1px solid #3a3a3a;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  button:hover,
+  button:focus-visible {
+    border-color: #777;
+  }
+  button:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
+  }
+  .close {
+    width: 24px;
+    padding: 0;
+    background: transparent;
+  }
+  .slide-fields,
+  .block-form {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 7px;
+  }
+  label {
+    min-width: 0;
+    display: grid;
+    gap: 3px;
+    color: #bbb;
+  }
+  input,
+  select,
+  textarea {
+    min-width: 0;
+    width: 100%;
+    box-sizing: border-box;
+    padding: 4px 6px;
+    background: #1b1b1b;
+    color: #eee;
+    border: 1px solid #3a3a3a;
+    border-radius: 3px;
+  }
+  input[type='color'] {
+    width: 28px;
+    height: 26px;
+    padding: 0;
+  }
+  input[type='file'] {
+    padding: 3px;
+  }
+  textarea {
+    resize: vertical;
+  }
+  .wide,
+  .repeated,
+  .table-wrap,
+  .range-row,
+  .error {
+    grid-column: 1 / -1;
+  }
+  .check {
+    display: flex;
+    align-items: center;
+    align-self: end;
+    gap: 5px;
+    min-height: 27px;
+  }
+  .check input {
+    width: auto;
+  }
+  .blocks-section,
+  .aside-section {
+    display: grid;
+    gap: 7px;
+  }
+  .blocks {
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 7px;
+    list-style: none;
+  }
+  .block {
+    padding: 7px;
+    display: grid;
+    gap: 7px;
+    background: #222;
+    border: 1px solid #363636;
+    border-radius: 5px;
+  }
+  .block-focus {
+    display: flex;
+    gap: 5px;
+    align-items: center;
+    background: transparent;
+    border-color: transparent;
+    color: #ccc;
+    text-transform: capitalize;
+  }
+  .drag {
+    color: #777;
+  }
+  .block-actions,
+  .table-actions {
+    gap: 3px;
+  }
+  .block-actions button {
+    width: 25px;
+    padding: 0;
+  }
+  .danger {
+    color: #f0bcbc;
+    border-color: #593333;
+  }
+  .danger:hover {
+    background: #3a1f1f;
+  }
+  .primary {
+    background: #2a4a78;
+    border-color: #3a6aa0;
+    color: #fff;
+  }
+  .add-block {
+    justify-content: flex-end;
+    gap: 7px;
+  }
+  .add-block label {
+    grid-template-columns: auto 150px;
+    align-items: center;
+    gap: 6px;
+  }
+  .repeated,
+  .table-wrap {
+    display: grid;
+    gap: 5px;
+  }
+  .item-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) repeat(3, 25px);
+    gap: 3px;
+  }
+  .definition-row,
+  .aside-row {
+    display: grid;
+    grid-template-columns: minmax(80px, 0.7fr) minmax(120px, 1.3fr) 25px;
+    gap: 4px;
+  }
+  .aside-row {
+    grid-template-columns: minmax(0, 1fr) 82px 25px;
+  }
+  .add-small {
+    justify-self: start;
+    color: #ddd;
+  }
+  .table-grid {
+    display: grid;
+    grid-template-columns: repeat(var(--columns), minmax(70px, 1fr));
+    gap: 3px;
+    overflow-x: auto;
+  }
+  .header-cell {
+    font-weight: 700;
+  }
+  .range-row {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 4px;
+  }
+  .graph-function {
+    display: grid;
+    grid-template-columns: 28px 78px minmax(0, 1fr) 25px;
+    gap: 4px;
+  }
+  .empty {
+    padding: 10px;
+    color: #999;
+    text-align: center;
+    border: 1px dashed #444;
+    border-radius: 4px;
+  }
+  .error {
+    margin: 0;
+    color: #ef9a9a;
+  }
+  @media (max-width: 420px) {
+    .slide-fields,
+    .block-form {
+      grid-template-columns: 1fr;
+    }
+    .wide,
+    .repeated,
+    .table-wrap,
+    .range-row,
+    .error {
+      grid-column: 1;
+    }
+    .range-row {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+</style>

--- a/src/lib/slides/editor/SlideEditor.svelte
+++ b/src/lib/slides/editor/SlideEditor.svelte
@@ -8,6 +8,7 @@
     SlideCalloutTone,
     SlideGraphBlock,
     SlideLayoutKind,
+    SlideMappingBlock,
     SlideTableBlock,
   } from '$lib/types';
   import {
@@ -28,6 +29,7 @@
   let { slide, onchange, onclose }: Props = $props();
   let addKind = $state<SlideBlock['kind']>('text');
   let imageError = $state('');
+  let mappingSelections = $state<Record<string, { from: number; to: number }>>({});
 
   const layouts: { value: SlideLayoutKind; label: string }[] = [
     { value: 'title', label: 'Title' },
@@ -46,6 +48,7 @@
     { value: 'graph', label: 'Graph' },
     { value: 'callout', label: 'Callout' },
     { value: 'image', label: 'Image' },
+    { value: 'mapping', label: 'Mapping diagram' },
     { value: 'spacer', label: 'Writing space' },
   ];
 
@@ -221,6 +224,96 @@
     range[index] = value;
     if (range[0] >= range[1]) return;
     updateGraph(block, { [axis]: range });
+  }
+
+  function updateMapping(block: SlideMappingBlock, patch: Partial<SlideMappingBlock>): void {
+    onchange(updateBlock(slide, block.id, patch));
+  }
+
+  function setMappingElement(
+    block: SlideMappingBlock,
+    side: 'left' | 'right',
+    index: number,
+    value: string,
+  ): void {
+    updateMapping(block, {
+      [side]: block[side].map((item, itemIndex) => (itemIndex === index ? value : item)),
+    });
+  }
+
+  function addMappingElement(block: SlideMappingBlock, side: 'left' | 'right'): void {
+    updateMapping(block, { [side]: [...block[side], 'Value'] });
+  }
+
+  function removeMappingElement(
+    block: SlideMappingBlock,
+    side: 'left' | 'right',
+    index: number,
+  ): void {
+    const pairKey = side === 'left' ? 'from' : 'to';
+    updateMapping(block, {
+      [side]: block[side].filter((_, itemIndex) => itemIndex !== index),
+      pairs: block.pairs
+        .filter((pair) => pair[pairKey] !== index)
+        .map((pair) => ({
+          ...pair,
+          [pairKey]: pair[pairKey] > index ? pair[pairKey] - 1 : pair[pairKey],
+        })),
+    });
+  }
+
+  function moveMappingElement(
+    block: SlideMappingBlock,
+    side: 'left' | 'right',
+    index: number,
+    direction: -1 | 1,
+  ): void {
+    const destination = index + direction;
+    if (destination < 0 || destination >= block[side].length) return;
+    const values = [...block[side]];
+    [values[index], values[destination]] = [values[destination], values[index]];
+    const pairKey = side === 'left' ? 'from' : 'to';
+    updateMapping(block, {
+      [side]: values,
+      pairs: block.pairs.map((pair) => ({
+        ...pair,
+        [pairKey]:
+          pair[pairKey] === index
+            ? destination
+            : pair[pairKey] === destination
+              ? index
+              : pair[pairKey],
+      })),
+    });
+  }
+
+  function setMappingPair(
+    block: SlideMappingBlock,
+    pairIndex: number,
+    patch: Partial<SlideMappingBlock['pairs'][number]>,
+  ): void {
+    updateMapping(block, {
+      pairs: block.pairs.map((pair, index) => (index === pairIndex ? { ...pair, ...patch } : pair)),
+    });
+  }
+
+  function setMappingSelection(blockId: string, side: 'from' | 'to', value: number): void {
+    const current = mappingSelections[blockId] ?? { from: 0, to: 0 };
+    mappingSelections[blockId] = { ...current, [side]: value };
+  }
+
+  function addMappingPair(block: SlideMappingBlock): void {
+    if (block.left.length === 0 || block.right.length === 0) return;
+    const selection = mappingSelections[block.id] ?? { from: 0, to: 0 };
+    const from = Math.min(block.left.length - 1, Math.max(0, selection.from));
+    const to = Math.min(block.right.length - 1, Math.max(0, selection.to));
+    updateMapping(block, { pairs: [...block.pairs, { from, to }] });
+  }
+
+  function removeMappingPair(block: SlideMappingBlock, index: number): void {
+    updateMapping(block, {
+      pairs: block.pairs.filter((_, pairIndex) => pairIndex !== index),
+    });
   }
 
   async function loadImage(
@@ -871,6 +964,216 @@
               {#if imageError}
                 <p class="error" role="alert">{imageError}</p>
               {/if}
+            {:else if block.kind === 'mapping'}
+              <label>
+                Left label
+                <input
+                  type="text"
+                  value={block.leftLabel}
+                  oninput={(event) =>
+                    updateMapping(block, {
+                      leftLabel: (event.currentTarget as HTMLInputElement).value,
+                    })}
+                />
+              </label>
+              <label>
+                Right label
+                <input
+                  type="text"
+                  value={block.rightLabel}
+                  oninput={(event) =>
+                    updateMapping(block, {
+                      rightLabel: (event.currentTarget as HTMLInputElement).value,
+                    })}
+                />
+              </label>
+              <label class="wide">
+                Caption
+                <input
+                  type="text"
+                  value={block.caption ?? ''}
+                  oninput={(event) =>
+                    updateMapping(block, {
+                      caption: (event.currentTarget as HTMLInputElement).value,
+                    })}
+                />
+              </label>
+              <div class="wide mapping-columns">
+                <section class="mapping-side" aria-label="Left mapping elements">
+                  <strong>{block.leftLabel || 'Left elements'}</strong>
+                  {#each block.left as item, itemIndex}
+                    <div class="mapping-item">
+                      <input
+                        type="text"
+                        value={item}
+                        aria-label={`Left element ${itemIndex + 1}`}
+                        oninput={(event) =>
+                          setMappingElement(
+                            block,
+                            'left',
+                            itemIndex,
+                            (event.currentTarget as HTMLInputElement).value,
+                          )}
+                      />
+                      <button
+                        type="button"
+                        aria-label={`Move left element ${itemIndex + 1} up`}
+                        disabled={itemIndex === 0}
+                        onclick={() => moveMappingElement(block, 'left', itemIndex, -1)}>↑</button
+                      >
+                      <button
+                        type="button"
+                        aria-label={`Move left element ${itemIndex + 1} down`}
+                        disabled={itemIndex === block.left.length - 1}
+                        onclick={() => moveMappingElement(block, 'left', itemIndex, 1)}>↓</button
+                      >
+                      <button
+                        type="button"
+                        class="danger"
+                        aria-label={`Delete left element ${itemIndex + 1}`}
+                        onclick={() => removeMappingElement(block, 'left', itemIndex)}>×</button
+                      >
+                    </div>
+                  {/each}
+                  <button
+                    type="button"
+                    class="add-small"
+                    onclick={() => addMappingElement(block, 'left')}>+ left value</button
+                  >
+                </section>
+                <section class="mapping-side" aria-label="Right mapping elements">
+                  <strong>{block.rightLabel || 'Right elements'}</strong>
+                  {#each block.right as item, itemIndex}
+                    <div class="mapping-item">
+                      <input
+                        type="text"
+                        value={item}
+                        aria-label={`Right element ${itemIndex + 1}`}
+                        oninput={(event) =>
+                          setMappingElement(
+                            block,
+                            'right',
+                            itemIndex,
+                            (event.currentTarget as HTMLInputElement).value,
+                          )}
+                      />
+                      <button
+                        type="button"
+                        aria-label={`Move right element ${itemIndex + 1} up`}
+                        disabled={itemIndex === 0}
+                        onclick={() => moveMappingElement(block, 'right', itemIndex, -1)}>↑</button
+                      >
+                      <button
+                        type="button"
+                        aria-label={`Move right element ${itemIndex + 1} down`}
+                        disabled={itemIndex === block.right.length - 1}
+                        onclick={() => moveMappingElement(block, 'right', itemIndex, 1)}>↓</button
+                      >
+                      <button
+                        type="button"
+                        class="danger"
+                        aria-label={`Delete right element ${itemIndex + 1}`}
+                        onclick={() => removeMappingElement(block, 'right', itemIndex)}>×</button
+                      >
+                    </div>
+                  {/each}
+                  <button
+                    type="button"
+                    class="add-small"
+                    onclick={() => addMappingElement(block, 'right')}>+ right value</button
+                  >
+                </section>
+              </div>
+              <div class="wide mapping-pairs">
+                <strong>Arrows</strong>
+                {#each block.pairs as pair, pairIndex}
+                  <div class="mapping-pair">
+                    <select
+                      value={pair.from}
+                      aria-label={`Arrow ${pairIndex + 1} left element`}
+                      onchange={(event) =>
+                        setMappingPair(block, pairIndex, {
+                          from: Number((event.currentTarget as HTMLSelectElement).value),
+                        })}
+                    >
+                      {#each block.left as item, itemIndex}
+                        <option value={itemIndex}>{item || `Left ${itemIndex + 1}`}</option>
+                      {/each}
+                    </select>
+                    <span aria-hidden="true">→</span>
+                    <select
+                      value={pair.to}
+                      aria-label={`Arrow ${pairIndex + 1} right element`}
+                      onchange={(event) =>
+                        setMappingPair(block, pairIndex, {
+                          to: Number((event.currentTarget as HTMLSelectElement).value),
+                        })}
+                    >
+                      {#each block.right as item, itemIndex}
+                        <option value={itemIndex}>{item || `Right ${itemIndex + 1}`}</option>
+                      {/each}
+                    </select>
+                    <button
+                      type="button"
+                      class="danger"
+                      aria-label={`Delete arrow ${pairIndex + 1}`}
+                      onclick={() => removeMappingPair(block, pairIndex)}>×</button
+                    >
+                  </div>
+                {/each}
+                <div class="new-mapping-pair">
+                  <label>
+                    From
+                    <select
+                      value={mappingSelections[block.id]?.from ?? 0}
+                      disabled={block.left.length === 0}
+                      onchange={(event) =>
+                        setMappingSelection(
+                          block.id,
+                          'from',
+                          Number((event.currentTarget as HTMLSelectElement).value),
+                        )}
+                    >
+                      {#each block.left as item, itemIndex}
+                        <option value={itemIndex}>{item || `Left ${itemIndex + 1}`}</option>
+                      {/each}
+                    </select>
+                  </label>
+                  <label>
+                    To
+                    <select
+                      value={mappingSelections[block.id]?.to ?? 0}
+                      disabled={block.right.length === 0}
+                      onchange={(event) =>
+                        setMappingSelection(
+                          block.id,
+                          'to',
+                          Number((event.currentTarget as HTMLSelectElement).value),
+                        )}
+                    >
+                      {#each block.right as item, itemIndex}
+                        <option value={itemIndex}>{item || `Right ${itemIndex + 1}`}</option>
+                      {/each}
+                    </select>
+                  </label>
+                  <button
+                    type="button"
+                    disabled={block.left.length === 0 || block.right.length === 0}
+                    onclick={() => addMappingPair(block)}>+ arrow</button
+                  >
+                </div>
+              </div>
+              <label>
+                Height
+                <input
+                  type="number"
+                  min="1"
+                  max="2000"
+                  value={block.height}
+                  onchange={(event) =>
+                    updateMapping(block, { height: numberValue(event, block.height) })}
+                />
+              </label>
             {:else if block.kind === 'spacer'}
               <label>
                 Writing-space height
@@ -1169,6 +1472,38 @@
     grid-template-columns: 28px 78px minmax(0, 1fr) 25px;
     gap: 4px;
   }
+  .mapping-columns {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+  }
+  .mapping-side,
+  .mapping-pairs {
+    display: grid;
+    gap: 5px;
+  }
+  .mapping-side strong,
+  .mapping-pairs strong {
+    color: #bbb;
+    font-size: 11px;
+  }
+  .mapping-item {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) repeat(3, 25px);
+    gap: 3px;
+  }
+  .mapping-pair {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr) 25px;
+    gap: 5px;
+    align-items: center;
+  }
+  .new-mapping-pair {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
+    gap: 5px;
+    align-items: end;
+  }
   .empty {
     padding: 10px;
     color: #999;
@@ -1194,6 +1529,9 @@
     }
     .range-row {
       grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+    .mapping-columns {
+      grid-template-columns: 1fr;
     }
   }
 </style>

--- a/src/lib/slides/editor/SlideOutline.svelte
+++ b/src/lib/slides/editor/SlideOutline.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+  import type { Slide } from '$lib/types';
+
+  interface Props {
+    slides: { pageIndex: number; slide: Slide }[];
+    activeIndex: number;
+    onselect: (pageIndex: number) => void;
+  }
+
+  let { slides, activeIndex, onselect }: Props = $props();
+</script>
+
+<nav class="outline" aria-label="Slide outline">
+  <h2>Slides</h2>
+  <ol>
+    {#each slides as entry, index (entry.pageIndex)}
+      <li>
+        <button
+          type="button"
+          class:active={entry.pageIndex === activeIndex}
+          aria-current={entry.pageIndex === activeIndex ? 'page' : undefined}
+          aria-label={`Slide ${index + 1}: ${entry.slide.title || 'Untitled slide'}`}
+          onclick={() => onselect(entry.pageIndex)}
+        >
+          <span class="number">{index + 1}</span>
+          <span class="title">{entry.slide.title || 'Untitled slide'}</span>
+        </button>
+      </li>
+    {/each}
+  </ol>
+</nav>
+
+<style>
+  .outline {
+    width: 190px;
+    padding: 10px;
+    box-sizing: border-box;
+    background: #252525;
+    color: #e8e8e8;
+    border: 1px solid #1a1a1a;
+    border-radius: 7px;
+    font-size: 12px;
+  }
+  h2 {
+    margin: 0 0 8px;
+    color: #aaa;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+  ol {
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 3px;
+    list-style: none;
+  }
+  button {
+    width: 100%;
+    padding: 5px 6px;
+    display: grid;
+    grid-template-columns: 22px minmax(0, 1fr);
+    gap: 5px;
+    align-items: center;
+    text-align: left;
+    background: transparent;
+    color: #ddd;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  button:hover,
+  button:focus-visible {
+    background: #2e2e2e;
+    border-color: #444;
+  }
+  button.active {
+    background: #2a4a78;
+    border-color: #3a6aa0;
+    color: #fff;
+  }
+  .number {
+    color: #999;
+    font-variant-numeric: tabular-nums;
+    text-align: right;
+  }
+  .active .number {
+    color: #d4e5ff;
+  }
+  .title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+</style>

--- a/src/lib/slides/editor/TemplatePicker.svelte
+++ b/src/lib/slides/editor/TemplatePicker.svelte
@@ -1,0 +1,180 @@
+<script lang="ts">
+  import type { Slide } from '$lib/types';
+  import { slideTemplates, type SlideTemplate } from '$lib/slides/templates';
+
+  interface Props {
+    onpick: (slide: Slide) => void;
+    onclose: () => void;
+  }
+
+  let { onpick, onclose }: Props = $props();
+  let query = $state('');
+
+  const groupedTemplates = $derived.by(() => {
+    const needle = query.trim().toLowerCase();
+    const groups = new Map<string, SlideTemplate[]>();
+    for (const template of slideTemplates) {
+      const searchable = `${template.name} ${template.description} ${template.group}`.toLowerCase();
+      if (needle && !searchable.includes(needle)) continue;
+      const group = groups.get(template.group) ?? [];
+      group.push(template);
+      groups.set(template.group, group);
+    }
+    return [...groups.entries()];
+  });
+</script>
+
+<div
+  class="picker"
+  role="dialog"
+  aria-modal="true"
+  aria-label="Choose a slide template"
+  tabindex="-1"
+>
+  <header>
+    <div>
+      <h2>New slide</h2>
+      <p>Choose a teaching-slide scaffold.</p>
+    </div>
+    <button type="button" class="close" aria-label="Close template picker" onclick={onclose}>
+      ×
+    </button>
+  </header>
+
+  <label class="search">
+    <span>Search templates</span>
+    <input type="search" bind:value={query} placeholder="Search…" />
+  </label>
+
+  <div class="groups">
+    {#each groupedTemplates as [group, templates] (group)}
+      <section class="group">
+        <h3>{group}</h3>
+        <div class="cards">
+          {#each templates as template (template.id)}
+            <button type="button" class="card" onclick={() => onpick(template.build())}>
+              <strong>{template.name}</strong>
+              <span>{template.description}</span>
+            </button>
+          {/each}
+        </div>
+      </section>
+    {:else}
+      <p class="empty">No templates match “{query}”.</p>
+    {/each}
+  </div>
+</div>
+
+<style>
+  .picker {
+    width: min(620px, calc(100vw - 32px));
+    max-height: min(720px, calc(100vh - 32px));
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 14px;
+    box-sizing: border-box;
+    background: #252525;
+    color: #e8e8e8;
+    border: 1px solid #1a1a1a;
+    border-radius: 8px;
+    box-shadow: 0 10px 32px rgba(0, 0, 0, 0.6);
+    font-size: 12px;
+  }
+  header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+  }
+  h2,
+  h3,
+  p {
+    margin: 0;
+  }
+  h2 {
+    font-size: 15px;
+  }
+  header p {
+    margin-top: 3px;
+    color: #aaa;
+  }
+  .close {
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    background: transparent;
+    color: #ccc;
+    border: 1px solid #3a3a3a;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  .search {
+    display: grid;
+    gap: 4px;
+    color: #bbb;
+  }
+  input {
+    background: #1b1b1b;
+    color: #eee;
+    border: 1px solid #3a3a3a;
+    border-radius: 4px;
+    padding: 6px 8px;
+  }
+  .groups {
+    overflow: auto;
+    display: grid;
+    gap: 14px;
+    padding-right: 2px;
+  }
+  .group {
+    display: grid;
+    gap: 6px;
+  }
+  h3 {
+    color: #aaa;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+  .cards {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 7px;
+  }
+  .card {
+    min-height: 62px;
+    padding: 9px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+    text-align: left;
+    background: #2a2a2a;
+    color: #eee;
+    border: 1px solid #3a3a3a;
+    border-radius: 5px;
+    cursor: pointer;
+  }
+  .card:hover,
+  .card:focus-visible {
+    border-color: #5d83b8;
+    background: #2d3540;
+  }
+  .card span {
+    color: #aaa;
+    font-size: 11px;
+    line-height: 1.3;
+  }
+  .empty {
+    color: #aaa;
+    padding: 20px 4px;
+  }
+  @media (max-width: 520px) {
+    .cards {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/src/lib/slides/index.ts
+++ b/src/lib/slides/index.ts
@@ -1,7 +1,16 @@
 export { defaultSlideTheme, isSafeSlideTheme, resolveTheme } from './theme';
 export { layoutSlide, measureBlock } from './layout';
 export type { LayoutBox, PlacedBlock, SlideLayout } from './layout';
+export { formatAlpha, formatRoman, presentList } from './listMarkers';
+export type { PresentedListItem } from './listMarkers';
 export { default as SlideLayer } from './render/SlideLayer.svelte';
+export { diagramGeometry } from './render/diagramGeometry';
+export type {
+  DiagramEdgeGeometry,
+  DiagramGeometry,
+  DiagramNodeGeometry,
+  DiagramPoint,
+} from './render/diagramGeometry';
 export { renderSlideBackground } from './render/renderSlideToCanvas';
 export { graphObjectForSlide, graphThemeForSlide } from './render/graphAdapter';
 export { mappingGeometry, MAX_MAPPING_ITEMS } from './render/mappingGeometry';
@@ -12,3 +21,13 @@ export type {
   MappingOval,
   MappingPoint,
 } from './render/mappingGeometry';
+export {
+  MAX_NUMBER_LINE_LABELS,
+  MAX_NUMBER_LINE_TICKS,
+  slideNumberLineGeometry,
+} from './render/numberLineGeometry';
+export type {
+  NumberLineMarkGeometry,
+  NumberLineTick,
+  SlideNumberLineGeometry,
+} from './render/numberLineGeometry';

--- a/src/lib/slides/index.ts
+++ b/src/lib/slides/index.ts
@@ -4,3 +4,11 @@ export type { LayoutBox, PlacedBlock, SlideLayout } from './layout';
 export { default as SlideLayer } from './render/SlideLayer.svelte';
 export { renderSlideBackground } from './render/renderSlideToCanvas';
 export { graphObjectForSlide, graphThemeForSlide } from './render/graphAdapter';
+export { mappingGeometry, MAX_MAPPING_ITEMS } from './render/mappingGeometry';
+export type {
+  MappingArrow,
+  MappingGeometry,
+  MappingItemPosition,
+  MappingOval,
+  MappingPoint,
+} from './render/mappingGeometry';

--- a/src/lib/slides/index.ts
+++ b/src/lib/slides/index.ts
@@ -1,0 +1,6 @@
+export { defaultSlideTheme, isSafeSlideTheme, resolveTheme } from './theme';
+export { layoutSlide, measureBlock } from './layout';
+export type { LayoutBox, PlacedBlock, SlideLayout } from './layout';
+export { default as SlideLayer } from './render/SlideLayer.svelte';
+export { renderSlideBackground } from './render/renderSlideToCanvas';
+export { graphObjectForSlide, graphThemeForSlide } from './render/graphAdapter';

--- a/src/lib/slides/layout.ts
+++ b/src/lib/slides/layout.ts
@@ -54,6 +54,21 @@ function textHeight(text: string, fontSize: number, width: number): number {
   return lineCount(text, fontSize, width) * fontSize * LINE_HEIGHT_RATIO;
 }
 
+/**
+ * Vertical space a block caption occupies, including the gap beneath it.
+ *
+ * Exported so the renderer subtracts exactly what the layouter reserved; a
+ * fixed estimate here would stretch the block's content once a caption wraps.
+ */
+export function captionHeight(
+  caption: string | undefined,
+  fontSize: number,
+  width: number,
+): number {
+  if (!caption) return 0;
+  return textHeight(caption, fontSize, width) + fontSize * 0.45;
+}
+
 function normalizedColumnWeights(block: Extract<SlideBlock, { kind: 'table' }>, count: number) {
   const weights = block.columnWeights;
   if (
@@ -111,10 +126,7 @@ export function measureBlock(block: SlideBlock, theme: SlideTheme, width: number
         }
         return height + rowHeight;
       }, 0);
-      const captionHeight = block.caption
-        ? textHeight(block.caption, fontSize, availableWidth) + fontSize * 0.45
-        : 0;
-      return captionHeight + rowsHeight;
+      return captionHeight(block.caption, fontSize, availableWidth) + rowsHeight;
     }
     case 'math': {
       const fontSize = safeFontSize(block.fontSize, bodySize);
@@ -122,10 +134,7 @@ export function measureBlock(block: SlideBlock, theme: SlideTheme, width: number
     }
     case 'graph': {
       const graphHeight = finiteNonNegative(block.height);
-      return (
-        graphHeight +
-        (block.caption ? textHeight(block.caption, bodySize, availableWidth) + bodySize * 0.45 : 0)
-      );
+      return graphHeight + captionHeight(block.caption, bodySize, availableWidth);
     }
     case 'mapping':
     case 'diagram':

--- a/src/lib/slides/layout.ts
+++ b/src/lib/slides/layout.ts
@@ -131,6 +131,8 @@ export function measureBlock(block: SlideBlock, theme: SlideTheme, width: number
         (block.caption ? textHeight(block.caption, bodySize, availableWidth) + bodySize * 0.45 : 0)
       );
     }
+    case 'mapping':
+      return finiteNonNegative(block.height);
     case 'callout': {
       const fontSize = safeFontSize(block.fontSize, bodySize);
       const padding = fontSize * 0.8;
@@ -151,6 +153,7 @@ function blockGap(block: SlideBlock, bodySize: number): number {
   switch (block.kind) {
     case 'graph':
     case 'image':
+    case 'mapping':
       return bodySize * 1.15;
     case 'table':
       return bodySize;

--- a/src/lib/slides/layout.ts
+++ b/src/lib/slides/layout.ts
@@ -1,0 +1,359 @@
+import type { Slide, SlideAlign, SlideBlock, SlideTheme } from '$lib/types';
+
+export interface LayoutBox {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface PlacedBlock {
+  block: SlideBlock;
+  box: LayoutBox;
+}
+
+export interface SlideLayout {
+  title: { text: string; box: LayoutBox; align: SlideAlign; fontSize: number } | null;
+  subtitle: { text: string; box: LayoutBox; fontSize: number } | null;
+  blocks: PlacedBlock[];
+  asides: PlacedBlock[];
+  overflow: boolean;
+}
+
+/**
+ * Average Latin glyph width as a fraction of font size. Keeping this estimate
+ * centralized makes the intentionally approximate wrapping math predictable.
+ */
+const AVERAGE_GLYPH_WIDTH_RATIO = 0.52;
+const LINE_HEIGHT_RATIO = 1.35;
+const HORIZONTAL_MARGIN_RATIO = 0.065;
+const VERTICAL_MARGIN_RATIO = 0.08;
+const MAX_COLUMNS = 6;
+
+function finiteNonNegative(value: number, fallback = 0): number {
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function safeFontSize(value: number | undefined, fallback: number): number {
+  return Number.isFinite(value) && (value ?? 0) > 0 ? (value as number) : fallback;
+}
+
+function lineCount(text: string, fontSize: number, width: number): number {
+  if (text.length === 0) return 1;
+  const charsPerLine = Math.max(
+    1,
+    Math.floor(finiteNonNegative(width) / (fontSize * AVERAGE_GLYPH_WIDTH_RATIO)),
+  );
+  return text.split(/\r?\n/).reduce((total, line) => {
+    return total + Math.max(1, Math.ceil(line.length / charsPerLine));
+  }, 0);
+}
+
+function textHeight(text: string, fontSize: number, width: number): number {
+  return lineCount(text, fontSize, width) * fontSize * LINE_HEIGHT_RATIO;
+}
+
+function clampedLevel(level: number): number {
+  if (!Number.isFinite(level)) return 0;
+  return Math.min(3, Math.max(0, Math.floor(level)));
+}
+
+function normalizedColumnWeights(block: Extract<SlideBlock, { kind: 'table' }>, count: number) {
+  const weights = block.columnWeights;
+  if (
+    !weights ||
+    weights.length !== count ||
+    weights.some((weight) => !Number.isFinite(weight) || weight <= 0)
+  ) {
+    return Array.from({ length: count }, () => 1);
+  }
+  return weights;
+}
+
+function tableColumnCount(block: Extract<SlideBlock, { kind: 'table' }>): number {
+  return Math.max(1, block.header.length, ...block.rows.map((row) => row.length));
+}
+
+export function measureBlock(block: SlideBlock, theme: SlideTheme, width: number): number {
+  const availableWidth = finiteNonNegative(width);
+  const bodySize = safeFontSize(theme.bodySize, 13);
+  switch (block.kind) {
+    case 'text': {
+      const fontSize = safeFontSize(block.fontSize, bodySize);
+      return textHeight(block.text, fontSize, availableWidth);
+    }
+    case 'list': {
+      const fontSize = safeFontSize(block.fontSize, bodySize);
+      return block.items.reduce((height, item) => {
+        const indent = clampedLevel(item.level) * fontSize * 1.4;
+        const itemWidth = Math.max(0, availableWidth - indent - fontSize * 1.5);
+        return height + textHeight(item.text, fontSize, itemWidth);
+      }, 0);
+    }
+    case 'definitions': {
+      const fontSize = safeFontSize(block.fontSize, bodySize);
+      return block.items.reduce((height, item) => {
+        return height + textHeight(`${item.term}: ${item.text}`, fontSize, availableWidth);
+      }, 0);
+    }
+    case 'table': {
+      const fontSize = safeFontSize(block.fontSize, bodySize);
+      const columns = tableColumnCount(block);
+      const weights = normalizedColumnWeights(block, columns);
+      const totalWeight = weights.reduce((sum, weight) => sum + weight, 0);
+      const cellPadding = fontSize * 0.55;
+      const rows = block.header.length > 0 ? [block.header, ...block.rows] : block.rows;
+      const rowsHeight = rows.reduce((height, row) => {
+        let rowHeight = fontSize * LINE_HEIGHT_RATIO + cellPadding * 2;
+        for (let column = 0; column < columns; column += 1) {
+          const columnWidth = (availableWidth * weights[column]) / totalWeight;
+          const cellWidth = Math.max(0, columnWidth - cellPadding * 2);
+          rowHeight = Math.max(
+            rowHeight,
+            textHeight(row[column] ?? '', fontSize, cellWidth) + cellPadding * 2,
+          );
+        }
+        return height + rowHeight;
+      }, 0);
+      const captionHeight = block.caption
+        ? textHeight(block.caption, fontSize, availableWidth) + fontSize * 0.45
+        : 0;
+      return captionHeight + rowsHeight;
+    }
+    case 'math': {
+      const fontSize = safeFontSize(block.fontSize, bodySize);
+      return fontSize * (block.display ? 1.9 : LINE_HEIGHT_RATIO);
+    }
+    case 'graph': {
+      const graphHeight = finiteNonNegative(block.height);
+      return (
+        graphHeight +
+        (block.caption ? textHeight(block.caption, bodySize, availableWidth) + bodySize * 0.45 : 0)
+      );
+    }
+    case 'callout': {
+      const fontSize = safeFontSize(block.fontSize, bodySize);
+      const padding = fontSize * 0.8;
+      return (
+        textHeight(block.text, fontSize, Math.max(0, availableWidth - padding * 2)) + padding * 2
+      );
+    }
+    case 'image':
+    case 'spacer':
+      return finiteNonNegative(block.height);
+  }
+}
+
+function blockGap(block: SlideBlock, bodySize: number): number {
+  if (Number.isFinite(block.marginTop) && (block.marginTop ?? 0) >= 0) {
+    return block.marginTop as number;
+  }
+  switch (block.kind) {
+    case 'graph':
+    case 'image':
+      return bodySize * 1.15;
+    case 'table':
+      return bodySize;
+    case 'math':
+    case 'callout':
+      return bodySize * 0.8;
+    case 'list':
+    case 'definitions':
+      return bodySize * 0.65;
+    case 'text':
+      return bodySize * 0.45;
+    case 'spacer':
+      return 0;
+  }
+}
+
+function clampColumnCount(value: number | undefined): number {
+  if (!Number.isFinite(value)) return 2;
+  return Math.min(MAX_COLUMNS, Math.max(1, Math.floor(value as number)));
+}
+
+function makeBox(x: number, y: number, w: number, h: number): LayoutBox {
+  return {
+    x: finiteNonNegative(x),
+    y: finiteNonNegative(y),
+    w: finiteNonNegative(w),
+    h: finiteNonNegative(h),
+  };
+}
+
+function stackBlocks(
+  blocks: SlideBlock[],
+  theme: SlideTheme,
+  x: number,
+  startY: number,
+  width: number,
+): { blocks: PlacedBlock[]; bottom: number } {
+  const placed: PlacedBlock[] = [];
+  let y = startY;
+  for (const block of blocks) {
+    y += blockGap(block, theme.bodySize);
+    const height = measureBlock(block, theme, width);
+    placed.push({ block, box: makeBox(x, y, width, height) });
+    y += height;
+  }
+  return { blocks: placed, bottom: y };
+}
+
+function placeAsides(
+  slide: Slide,
+  theme: SlideTheme,
+  pageWidth: number,
+  marginX: number,
+  marginY: number,
+): { blocks: PlacedBlock[]; bottom: number } {
+  const asideWidth = Math.max(0, (pageWidth - marginX * 2) * 0.3);
+  return stackBlocks(
+    slide.aside ?? [],
+    theme,
+    Math.max(0, pageWidth - marginX - asideWidth),
+    marginY,
+    asideWidth,
+  );
+}
+
+export function layoutSlide(
+  slide: Slide,
+  theme: SlideTheme,
+  pageWidth: number,
+  pageHeight: number,
+): SlideLayout {
+  const width = finiteNonNegative(pageWidth);
+  const height = finiteNonNegative(pageHeight);
+  const marginX = width * HORIZONTAL_MARGIN_RATIO;
+  const marginY = Math.min(marginX, height * VERTICAL_MARGIN_RATIO);
+  const innerWidth = Math.max(0, width - marginX * 2);
+  const contentBottom = Math.max(0, height - marginY);
+  const asideLayout = placeAsides(slide, theme, width, marginX, marginY);
+  const hasAsides = asideLayout.blocks.length > 0;
+  const titleWidth = hasAsides ? innerWidth * 0.64 : innerWidth;
+  const headingSize = safeFontSize(theme.headingSize, 20);
+  const titleSize = safeFontSize(theme.titleSize, 34);
+  const bodySize = safeFontSize(theme.bodySize, 13);
+
+  let title: SlideLayout['title'] = null;
+  let subtitle: SlideLayout['subtitle'] = null;
+  let contentTop = marginY;
+
+  if (slide.layout === 'title') {
+    const heroWidth = innerWidth * 0.82;
+    const heroX = marginX + (innerWidth - heroWidth) / 2;
+    const titleHeight = textHeight(slide.title, titleSize, heroWidth);
+    const titleY = height * 0.2;
+    title = {
+      text: slide.title,
+      box: makeBox(heroX, titleY, heroWidth, titleHeight),
+      align: 'center',
+      fontSize: titleSize,
+    };
+    if (slide.subtitle) {
+      const subtitleSize = Math.max(bodySize, headingSize * 0.75);
+      const subtitleY = titleY + titleHeight + subtitleSize * 0.8;
+      subtitle = {
+        text: slide.subtitle,
+        box: makeBox(
+          heroX,
+          subtitleY,
+          heroWidth,
+          textHeight(slide.subtitle, subtitleSize, heroWidth),
+        ),
+        fontSize: subtitleSize,
+      };
+    }
+    contentTop = Math.max(
+      height * 0.52,
+      (subtitle?.box.y ?? titleY) + (subtitle?.box.h ?? titleHeight),
+    );
+  } else if (slide.layout !== 'blank') {
+    const titleHeight = textHeight(slide.title, headingSize, titleWidth);
+    title = {
+      text: slide.title,
+      box: makeBox(marginX, marginY, titleWidth, titleHeight),
+      align: 'left',
+      fontSize: headingSize,
+    };
+    contentTop = marginY + titleHeight + headingSize * 0.9;
+  }
+
+  let placed: PlacedBlock[] = [];
+  let flowBottom = contentTop;
+
+  if (slide.layout === 'columns') {
+    const columns = clampColumnCount(slide.columnCount);
+    const gap = innerWidth * 0.035;
+    const columnWidth = Math.max(0, (innerWidth - gap * (columns - 1)) / columns);
+    const columnBottoms = Array.from({ length: columns }, () => contentTop);
+    for (const block of slide.blocks) {
+      let column = 0;
+      for (let index = 1; index < columns; index += 1) {
+        if (columnBottoms[index] < columnBottoms[column]) column = index;
+      }
+      const y = columnBottoms[column] + blockGap(block, bodySize);
+      const blockHeight = measureBlock(block, theme, columnWidth);
+      const x = marginX + column * (columnWidth + gap);
+      placed.push({ block, box: makeBox(x, y, columnWidth, blockHeight) });
+      columnBottoms[column] = y + blockHeight;
+    }
+    flowBottom = Math.max(contentTop, ...columnBottoms);
+  } else if (slide.layout === 'grid') {
+    const columns = clampColumnCount(slide.columnCount);
+    const rows = Math.ceil(slide.blocks.length / columns);
+    const gapX = innerWidth * 0.025;
+    const availableHeight = Math.max(0, contentBottom - contentTop);
+    const gapY = rows > 1 ? availableHeight * 0.035 : 0;
+    const cellWidth = Math.max(0, (innerWidth - gapX * (columns - 1)) / columns);
+    const cellHeight = rows > 0 ? Math.max(0, (availableHeight - gapY * (rows - 1)) / rows) : 0;
+    const padX = cellWidth * 0.05;
+    const padY = cellHeight * 0.06;
+    for (let index = 0; index < slide.blocks.length; index += 1) {
+      const row = Math.floor(index / columns);
+      const column = index % columns;
+      const block = slide.blocks[index];
+      placed.push({
+        block,
+        box: makeBox(
+          marginX + column * (cellWidth + gapX) + padX,
+          contentTop + row * (cellHeight + gapY) + padY,
+          Math.max(0, cellWidth - padX * 2),
+          Math.max(0, cellHeight - padY * 2),
+        ),
+      });
+    }
+    flowBottom = rows > 0 ? contentTop + rows * cellHeight + (rows - 1) * gapY : contentTop;
+  } else {
+    const stacked = stackBlocks(slide.blocks, theme, marginX, contentTop, innerWidth);
+    placed = stacked.blocks;
+    flowBottom = stacked.bottom;
+  }
+
+  const gridOverflow =
+    slide.layout === 'grid' &&
+    placed.some(({ block, box }) => measureBlock(block, theme, box.w) > box.h);
+  const boundsOverflow = placed.some(
+    ({ box }) =>
+      box.x < marginX - 1e-6 ||
+      box.x + box.w > width - marginX + 1e-6 ||
+      box.y < 0 ||
+      box.y + box.h > contentBottom + 1e-6,
+  );
+  const chromeOverflow =
+    (title !== null && title.box.y + title.box.h > contentBottom) ||
+    (subtitle !== null && subtitle.box.y + subtitle.box.h > contentBottom);
+
+  return {
+    title,
+    subtitle,
+    blocks: placed,
+    asides: asideLayout.blocks,
+    overflow:
+      gridOverflow ||
+      boundsOverflow ||
+      chromeOverflow ||
+      flowBottom > contentBottom + 1e-6 ||
+      asideLayout.bottom > contentBottom + 1e-6,
+  };
+}

--- a/src/lib/slides/layout.ts
+++ b/src/lib/slides/layout.ts
@@ -1,4 +1,5 @@
 import type { Slide, SlideAlign, SlideBlock, SlideTheme } from '$lib/types';
+import { presentList } from './listMarkers';
 
 export interface LayoutBox {
   x: number;
@@ -53,11 +54,6 @@ function textHeight(text: string, fontSize: number, width: number): number {
   return lineCount(text, fontSize, width) * fontSize * LINE_HEIGHT_RATIO;
 }
 
-function clampedLevel(level: number): number {
-  if (!Number.isFinite(level)) return 0;
-  return Math.min(3, Math.max(0, Math.floor(level)));
-}
-
 function normalizedColumnWeights(block: Extract<SlideBlock, { kind: 'table' }>, count: number) {
   const weights = block.columnWeights;
   if (
@@ -84,9 +80,9 @@ export function measureBlock(block: SlideBlock, theme: SlideTheme, width: number
     }
     case 'list': {
       const fontSize = safeFontSize(block.fontSize, bodySize);
-      return block.items.reduce((height, item) => {
-        const indent = clampedLevel(item.level) * fontSize * 1.4;
-        const itemWidth = Math.max(0, availableWidth - indent - fontSize * 1.5);
+      return presentList(block).reduce((height, item) => {
+        const reservedWidth = (item.indentEm + item.markerWidthEm + 0.55) * fontSize;
+        const itemWidth = Math.max(0, availableWidth - reservedWidth);
         return height + textHeight(item.text, fontSize, itemWidth);
       }, 0);
     }
@@ -132,6 +128,8 @@ export function measureBlock(block: SlideBlock, theme: SlideTheme, width: number
       );
     }
     case 'mapping':
+    case 'diagram':
+    case 'numberline':
       return finiteNonNegative(block.height);
     case 'callout': {
       const fontSize = safeFontSize(block.fontSize, bodySize);
@@ -154,6 +152,8 @@ function blockGap(block: SlideBlock, bodySize: number): number {
     case 'graph':
     case 'image':
     case 'mapping':
+    case 'diagram':
+    case 'numberline':
       return bodySize * 1.15;
     case 'table':
       return bodySize;

--- a/src/lib/slides/listMarkers.ts
+++ b/src/lib/slides/listMarkers.ts
@@ -1,0 +1,116 @@
+import type { SlideListBlock, SlideListMarker } from '$lib/types';
+
+type ResolvedListMarker = SlideListMarker | 'hollow' | 'dash';
+
+export interface PresentedListItem {
+  text: string;
+  level: number;
+  marker: string;
+  markerWidthEm: number;
+  indentEm: number;
+}
+
+const NUMBERED_SEQUENCE: readonly ResolvedListMarker[] = ['decimal', 'alpha', 'roman', 'alpha'];
+const BULLET_SEQUENCE: readonly ResolvedListMarker[] = ['bullet', 'hollow', 'dash', 'hollow'];
+
+function clampLevel(level: number): number {
+  if (!Number.isFinite(level)) return 0;
+  return Math.min(3, Math.max(0, Math.floor(level)));
+}
+
+export function formatAlpha(value: number): string {
+  if (!Number.isInteger(value) || value < 1) return '';
+  let remaining = value;
+  let result = '';
+  while (remaining > 0) {
+    remaining -= 1;
+    result = String.fromCharCode(97 + (remaining % 26)) + result;
+    remaining = Math.floor(remaining / 26);
+  }
+  return result;
+}
+
+export function formatRoman(value: number): string {
+  if (!Number.isInteger(value) || value < 1) return '';
+  if (value > 3999) return String(value);
+  const numerals: ReadonlyArray<readonly [number, string]> = [
+    [1000, 'm'],
+    [900, 'cm'],
+    [500, 'd'],
+    [400, 'cd'],
+    [100, 'c'],
+    [90, 'xc'],
+    [50, 'l'],
+    [40, 'xl'],
+    [10, 'x'],
+    [9, 'ix'],
+    [5, 'v'],
+    [4, 'iv'],
+    [1, 'i'],
+  ];
+  let remaining = value;
+  let result = '';
+  for (const [amount, numeral] of numerals) {
+    while (remaining >= amount) {
+      result += numeral;
+      remaining -= amount;
+    }
+  }
+  return result;
+}
+
+function automaticMarker(marker: SlideListMarker, level: number): ResolvedListMarker {
+  if (marker === 'bullet') return BULLET_SEQUENCE[level];
+  if (marker === 'decimal') return NUMBERED_SEQUENCE[level];
+  if (marker === 'alpha') return NUMBERED_SEQUENCE[(level + 1) % NUMBERED_SEQUENCE.length];
+  if (marker === 'roman') return NUMBERED_SEQUENCE[(level + 2) % NUMBERED_SEQUENCE.length];
+  return 'none';
+}
+
+function markerAtLevel(block: SlideListBlock, level: number): ResolvedListMarker {
+  return block.markerByLevel?.[level] ?? automaticMarker(block.marker, level);
+}
+
+function markerText(marker: ResolvedListMarker, count: number): string {
+  switch (marker) {
+    case 'bullet':
+      return '•';
+    case 'hollow':
+      return '◦';
+    case 'dash':
+      return '–';
+    case 'decimal':
+      return `${count}.`;
+    case 'alpha':
+      return `${formatAlpha(count)}.`;
+    case 'roman':
+      return `${formatRoman(count)}.`;
+    case 'none':
+      return '';
+  }
+}
+
+function markerWidth(marker: string): number {
+  return marker.length === 0 ? 0 : Math.max(1.2, marker.length * 0.62 + 0.45);
+}
+
+/** Resolve nested marker styles and sibling-local numbering for a flat list. */
+export function presentList(block: SlideListBlock): PresentedListItem[] {
+  const counters = [0, 0, 0, 0];
+  const provisional = block.items.map((item) => {
+    const level = clampLevel(item.level);
+    counters[level] += 1;
+    for (let deeper = level + 1; deeper < counters.length; deeper += 1) counters[deeper] = 0;
+    const marker = markerText(markerAtLevel(block, level), counters[level]);
+    return { text: item.text, level, marker };
+  });
+  const widths = [0, 0, 0, 0];
+  for (const item of provisional) {
+    widths[item.level] = Math.max(widths[item.level], markerWidth(item.marker));
+  }
+  return provisional.map((item) => ({
+    ...item,
+    markerWidthEm: widths[item.level],
+    indentEm: widths.slice(0, item.level).reduce((sum, width) => sum + width + 0.65, 0),
+  }));
+}

--- a/src/lib/slides/pageOps.ts
+++ b/src/lib/slides/pageOps.ts
@@ -1,0 +1,24 @@
+import type { Page, Slide } from '$lib/types';
+
+export const SLIDE_PAGE_SIZE = {
+  widescreen: { width: 960, height: 540 },
+  letter: { width: 612, height: 792 },
+} as const;
+
+export function slidePage(
+  pageIndex: number,
+  slide: Slide,
+  width: number,
+  height: number,
+  insertedAfterPdfPage: number | null,
+): Page {
+  return {
+    pageIndex,
+    type: 'slide',
+    insertedAfterPdfPage,
+    width,
+    height,
+    slide: structuredClone(slide),
+    objects: [],
+  };
+}

--- a/src/lib/slides/render/SlideLayer.svelte
+++ b/src/lib/slides/render/SlideLayer.svelte
@@ -4,7 +4,7 @@
   import { renderLatex } from '$lib/text/latex';
   import type { Slide, SlideBlock, SlideTheme } from '$lib/types';
   import { presentList } from '../listMarkers';
-  import { layoutSlide, type LayoutBox } from '../layout';
+  import { captionHeight, layoutSlide, type LayoutBox } from '../layout';
   import { resolveTheme } from '../theme';
   import { diagramGeometry } from './diagramGeometry';
   import { graphObjectForSlide, graphThemeForSlide } from './graphAdapter';
@@ -211,7 +211,7 @@
           {@html mathHtml(placed.block.latex, placed.block.display)}
         </div>
       {:else if placed.block.kind === 'graph'}
-        {@const captionSize = placed.block.caption ? theme.bodySize * 1.8 : 0}
+        {@const captionSize = captionHeight(placed.block.caption, theme.bodySize, placed.box.w)}
         {@const graphHeight = Math.max(0, placed.box.h - captionSize)}
         {#if placed.block.caption}
           <div class="caption" style:font-size={`${theme.bodySize * scale}px`}>

--- a/src/lib/slides/render/SlideLayer.svelte
+++ b/src/lib/slides/render/SlideLayer.svelte
@@ -552,8 +552,10 @@
 
   .hero-tint {
     position: absolute;
-    inset: 0 0 42% 0;
+    inset: 0;
     opacity: 0.07;
+    -webkit-mask-image: linear-gradient(to bottom, #000 0%, #000 40%, transparent 72%);
+    mask-image: linear-gradient(to bottom, #000 0%, #000 40%, transparent 72%);
   }
 
   .slide-title,

--- a/src/lib/slides/render/SlideLayer.svelte
+++ b/src/lib/slides/render/SlideLayer.svelte
@@ -7,6 +7,7 @@
   import { resolveTheme } from '../theme';
   import { graphObjectForSlide, graphThemeForSlide } from './graphAdapter';
   import { renderInlineMath } from './inlineMath';
+  import { mappingGeometry } from './mappingGeometry';
 
   interface Props {
     slide: Slide;
@@ -228,6 +229,107 @@
             theme={graphThemeForSlide(theme, scale)}
           />
         </div>
+      {:else if placed.block.kind === 'mapping'}
+        {@const mapping = mappingGeometry(placed.block, placed.box.w, placed.box.h, theme.bodySize)}
+        <div class="mapping">
+          <svg
+            class="mapping-svg"
+            viewBox={`0 0 ${placed.box.w} ${placed.box.h}`}
+            aria-hidden="true"
+          >
+            <ellipse
+              cx={mapping.leftOval.cx}
+              cy={mapping.leftOval.cy}
+              rx={mapping.leftOval.rx}
+              ry={mapping.leftOval.ry}
+              fill={theme.accent}
+              fill-opacity="0.1"
+              stroke={theme.accent}
+              stroke-opacity="0.45"
+              stroke-width="1.1"
+            />
+            <ellipse
+              cx={mapping.rightOval.cx}
+              cy={mapping.rightOval.cy}
+              rx={mapping.rightOval.rx}
+              ry={mapping.rightOval.ry}
+              fill={theme.textColor}
+              fill-opacity="0.045"
+              stroke={theme.textColor}
+              stroke-opacity="0.28"
+              stroke-width="1.1"
+            />
+            {#each mapping.arrows as arrow}
+              <line
+                x1={arrow.from.x}
+                y1={arrow.from.y}
+                x2={arrow.to.x}
+                y2={arrow.to.y}
+                stroke={theme.textColor}
+                stroke-opacity="0.65"
+                stroke-width="1.15"
+              />
+              <polygon
+                points={arrow.head.map((point) => `${point.x},${point.y}`).join(' ')}
+                fill={theme.textColor}
+                fill-opacity="0.7"
+              />
+            {/each}
+          </svg>
+          {#if mapping.caption && placed.block.caption}
+            <div
+              class="mapping-caption"
+              style:left={`${mapping.caption.x * scale}px`}
+              style:top={`${mapping.caption.y * scale}px`}
+              style:font-size={`${theme.bodySize * scale}px`}
+            >
+              <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+              {@html renderInlineMath(placed.block.caption)}
+            </div>
+          {/if}
+          {#each mapping.leftItems as item}
+            <div
+              class="mapping-item"
+              style:left={`${item.x * scale}px`}
+              style:top={`${item.y * scale}px`}
+              style:width={`${mapping.leftOval.rx * 1.35 * scale}px`}
+              style:font-size={`${theme.bodySize * scale}px`}
+            >
+              <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+              {@html renderInlineMath(item.text)}
+            </div>
+          {/each}
+          {#each mapping.rightItems as item}
+            <div
+              class="mapping-item"
+              style:left={`${item.x * scale}px`}
+              style:top={`${item.y * scale}px`}
+              style:width={`${mapping.rightOval.rx * 1.35 * scale}px`}
+              style:font-size={`${theme.bodySize * scale}px`}
+            >
+              <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+              {@html renderInlineMath(item.text)}
+            </div>
+          {/each}
+          <div
+            class="mapping-label"
+            style:left={`${mapping.leftLabel.x * scale}px`}
+            style:top={`${mapping.leftLabel.y * scale}px`}
+            style:font-size={`${theme.bodySize * 0.86 * scale}px`}
+          >
+            <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+            {@html renderInlineMath(placed.block.leftLabel)}
+          </div>
+          <div
+            class="mapping-label"
+            style:left={`${mapping.rightLabel.x * scale}px`}
+            style:top={`${mapping.rightLabel.y * scale}px`}
+            style:font-size={`${theme.bodySize * 0.86 * scale}px`}
+          >
+            <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+            {@html renderInlineMath(placed.block.rightLabel)}
+          </div>
+        </div>
       {:else if placed.block.kind === 'callout'}
         <div
           class="callout"
@@ -341,6 +443,31 @@
     position: relative;
     width: 100%;
     overflow: hidden;
+  }
+
+  .mapping,
+  .mapping-svg {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+  }
+
+  .mapping-item,
+  .mapping-label,
+  .mapping-caption {
+    position: absolute;
+    transform: translate(-50%, -50%);
+    text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .mapping-label,
+  .mapping-caption {
+    font-weight: 600;
   }
 
   .callout {

--- a/src/lib/slides/render/SlideLayer.svelte
+++ b/src/lib/slides/render/SlideLayer.svelte
@@ -2,12 +2,15 @@
   import { isSafeHexColor } from '$lib/color';
   import GraphLayer from '$lib/canvas/GraphLayer.svelte';
   import { renderLatex } from '$lib/text/latex';
-  import type { Slide, SlideBlock, SlideListItem, SlideTheme } from '$lib/types';
+  import type { Slide, SlideBlock, SlideTheme } from '$lib/types';
+  import { presentList } from '../listMarkers';
   import { layoutSlide, type LayoutBox } from '../layout';
   import { resolveTheme } from '../theme';
+  import { diagramGeometry } from './diagramGeometry';
   import { graphObjectForSlide, graphThemeForSlide } from './graphAdapter';
   import { renderInlineMath } from './inlineMath';
   import { mappingGeometry } from './mappingGeometry';
+  import { slideNumberLineGeometry } from './numberLineGeometry';
 
   interface Props {
     slide: Slide;
@@ -35,25 +38,6 @@
     return Number.isFinite(size) && (size ?? 0) > 0 ? (size as number) : theme.bodySize;
   }
 
-  function level(item: SlideListItem): number {
-    return Number.isFinite(item.level) ? Math.min(3, Math.max(0, Math.floor(item.level))) : 0;
-  }
-
-  function listMarker(
-    items: SlideListItem[],
-    index: number,
-    marker: 'bullet' | 'decimal' | 'none',
-  ): string {
-    if (marker === 'none') return '';
-    if (level(items[index]) > 0) return '•';
-    if (marker === 'bullet') return '•';
-    let number = 0;
-    for (let itemIndex = 0; itemIndex <= index; itemIndex += 1) {
-      if (level(items[itemIndex]) === 0) number += 1;
-    }
-    return `${number}.`;
-  }
-
   function tableColumnCount(block: Extract<SlideBlock, { kind: 'table' }>): number {
     return Math.max(1, block.header.length, ...block.rows.map((row) => row.length));
   }
@@ -73,6 +57,20 @@
     return Array.from({ length: count }, (_, index) => row[index] ?? '');
   }
 
+  function tableRows(block: Extract<SlideBlock, { kind: 'table' }>): string[][] {
+    return block.header.length > 0 ? [block.header, ...block.rows] : block.rows;
+  }
+
+  function isTableHeader(
+    block: Extract<SlideBlock, { kind: 'table' }>,
+    row: number,
+    column: number,
+  ): boolean {
+    return block.headerOrientation === 'column'
+      ? column === 0
+      : block.header.length > 0 && row === 0;
+  }
+
   function calloutBackground(tone: Extract<SlideBlock, { kind: 'callout' }>['tone']): string {
     if (tone === 'tip') return '#e8f3ea';
     if (tone === 'warn') return '#fff1d6';
@@ -85,6 +83,14 @@
 
   function mathHtml(source: string, display: boolean): string {
     return renderLatex(source, { displayMode: display }).html;
+  }
+
+  function horizontalArrowPoints(x: number, y: number, direction: number, size: number): string {
+    return `${x},${y} ${x - direction * size},${y - size * 0.55} ${x - direction * size},${y + size * 0.55}`;
+  }
+
+  function numberLineLabel(value: number): string {
+    return Number.isInteger(value) ? value.toFixed(0) : value.toFixed(6).replace(/\.?0+$/, '');
   }
 </script>
 
@@ -140,14 +146,17 @@
           {@html renderInlineMath(placed.block.text)}
         </div>
       {:else if placed.block.kind === 'list'}
+        {@const listItems = presentList(placed.block)}
         <div class="list" style:font-size={`${fontSize(placed.block.fontSize) * scale}px`}>
-          {#each placed.block.items as item, index}
+          {#each listItems as item}
             <div
               class="list-item"
-              style:padding-left={`${level(item) * fontSize(placed.block.fontSize) * 1.4 * scale}px`}
+              style:padding-left={`${item.indentEm * fontSize(placed.block.fontSize) * scale}px`}
             >
-              <span class="marker"
-                >{listMarker(placed.block.items, index, placed.block.marker)}</span
+              <span
+                class="marker"
+                style:flex-basis={`${item.markerWidthEm}em`}
+                style:width={`${item.markerWidthEm}em`}>{item.marker}</span
               >
               <!-- eslint-disable-next-line svelte/no-at-html-tags -->
               <span>{@html renderInlineMath(item.text)}</span>
@@ -168,6 +177,7 @@
       {:else if placed.block.kind === 'table'}
         {@const columnCount = tableColumnCount(placed.block)}
         {@const weights = tableWeights(placed.block)}
+        {@const rows = tableRows(placed.block)}
         <div class="table-wrap" style:font-size={`${fontSize(placed.block.fontSize) * scale}px`}>
           {#if placed.block.caption}
             <!-- eslint-disable-next-line svelte/no-at-html-tags -->
@@ -177,16 +187,15 @@
             class="table"
             style:grid-template-columns={weights.map((weight) => `${weight}fr`).join(' ')}
           >
-            {#if placed.block.header.length > 0}
-              {#each paddedRow(placed.block.header, columnCount) as cell}
-                <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-                <div class="cell header-cell">{@html renderInlineMath(cell)}</div>
-              {/each}
-            {/if}
-            {#each placed.block.rows as row}
-              {#each paddedRow(row, columnCount) as cell}
-                <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-                <div class="cell">{@html renderInlineMath(cell)}</div>
+            {#each rows as row, rowIndex}
+              {#each paddedRow(row, columnCount) as cell, columnIndex}
+                <div
+                  class="cell"
+                  class:header-cell={isTableHeader(placed.block, rowIndex, columnIndex)}
+                >
+                  <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                  {@html renderInlineMath(cell)}
+                </div>
               {/each}
             {/each}
           </div>
@@ -330,6 +339,184 @@
             {@html renderInlineMath(placed.block.rightLabel)}
           </div>
         </div>
+      {:else if placed.block.kind === 'diagram'}
+        {@const diagram = diagramGeometry(placed.block, placed.box.w, placed.box.h, theme.bodySize)}
+        <div class="diagram">
+          <svg
+            class="diagram-svg"
+            viewBox={`0 0 ${placed.box.w} ${placed.box.h}`}
+            aria-hidden="true"
+          >
+            {#each diagram.edges as edge}
+              <line
+                x1={edge.from.x}
+                y1={edge.from.y}
+                x2={edge.to.x}
+                y2={edge.to.y}
+                stroke={theme.textColor}
+                stroke-opacity="0.72"
+                stroke-width="1.2"
+              />
+              <polygon
+                points={edge.head.map((point) => `${point.x},${point.y}`).join(' ')}
+                fill={theme.textColor}
+                fill-opacity="0.78"
+              />
+            {/each}
+            {#each diagram.nodes.filter((node) => node.shape === 'box') as node}
+              <rect
+                x={node.x - node.w / 2}
+                y={node.y - node.h / 2}
+                width={node.w}
+                height={node.h}
+                rx={Math.min(theme.bodySize * 0.5, node.h * 0.18)}
+                fill={theme.accent}
+                fill-opacity="0.1"
+                stroke={theme.accent}
+                stroke-opacity="0.48"
+                stroke-width="1.1"
+              />
+            {/each}
+          </svg>
+          {#if diagram.caption && placed.block.caption}
+            <div
+              class="diagram-caption"
+              style:left={`${diagram.caption.x * scale}px`}
+              style:top={`${diagram.caption.y * scale}px`}
+              style:font-size={`${theme.bodySize * scale}px`}
+            >
+              <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+              {@html renderInlineMath(placed.block.caption)}
+            </div>
+          {/if}
+          {#each diagram.nodes as node}
+            <div
+              class="diagram-node"
+              class:plain={node.shape === 'plain'}
+              style:left={`${node.x * scale}px`}
+              style:top={`${node.y * scale}px`}
+              style:width={`${node.w * scale}px`}
+              style:height={`${node.h * scale}px`}
+              style:font-size={`${theme.bodySize * scale}px`}
+            >
+              <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+              {@html renderInlineMath(node.text)}
+            </div>
+          {/each}
+          {#each diagram.edges.filter((edge) => edge.label) as edge}
+            <div
+              class="diagram-edge-label"
+              style:left={`${edge.labelAt.x * scale}px`}
+              style:top={`${edge.labelAt.y * scale}px`}
+              style:font-size={`${theme.bodySize * 0.86 * scale}px`}
+              style:background={theme.background}
+            >
+              <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+              {@html renderInlineMath(edge.label ?? '')}
+            </div>
+          {/each}
+        </div>
+      {:else if placed.block.kind === 'numberline'}
+        {@const numberLine = slideNumberLineGeometry(
+          placed.block,
+          placed.box.w,
+          placed.box.h,
+          theme,
+        )}
+        <div class="slide-number-line">
+          <svg
+            class="number-line-svg"
+            viewBox={`0 0 ${placed.box.w} ${placed.box.h}`}
+            aria-hidden="true"
+          >
+            {#if numberLine.valid}
+              <line
+                x1={numberLine.x0}
+                y1={numberLine.y}
+                x2={numberLine.x1}
+                y2={numberLine.y}
+                stroke={theme.textColor}
+                stroke-width="1.4"
+              />
+              <polygon
+                points={horizontalArrowPoints(
+                  numberLine.x0,
+                  numberLine.y,
+                  -1,
+                  numberLine.arrowSize,
+                )}
+                fill={theme.textColor}
+              />
+              <polygon
+                points={horizontalArrowPoints(numberLine.x1, numberLine.y, 1, numberLine.arrowSize)}
+                fill={theme.textColor}
+              />
+              {#each numberLine.ticks as tick}
+                <line
+                  x1={tick.x}
+                  y1={numberLine.y - theme.bodySize * 0.34}
+                  x2={tick.x}
+                  y2={numberLine.y + theme.bodySize * 0.34}
+                  stroke={theme.textColor}
+                  stroke-width="1"
+                />
+              {/each}
+              {#each numberLine.marks as mark}
+                {#if mark.kind === 'open' || mark.kind === 'closed'}
+                  <circle
+                    cx={mark.x}
+                    cy={numberLine.y}
+                    r={theme.bodySize * 0.31}
+                    fill={mark.kind === 'closed' ? theme.accent : theme.background}
+                    stroke={theme.accent}
+                    stroke-width="1.5"
+                  />
+                {:else}
+                  {@const rayEnd = mark.kind === 'arrow-left' ? numberLine.x0 : numberLine.x1}
+                  {@const direction = mark.kind === 'arrow-left' ? -1 : 1}
+                  <line
+                    x1={mark.x}
+                    y1={numberLine.y}
+                    x2={rayEnd}
+                    y2={numberLine.y}
+                    stroke={theme.accent}
+                    stroke-width="2"
+                  />
+                  <polygon
+                    points={horizontalArrowPoints(
+                      rayEnd,
+                      numberLine.y,
+                      direction,
+                      numberLine.arrowSize,
+                    )}
+                    fill={theme.accent}
+                  />
+                {/if}
+              {/each}
+            {/if}
+          </svg>
+          {#if numberLine.captionY !== null && placed.block.caption}
+            <div
+              class="number-line-caption"
+              style:left={`${((numberLine.x0 + numberLine.x1) / 2) * scale}px`}
+              style:top={`${numberLine.captionY * scale}px`}
+              style:font-size={`${theme.bodySize * scale}px`}
+            >
+              <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+              {@html renderInlineMath(placed.block.caption)}
+            </div>
+          {/if}
+          {#each numberLine.labels as label}
+            <div
+              class="number-line-label"
+              style:left={`${label.x * scale}px`}
+              style:top={`${(numberLine.y + theme.bodySize * 1.05) * scale}px`}
+              style:font-size={`${theme.bodySize * 0.82 * scale}px`}
+            >
+              {numberLineLabel(label.value)}
+            </div>
+          {/each}
+        </div>
       {:else if placed.block.kind === 'callout'}
         <div
           class="callout"
@@ -468,6 +655,52 @@
   .mapping-label,
   .mapping-caption {
     font-weight: 600;
+  }
+
+  .diagram,
+  .diagram-svg,
+  .slide-number-line,
+  .number-line-svg {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+  }
+
+  .diagram-node {
+    position: absolute;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    transform: translate(-50%, -50%);
+    padding: 0.3em 0.6em;
+    text-align: center;
+    overflow: hidden;
+  }
+
+  .diagram-node.plain {
+    padding: 0;
+  }
+
+  .diagram-caption,
+  .diagram-edge-label,
+  .number-line-caption,
+  .number-line-label {
+    position: absolute;
+    transform: translate(-50%, -50%);
+    white-space: nowrap;
+    text-align: center;
+  }
+
+  .diagram-caption,
+  .number-line-caption {
+    font-weight: 600;
+  }
+
+  .diagram-edge-label {
+    padding: 0 0.25em;
   }
 
   .callout {

--- a/src/lib/slides/render/SlideLayer.svelte
+++ b/src/lib/slides/render/SlideLayer.svelte
@@ -1,0 +1,384 @@
+<script lang="ts">
+  import { isSafeHexColor } from '$lib/color';
+  import GraphLayer from '$lib/canvas/GraphLayer.svelte';
+  import { renderLatex } from '$lib/text/latex';
+  import type { Slide, SlideBlock, SlideListItem, SlideTheme } from '$lib/types';
+  import { layoutSlide, type LayoutBox } from '../layout';
+  import { resolveTheme } from '../theme';
+  import { graphObjectForSlide, graphThemeForSlide } from './graphAdapter';
+  import { renderInlineMath } from './inlineMath';
+
+  interface Props {
+    slide: Slide;
+    theme: SlideTheme;
+    width: number;
+    height: number;
+    ptToPx: number;
+  }
+
+  let { slide, theme: themeInput, width, height, ptToPx }: Props = $props();
+
+  const scale = $derived(Number.isFinite(ptToPx) && ptToPx > 0 ? ptToPx : 1);
+  const theme = $derived(resolveTheme(themeInput, slide.theme));
+  const layout = $derived(layoutSlide(slide, theme, width / scale, height / scale));
+
+  function boxStyle(box: LayoutBox): string {
+    return `left:${box.x * scale}px;top:${box.y * scale}px;width:${box.w * scale}px;height:${box.h * scale}px`;
+  }
+
+  function textColor(color: string | undefined): string {
+    return isSafeHexColor(color) ? color : theme.textColor;
+  }
+
+  function fontSize(size: number | undefined): number {
+    return Number.isFinite(size) && (size ?? 0) > 0 ? (size as number) : theme.bodySize;
+  }
+
+  function level(item: SlideListItem): number {
+    return Number.isFinite(item.level) ? Math.min(3, Math.max(0, Math.floor(item.level))) : 0;
+  }
+
+  function listMarker(
+    items: SlideListItem[],
+    index: number,
+    marker: 'bullet' | 'decimal' | 'none',
+  ): string {
+    if (marker === 'none') return '';
+    if (level(items[index]) > 0) return '•';
+    if (marker === 'bullet') return '•';
+    let number = 0;
+    for (let itemIndex = 0; itemIndex <= index; itemIndex += 1) {
+      if (level(items[itemIndex]) === 0) number += 1;
+    }
+    return `${number}.`;
+  }
+
+  function tableColumnCount(block: Extract<SlideBlock, { kind: 'table' }>): number {
+    return Math.max(1, block.header.length, ...block.rows.map((row) => row.length));
+  }
+
+  function tableWeights(block: Extract<SlideBlock, { kind: 'table' }>): number[] {
+    const count = tableColumnCount(block);
+    if (
+      block.columnWeights?.length === count &&
+      block.columnWeights.every((weight) => Number.isFinite(weight) && weight > 0)
+    ) {
+      return block.columnWeights;
+    }
+    return Array.from({ length: count }, () => 1);
+  }
+
+  function paddedRow(row: string[], count: number): string[] {
+    return Array.from({ length: count }, (_, index) => row[index] ?? '');
+  }
+
+  function calloutBackground(tone: Extract<SlideBlock, { kind: 'callout' }>['tone']): string {
+    if (tone === 'tip') return '#e8f3ea';
+    if (tone === 'warn') return '#fff1d6';
+    return '#e8f0f7';
+  }
+
+  function safeImageSource(src: string): string | undefined {
+    return /^data:image\/(?:png|jpeg|gif|webp);base64,[a-z0-9+/=\s]+$/i.test(src) ? src : undefined;
+  }
+
+  function mathHtml(source: string, display: boolean): string {
+    return renderLatex(source, { displayMode: display }).html;
+  }
+</script>
+
+<div
+  class="slide-layer"
+  class:title-layout={slide.layout === 'title'}
+  style:width={`${width}px`}
+  style:height={`${height}px`}
+  style:background={theme.background}
+  style:color={theme.textColor}
+  style:font-family={theme.fontFamily}
+>
+  {#if slide.layout === 'title'}
+    <div class="hero-tint" style:background={theme.accent}></div>
+  {/if}
+
+  {#if layout.title}
+    <div
+      class="slide-title"
+      style={boxStyle(layout.title.box)}
+      style:color={theme.titleColor}
+      style:font-size={`${layout.title.fontSize * scale}px`}
+      style:text-align={layout.title.align}
+    >
+      <!-- Only escaped text and KaTeX output reach this trust boundary. -->
+      <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+      {@html renderInlineMath(layout.title.text)}
+    </div>
+  {/if}
+
+  {#if layout.subtitle}
+    <div
+      class="slide-subtitle"
+      style={boxStyle(layout.subtitle.box)}
+      style:font-size={`${layout.subtitle.fontSize * scale}px`}
+    >
+      <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+      {@html renderInlineMath(layout.subtitle.text)}
+    </div>
+  {/if}
+
+  {#each [...layout.blocks, ...layout.asides] as placed (placed.block.id)}
+    <div class="slide-block block-{placed.block.kind}" style={boxStyle(placed.box)}>
+      {#if placed.block.kind === 'text'}
+        <div
+          class:bold={placed.block.bold}
+          class:italic={placed.block.italic}
+          style:color={textColor(placed.block.color)}
+          style:font-size={`${fontSize(placed.block.fontSize) * scale}px`}
+          style:text-align={placed.block.align ?? 'left'}
+        >
+          <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+          {@html renderInlineMath(placed.block.text)}
+        </div>
+      {:else if placed.block.kind === 'list'}
+        <div class="list" style:font-size={`${fontSize(placed.block.fontSize) * scale}px`}>
+          {#each placed.block.items as item, index}
+            <div
+              class="list-item"
+              style:padding-left={`${level(item) * fontSize(placed.block.fontSize) * 1.4 * scale}px`}
+            >
+              <span class="marker"
+                >{listMarker(placed.block.items, index, placed.block.marker)}</span
+              >
+              <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+              <span>{@html renderInlineMath(item.text)}</span>
+            </div>
+          {/each}
+        </div>
+      {:else if placed.block.kind === 'definitions'}
+        <div class="definitions" style:font-size={`${fontSize(placed.block.fontSize) * scale}px`}>
+          {#each placed.block.items as item}
+            <div class="definition">
+              <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+              <strong>{@html renderInlineMath(item.term)}</strong>
+              <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+              <span>: {@html renderInlineMath(item.text)}</span>
+            </div>
+          {/each}
+        </div>
+      {:else if placed.block.kind === 'table'}
+        {@const columnCount = tableColumnCount(placed.block)}
+        {@const weights = tableWeights(placed.block)}
+        <div class="table-wrap" style:font-size={`${fontSize(placed.block.fontSize) * scale}px`}>
+          {#if placed.block.caption}
+            <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+            <div class="caption">{@html renderInlineMath(placed.block.caption)}</div>
+          {/if}
+          <div
+            class="table"
+            style:grid-template-columns={weights.map((weight) => `${weight}fr`).join(' ')}
+          >
+            {#if placed.block.header.length > 0}
+              {#each paddedRow(placed.block.header, columnCount) as cell}
+                <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                <div class="cell header-cell">{@html renderInlineMath(cell)}</div>
+              {/each}
+            {/if}
+            {#each placed.block.rows as row}
+              {#each paddedRow(row, columnCount) as cell}
+                <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                <div class="cell">{@html renderInlineMath(cell)}</div>
+              {/each}
+            {/each}
+          </div>
+        </div>
+      {:else if placed.block.kind === 'math'}
+        <div
+          class="math"
+          style:color={textColor(placed.block.color)}
+          style:font-size={`${fontSize(placed.block.fontSize) * scale}px`}
+          style:text-align={placed.block.align ?? 'center'}
+        >
+          <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+          {@html mathHtml(placed.block.latex, placed.block.display)}
+        </div>
+      {:else if placed.block.kind === 'graph'}
+        {@const captionSize = placed.block.caption ? theme.bodySize * 1.8 : 0}
+        {@const graphHeight = Math.max(0, placed.box.h - captionSize)}
+        {#if placed.block.caption}
+          <div class="caption" style:font-size={`${theme.bodySize * scale}px`}>
+            <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+            {@html renderInlineMath(placed.block.caption)}
+          </div>
+        {/if}
+        <div
+          class="graph"
+          style:height={`${graphHeight * scale}px`}
+          style:margin-top={placed.block.caption ? `${theme.bodySize * 0.45 * scale}px` : '0'}
+        >
+          <GraphLayer
+            graphs={[
+              graphObjectForSlide(
+                placed.block.graph,
+                { x: 0, y: 0, w: placed.box.w, h: graphHeight },
+                theme,
+              ),
+            ]}
+            width={placed.box.w * scale}
+            height={graphHeight * scale}
+            ptToPx={scale}
+            theme={graphThemeForSlide(theme, scale)}
+          />
+        </div>
+      {:else if placed.block.kind === 'callout'}
+        <div
+          class="callout"
+          style:background={calloutBackground(placed.block.tone)}
+          style:border-color={theme.accent}
+          style:font-size={`${fontSize(placed.block.fontSize) * scale}px`}
+        >
+          <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+          {@html renderInlineMath(placed.block.text)}
+        </div>
+      {:else if placed.block.kind === 'image'}
+        {@const src = safeImageSource(placed.block.src)}
+        <div class="image-wrap align-{placed.block.align ?? 'center'}">
+          {#if src}
+            <img {src} alt={placed.block.alt} />
+          {:else}
+            <span class="image-fallback">{placed.block.alt}</span>
+          {/if}
+        </div>
+      {/if}
+    </div>
+  {/each}
+</div>
+
+<style>
+  .slide-layer {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    pointer-events: none;
+    line-height: 1.35;
+  }
+
+  .hero-tint {
+    position: absolute;
+    inset: 0 0 42% 0;
+    opacity: 0.07;
+  }
+
+  .slide-title,
+  .slide-subtitle,
+  .slide-block {
+    position: absolute;
+    box-sizing: border-box;
+    overflow: hidden;
+  }
+
+  .slide-title {
+    font-weight: 700;
+    line-height: 1.16;
+  }
+
+  .slide-subtitle {
+    text-align: center;
+    opacity: 0.8;
+  }
+
+  .bold {
+    font-weight: 700;
+  }
+
+  .italic {
+    font-style: italic;
+  }
+
+  .list-item {
+    display: flex;
+    align-items: baseline;
+    min-width: 0;
+  }
+
+  .marker {
+    flex: 0 0 1.45em;
+    text-align: right;
+    margin-right: 0.55em;
+  }
+
+  .definition + .definition {
+    margin-top: 0.35em;
+  }
+
+  .table {
+    display: grid;
+    border-top: 1px solid color-mix(in srgb, currentColor 22%, transparent);
+    border-left: 1px solid color-mix(in srgb, currentColor 22%, transparent);
+  }
+
+  .cell {
+    min-width: 0;
+    padding: 0.55em;
+    border-right: 1px solid color-mix(in srgb, currentColor 22%, transparent);
+    border-bottom: 1px solid color-mix(in srgb, currentColor 22%, transparent);
+    overflow-wrap: anywhere;
+  }
+
+  .header-cell {
+    background: color-mix(in srgb, currentColor 7%, transparent);
+    font-weight: 650;
+  }
+
+  .caption {
+    margin-bottom: 0.45em;
+    font-weight: 600;
+  }
+
+  .math {
+    width: 100%;
+  }
+
+  .graph {
+    position: relative;
+    width: 100%;
+    overflow: hidden;
+  }
+
+  .callout {
+    box-sizing: border-box;
+    width: 100%;
+    height: 100%;
+    padding: 0.8em;
+    border-left: 0.28em solid;
+    border-radius: 0.55em;
+  }
+
+  .image-wrap {
+    display: flex;
+    width: 100%;
+    height: 100%;
+  }
+
+  .align-left {
+    justify-content: flex-start;
+  }
+
+  .align-center {
+    justify-content: center;
+  }
+
+  .align-right {
+    justify-content: flex-end;
+  }
+
+  img {
+    display: block;
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+  }
+
+  .image-fallback {
+    align-self: center;
+    opacity: 0.5;
+  }
+</style>

--- a/src/lib/slides/render/diagramGeometry.ts
+++ b/src/lib/slides/render/diagramGeometry.ts
@@ -1,0 +1,142 @@
+import type { SlideDiagramBlock, SlideDiagramNode } from '$lib/types';
+
+export interface DiagramPoint {
+  x: number;
+  y: number;
+}
+
+export interface DiagramNodeGeometry {
+  id: string;
+  text: string;
+  shape: 'box' | 'plain';
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface DiagramEdgeGeometry {
+  from: DiagramPoint;
+  to: DiagramPoint;
+  head: [DiagramPoint, DiagramPoint, DiagramPoint];
+  label: string | undefined;
+  labelAt: DiagramPoint;
+}
+
+export interface DiagramGeometry {
+  nodes: DiagramNodeGeometry[];
+  edges: DiagramEdgeGeometry[];
+  caption: DiagramPoint | null;
+}
+
+function finite(value: number, fallback: number): number {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function nodeSize(
+  node: SlideDiagramNode,
+  width: number,
+  height: number,
+  bodySize: number,
+): { w: number; h: number } {
+  const shape = node.shape ?? 'box';
+  const naturalWidth = clamp(
+    node.text.length * bodySize * 0.52 + bodySize * (shape === 'box' ? 1.8 : 0.5),
+    bodySize * 2,
+    width * 0.6,
+  );
+  const naturalHeight = bodySize * (shape === 'box' ? 2.1 : 1.5);
+  return {
+    w: node.w === undefined ? naturalWidth : clamp(finite(node.w, 0) * width, bodySize, width),
+    h:
+      node.h === undefined
+        ? Math.min(height, naturalHeight)
+        : clamp(finite(node.h, 0) * height, bodySize, height),
+  };
+}
+
+function edgePoint(source: DiagramNodeGeometry, target: DiagramNodeGeometry): DiagramPoint {
+  const dx = target.x - source.x;
+  const dy = target.y - source.y;
+  if (dx === 0 && dy === 0) return { x: source.x, y: source.y };
+  const xScale = dx === 0 ? Infinity : source.w / 2 / Math.abs(dx);
+  const yScale = dy === 0 ? Infinity : source.h / 2 / Math.abs(dy);
+  const scale = Math.min(xScale, yScale);
+  return { x: source.x + dx * scale, y: source.y + dy * scale };
+}
+
+function arrowHead(
+  from: DiagramPoint,
+  to: DiagramPoint,
+  size: number,
+): DiagramEdgeGeometry['head'] {
+  const dx = to.x - from.x;
+  const dy = to.y - from.y;
+  const length = Math.hypot(dx, dy);
+  if (length === 0) return [to, to, to];
+  const ux = dx / length;
+  const uy = dy / length;
+  const px = -uy;
+  const py = ux;
+  const baseX = to.x - ux * size;
+  const baseY = to.y - uy * size;
+  return [
+    to,
+    { x: baseX + px * size * 0.45, y: baseY + py * size * 0.45 },
+    { x: baseX - px * size * 0.45, y: baseY - py * size * 0.45 },
+  ];
+}
+
+/** Convert fractional node positions into bounded local diagram coordinates. */
+export function diagramGeometry(
+  block: SlideDiagramBlock,
+  width: number,
+  height: number,
+  bodySize: number,
+): DiagramGeometry {
+  const w = Math.max(0, finite(width, 0));
+  const h = Math.max(0, finite(height, 0));
+  const fontSize = Math.max(1, finite(bodySize, 13));
+  const nodes = block.nodes.map((node): DiagramNodeGeometry => {
+    const size = nodeSize(node, w, h, fontSize);
+    const x = clamp(finite(node.x, 0.5), 0, 1) * w;
+    const y = clamp(finite(node.y, 0.5), 0, 1) * h;
+    return {
+      id: node.id,
+      text: node.text,
+      shape: node.shape ?? 'box',
+      x: clamp(x, size.w / 2, Math.max(size.w / 2, w - size.w / 2)),
+      y: clamp(y, size.h / 2, Math.max(size.h / 2, h - size.h / 2)),
+      ...size,
+    };
+  });
+  const byId = new Map<string, DiagramNodeGeometry>();
+  for (const node of nodes) {
+    if (!byId.has(node.id)) byId.set(node.id, node);
+  }
+  const edges: DiagramEdgeGeometry[] = [];
+  const headSize = Math.min(fontSize * 0.55, w * 0.018);
+  for (const edge of block.edges) {
+    const fromNode = byId.get(edge.from);
+    const toNode = byId.get(edge.to);
+    if (!fromNode || !toNode || fromNode === toNode) continue;
+    const from = edgePoint(fromNode, toNode);
+    const to = edgePoint(toNode, fromNode);
+    edges.push({
+      from,
+      to,
+      head: arrowHead(from, to, headSize),
+      label: edge.label,
+      labelAt: { x: (from.x + to.x) / 2, y: (from.y + to.y) / 2 - fontSize * 0.7 },
+    });
+  }
+  return {
+    nodes,
+    edges,
+    caption: block.caption ? { x: w / 2, y: Math.min(h, fontSize * 0.75) } : null,
+  };
+}

--- a/src/lib/slides/render/graphAdapter.ts
+++ b/src/lib/slides/render/graphAdapter.ts
@@ -1,0 +1,61 @@
+import { isSafeHexColor } from '$lib/color';
+import { resolveTheme as resolveGraphTheme, type GraphTheme } from '$lib/graph/theme';
+import type { GraphFunction, GraphObject, SlideGraphSpec, SlideTheme } from '$lib/types';
+import type { LayoutBox } from '../layout';
+
+function safeRange(value: [number, number], fallback: [number, number]): [number, number] {
+  return Number.isFinite(value[0]) && Number.isFinite(value[1]) && value[1] > value[0]
+    ? value
+    : fallback;
+}
+
+function safeFunction(fn: GraphFunction, theme: SlideTheme): GraphFunction {
+  return {
+    ...fn,
+    color: isSafeHexColor(fn.color) ? fn.color : theme.accent,
+    width: Number.isFinite(fn.width) && fn.width > 0 ? Math.min(fn.width, 20) : 2,
+    dash: fn.dash === 'dashed' || fn.dash === 'dotted' ? fn.dash : 'solid',
+    domain:
+      fn.domain &&
+      Number.isFinite(fn.domain[0]) &&
+      Number.isFinite(fn.domain[1]) &&
+      fn.domain[1] > fn.domain[0]
+        ? fn.domain
+        : null,
+  };
+}
+
+/** Adapt a slide graph into the existing GraphLayer data contract. */
+export function graphObjectForSlide(
+  spec: SlideGraphSpec,
+  box: LayoutBox,
+  theme: SlideTheme,
+): GraphObject {
+  return {
+    id: 'slide-graph',
+    createdAt: 0,
+    type: 'graph',
+    bounds: { x: 0, y: 0, w: Math.max(0, box.w), h: Math.max(0, box.h) },
+    xRange: safeRange(spec.xRange, [-10, 10]),
+    yRange: safeRange(spec.yRange, [-10, 10]),
+    gridStep: Number.isFinite(spec.gridStep) && spec.gridStep > 0 ? spec.gridStep : 0,
+    showAxes: spec.showAxes === true,
+    showGrid: spec.showGrid === true,
+    functions: spec.functions.map((fn) => safeFunction(fn, theme)),
+  };
+}
+
+export function graphThemeForSlide(theme: SlideTheme, ptToPx: number): GraphTheme {
+  const graphTheme = resolveGraphTheme({ graphTheme: 'classic' });
+  return {
+    ...graphTheme,
+    background: theme.background,
+    frameColor: theme.accent,
+    axisColor: theme.textColor,
+    labelColor: theme.textColor,
+    labelFontFamily: theme.fontFamily,
+    labelFontSize: Math.max(7, theme.bodySize * ptToPx * 0.75),
+    gridMajor: { ...graphTheme.gridMajor, color: theme.accent, opacity: 0.25 },
+    gridMinor: { ...graphTheme.gridMinor, color: theme.accent, opacity: 0.1 },
+  };
+}

--- a/src/lib/slides/render/inlineMath.ts
+++ b/src/lib/slides/render/inlineMath.ts
@@ -1,0 +1,34 @@
+import { escapeHtml, renderLatex } from '$lib/text/latex';
+import { segmentLatex } from '$lib/text/segment';
+
+type SharedRenderer = {
+  renderMixed?: (source: string, mode: 'auto') => unknown;
+};
+
+const sharedModules = import.meta.glob('../../text/render.ts', { eager: true });
+const sharedRenderer = Object.values(sharedModules)[0] as SharedRenderer | undefined;
+
+function sharedHtml(result: unknown): string | null {
+  if (typeof result === 'string') return result;
+  if (typeof result !== 'object' || result === null) return null;
+  const html = (result as Record<string, unknown>).html;
+  return typeof html === 'string' ? html : null;
+}
+
+/**
+ * Narrow compatibility seam for the shared mixed-text renderer. The local
+ * fallback keeps this branch standalone until `$lib/text/render` is present.
+ */
+export function renderInlineMath(source: string): string {
+  if (sharedRenderer?.renderMixed) {
+    const html = sharedHtml(sharedRenderer.renderMixed(source, 'auto'));
+    if (html !== null) return html;
+  }
+
+  return segmentLatex(source)
+    .map((segment) => {
+      if (segment.kind === 'text') return escapeHtml(segment.value);
+      return renderLatex(segment.value, { displayMode: segment.display }).html;
+    })
+    .join('');
+}

--- a/src/lib/slides/render/inlineMath.ts
+++ b/src/lib/slides/render/inlineMath.ts
@@ -1,34 +1,17 @@
-import { escapeHtml, renderLatex } from '$lib/text/latex';
-import { segmentLatex } from '$lib/text/segment';
-
-type SharedRenderer = {
-  renderMixed?: (source: string, mode: 'auto') => unknown;
-};
-
-const sharedModules = import.meta.glob('../../text/render.ts', { eager: true });
-const sharedRenderer = Object.values(sharedModules)[0] as SharedRenderer | undefined;
-
-function sharedHtml(result: unknown): string | null {
-  if (typeof result === 'string') return result;
-  if (typeof result !== 'object' || result === null) return null;
-  const html = (result as Record<string, unknown>).html;
-  return typeof html === 'string' ? html : null;
-}
+import { escapeHtml } from '$lib/text/latex';
+import { renderMixed } from '$lib/text/render';
 
 /**
- * Narrow compatibility seam for the shared mixed-text renderer. The local
- * fallback keeps this branch standalone until `$lib/text/render` is present.
+ * Render a slide string as HTML with inline math typeset.
+ *
+ * Slide strings are authored as prose, so they use `auto` mode: explicitly
+ * delimited runs are honored and bare math is detected heuristically.
+ *
+ * The result is injected with `{@html}`, so every text run is escaped here and
+ * every math run carries either KaTeX output or an escaped fallback.
  */
 export function renderInlineMath(source: string): string {
-  if (sharedRenderer?.renderMixed) {
-    const html = sharedHtml(sharedRenderer.renderMixed(source, 'auto'));
-    if (html !== null) return html;
-  }
-
-  return segmentLatex(source)
-    .map((segment) => {
-      if (segment.kind === 'text') return escapeHtml(segment.value);
-      return renderLatex(segment.value, { displayMode: segment.display }).html;
-    })
+  return renderMixed(source, 'auto')
+    .runs.map((run) => (run.kind === 'text' ? escapeHtml(run.value) : run.html))
     .join('');
 }

--- a/src/lib/slides/render/mappingGeometry.ts
+++ b/src/lib/slides/render/mappingGeometry.ts
@@ -1,0 +1,153 @@
+import type { SlideMappingBlock } from '$lib/types';
+
+export interface MappingPoint {
+  x: number;
+  y: number;
+}
+
+export interface MappingOval {
+  cx: number;
+  cy: number;
+  rx: number;
+  ry: number;
+}
+
+export interface MappingItemPosition extends MappingPoint {
+  index: number;
+  text: string;
+}
+
+export interface MappingArrow {
+  from: MappingPoint;
+  to: MappingPoint;
+  head: [MappingPoint, MappingPoint, MappingPoint];
+}
+
+export interface MappingGeometry {
+  leftOval: MappingOval;
+  rightOval: MappingOval;
+  leftItems: MappingItemPosition[];
+  rightItems: MappingItemPosition[];
+  arrows: MappingArrow[];
+  leftLabel: MappingPoint;
+  rightLabel: MappingPoint;
+  caption: MappingPoint | null;
+}
+
+export const MAX_MAPPING_ITEMS = 48;
+
+function nonNegative(value: number): number {
+  return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+function itemPositions(
+  values: string[],
+  oval: MappingOval,
+  bodySize: number,
+): MappingItemPosition[] {
+  if (oval.ry <= 0) return [];
+  const maximumByHeight = Math.max(1, Math.floor((oval.ry * 1.4) / (bodySize * 1.05)) + 1);
+  const visible = values.slice(0, Math.min(MAX_MAPPING_ITEMS, maximumByHeight));
+  if (visible.length === 0) return [];
+  if (visible.length === 1) {
+    return [{ index: 0, text: visible[0], x: oval.cx, y: oval.cy }];
+  }
+  const usableHeight = oval.ry * 1.4;
+  const spacing = usableHeight / (visible.length - 1);
+  return visible.map((text, index) => ({
+    index,
+    text,
+    x: oval.cx,
+    y: oval.cy - usableHeight / 2 + spacing * index,
+  }));
+}
+
+function ovalHeight(itemCount: number, availableHeight: number, bodySize: number): number {
+  const count = Math.min(MAX_MAPPING_ITEMS, Math.max(0, itemCount));
+  const desired = Math.max(bodySize * 3, count * bodySize * 1.55 + bodySize);
+  return Math.min(availableHeight, desired);
+}
+
+function arrowHead(from: MappingPoint, to: MappingPoint, size: number): MappingArrow['head'] {
+  const dx = to.x - from.x;
+  const dy = to.y - from.y;
+  const length = Math.hypot(dx, dy);
+  if (length === 0) return [to, to, to];
+  const ux = dx / length;
+  const uy = dy / length;
+  const px = -uy;
+  const py = ux;
+  const base = { x: to.x - ux * size, y: to.y - uy * size };
+  return [
+    to,
+    { x: base.x + px * size * 0.45, y: base.y + py * size * 0.45 },
+    { x: base.x - px * size * 0.45, y: base.y - py * size * 0.45 },
+  ];
+}
+
+/** Compute bounded local coordinates for a mapping diagram. */
+export function mappingGeometry(
+  block: SlideMappingBlock,
+  width: number,
+  height: number,
+  fontSize: number,
+): MappingGeometry {
+  const w = nonNegative(width);
+  const h = nonNegative(height);
+  const bodySize = nonNegative(fontSize) || 13;
+  const captionHeight = block.caption ? Math.min(h * 0.16, bodySize * 1.5) : 0;
+  const labelHeight = Math.min(Math.max(0, h - captionHeight), bodySize * 1.6);
+  const diagramTop = captionHeight;
+  const diagramHeight = Math.max(0, h - captionHeight - labelHeight);
+  const ovalWidth = w / 3;
+  const rx = ovalWidth * 0.42;
+  const leftHeight = ovalHeight(block.left.length, diagramHeight, bodySize);
+  const rightHeight = ovalHeight(block.right.length, diagramHeight, bodySize);
+  const diagramCenterY = diagramTop + diagramHeight / 2;
+  const leftOval: MappingOval = {
+    cx: w / 6,
+    cy: diagramCenterY,
+    rx,
+    ry: leftHeight / 2,
+  };
+  const rightOval: MappingOval = {
+    cx: (w * 5) / 6,
+    cy: diagramCenterY,
+    rx,
+    ry: rightHeight / 2,
+  };
+  const leftItems = itemPositions(block.left, leftOval, bodySize);
+  const rightItems = itemPositions(block.right, rightOval, bodySize);
+  const arrowSize = Math.min(bodySize * 0.45, w * 0.018);
+  const arrows: MappingArrow[] = [];
+
+  for (const pair of block.pairs) {
+    if (
+      !Number.isInteger(pair.from) ||
+      !Number.isInteger(pair.to) ||
+      pair.from < 0 ||
+      pair.to < 0 ||
+      pair.from >= leftItems.length ||
+      pair.to >= rightItems.length
+    ) {
+      continue;
+    }
+    const source = leftItems[pair.from];
+    const target = rightItems[pair.to];
+    const from = { x: leftOval.cx + leftOval.rx * 0.72, y: source.y };
+    const to = { x: rightOval.cx - rightOval.rx * 0.72, y: target.y };
+    arrows.push({ from, to, head: arrowHead(from, to, arrowSize) });
+  }
+
+  const labelY = Math.min(h, diagramTop + diagramHeight + labelHeight * 0.55);
+  return {
+    leftOval,
+    rightOval,
+    leftItems,
+    rightItems,
+    arrows,
+    leftLabel: { x: leftOval.cx, y: labelY },
+    rightLabel: { x: rightOval.cx, y: labelY },
+    caption: block.caption ? { x: w / 2, y: captionHeight * 0.45 } : null,
+  };
+}

--- a/src/lib/slides/render/numberLineGeometry.ts
+++ b/src/lib/slides/render/numberLineGeometry.ts
@@ -1,0 +1,115 @@
+import { numberLineValueToX } from '$lib/tools/shapes';
+import type {
+  NumberLineMarkKind,
+  NumberLineObject,
+  SlideNumberLineBlock,
+  SlideTheme,
+} from '$lib/types';
+
+export interface NumberLineTick {
+  value: number;
+  x: number;
+}
+
+export interface NumberLineMarkGeometry extends NumberLineTick {
+  kind: NumberLineMarkKind;
+}
+
+export interface SlideNumberLineGeometry {
+  valid: boolean;
+  x0: number;
+  x1: number;
+  y: number;
+  ticks: NumberLineTick[];
+  labels: NumberLineTick[];
+  marks: NumberLineMarkGeometry[];
+  captionY: number | null;
+  arrowSize: number;
+}
+
+export const MAX_NUMBER_LINE_TICKS = 200;
+export const MAX_NUMBER_LINE_LABELS = 80;
+
+function finite(value: number, fallback: number): number {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+function valuesForStep(min: number, max: number, requestedStep: number, maximum: number): number[] {
+  if (!Number.isFinite(requestedStep) || requestedStep <= 0) return [];
+  const span = max - min;
+  const multiple = Math.max(1, Math.ceil(span / requestedStep / maximum));
+  const step = requestedStep * multiple;
+  const first = Math.ceil(min / step - 1e-10) * step;
+  const values: number[] = [];
+  for (let index = 0; index < maximum; index += 1) {
+    const value = first + index * step;
+    if (value > max + step * 1e-9) break;
+    values.push(value);
+  }
+  return values;
+}
+
+/** Build slide number-line geometry through the annotation value-to-x mapping. */
+export function slideNumberLineGeometry(
+  block: SlideNumberLineBlock,
+  width: number,
+  height: number,
+  theme: SlideTheme,
+): SlideNumberLineGeometry {
+  const w = Math.max(0, finite(width, 0));
+  const h = Math.max(0, finite(height, 0));
+  const bodySize = Math.max(1, finite(theme.bodySize, 13));
+  const captionHeight = block.caption ? Math.min(h * 0.2, bodySize * 1.6) : 0;
+  const xPadding = Math.min(w / 2, Math.max(bodySize * 1.8, w * 0.055));
+  const x0 = xPadding;
+  const x1 = Math.max(x0, w - xPadding);
+  const y = captionHeight + Math.max(0, h - captionHeight) * 0.48;
+  const min = finite(block.min, 0);
+  const max = finite(block.max, 0);
+  const valid = max > min && x1 > x0;
+  if (!valid) {
+    return {
+      valid: false,
+      x0,
+      x1,
+      y,
+      ticks: [],
+      labels: [],
+      marks: [],
+      captionY: block.caption ? captionHeight * 0.45 : null,
+      arrowSize: Math.min(bodySize * 0.55, w * 0.018),
+    };
+  }
+
+  const annotationLine: NumberLineObject = {
+    id: 'slide-numberline',
+    createdAt: 0,
+    type: 'numberline',
+    style: { color: theme.textColor, width: 1.5, dash: 'solid', opacity: 1 },
+    from: { x: x0, y },
+    length: x1 - x0,
+    min,
+    max,
+    tickStep: block.tickStep,
+    labelStep: block.labelStep,
+    marks: block.marks,
+  };
+  const toTick = (value: number): NumberLineTick => ({
+    value,
+    x: numberLineValueToX(annotationLine, value),
+  });
+  const marks = block.marks
+    .filter((mark) => Number.isFinite(mark.value) && mark.value >= min && mark.value <= max)
+    .map((mark) => ({ ...toTick(mark.value), kind: mark.kind }));
+  return {
+    valid: true,
+    x0,
+    x1,
+    y,
+    ticks: valuesForStep(min, max, block.tickStep, MAX_NUMBER_LINE_TICKS).map(toTick),
+    labels: valuesForStep(min, max, block.labelStep, MAX_NUMBER_LINE_LABELS).map(toTick),
+    marks,
+    captionY: block.caption ? captionHeight * 0.45 : null,
+    arrowSize: Math.min(bodySize * 0.55, w * 0.018),
+  };
+}

--- a/src/lib/slides/render/renderSlideToCanvas.ts
+++ b/src/lib/slides/render/renderSlideToCanvas.ts
@@ -1,6 +1,52 @@
-import type { Slide, SlideTheme } from '$lib/types';
-import { layoutSlide } from '../layout';
+import type { Slide, SlideMappingBlock, SlideTheme } from '$lib/types';
+import { layoutSlide, type LayoutBox } from '../layout';
 import { resolveTheme } from '../theme';
+import { mappingGeometry } from './mappingGeometry';
+
+function drawMappingPlaceholder(
+  ctx: CanvasRenderingContext2D,
+  block: SlideMappingBlock,
+  box: LayoutBox,
+  theme: SlideTheme,
+  scale: number,
+): void {
+  const geometry = mappingGeometry(block, box.w, box.h, theme.bodySize);
+  const offsetX = box.x * scale;
+  const offsetY = box.y * scale;
+
+  ctx.save();
+  ctx.lineWidth = Math.max(0.75, scale);
+  for (const [oval, color, opacity] of [
+    [geometry.leftOval, theme.accent, 0.15],
+    [geometry.rightOval, theme.textColor, 0.07],
+  ] as const) {
+    ctx.beginPath();
+    ctx.ellipse(
+      offsetX + oval.cx * scale,
+      offsetY + oval.cy * scale,
+      oval.rx * scale,
+      oval.ry * scale,
+      0,
+      0,
+      Math.PI * 2,
+    );
+    ctx.fillStyle = color;
+    ctx.globalAlpha = opacity;
+    ctx.fill();
+    ctx.globalAlpha = 0.35;
+    ctx.strokeStyle = color;
+    ctx.stroke();
+  }
+  ctx.strokeStyle = theme.textColor;
+  ctx.globalAlpha = 0.45;
+  for (const arrow of geometry.arrows.slice(0, 8)) {
+    ctx.beginPath();
+    ctx.moveTo(offsetX + arrow.from.x * scale, offsetY + arrow.from.y * scale);
+    ctx.lineTo(offsetX + arrow.to.x * scale, offsetY + arrow.to.y * scale);
+    ctx.stroke();
+  }
+  ctx.restore();
+}
 
 export function renderSlideBackground(
   ctx: CanvasRenderingContext2D,
@@ -36,6 +82,10 @@ export function renderSlideBackground(
     const y = box.y * scale;
     const w = box.w * scale;
     const h = box.h * scale;
+    if (block.kind === 'mapping') {
+      drawMappingPlaceholder(ctx, block, box, safeTheme, scale);
+      continue;
+    }
     ctx.fillStyle = block.kind === 'callout' ? safeTheme.accent : safeTheme.textColor;
     ctx.globalAlpha = block.kind === 'callout' ? 0.14 : 0.18;
     if (block.kind === 'graph' || block.kind === 'image' || block.kind === 'table') {

--- a/src/lib/slides/render/renderSlideToCanvas.ts
+++ b/src/lib/slides/render/renderSlideToCanvas.ts
@@ -1,7 +1,15 @@
-import type { Slide, SlideMappingBlock, SlideTheme } from '$lib/types';
+import type {
+  Slide,
+  SlideDiagramBlock,
+  SlideMappingBlock,
+  SlideNumberLineBlock,
+  SlideTheme,
+} from '$lib/types';
 import { layoutSlide, type LayoutBox } from '../layout';
 import { resolveTheme } from '../theme';
+import { diagramGeometry } from './diagramGeometry';
 import { mappingGeometry } from './mappingGeometry';
+import { slideNumberLineGeometry } from './numberLineGeometry';
 
 function drawMappingPlaceholder(
   ctx: CanvasRenderingContext2D,
@@ -48,6 +56,67 @@ function drawMappingPlaceholder(
   ctx.restore();
 }
 
+function drawDiagramPlaceholder(
+  ctx: CanvasRenderingContext2D,
+  block: SlideDiagramBlock,
+  box: LayoutBox,
+  theme: SlideTheme,
+  scale: number,
+): void {
+  const geometry = diagramGeometry(block, box.w, box.h, theme.bodySize);
+  const offsetX = box.x * scale;
+  const offsetY = box.y * scale;
+  ctx.save();
+  ctx.strokeStyle = theme.textColor;
+  ctx.lineWidth = Math.max(0.75, scale);
+  ctx.globalAlpha = 0.35;
+  for (const edge of geometry.edges.slice(0, 12)) {
+    ctx.beginPath();
+    ctx.moveTo(offsetX + edge.from.x * scale, offsetY + edge.from.y * scale);
+    ctx.lineTo(offsetX + edge.to.x * scale, offsetY + edge.to.y * scale);
+    ctx.stroke();
+  }
+  ctx.fillStyle = theme.accent;
+  ctx.globalAlpha = 0.13;
+  for (const node of geometry.nodes.filter((item) => item.shape === 'box').slice(0, 12)) {
+    ctx.fillRect(
+      offsetX + (node.x - node.w / 2) * scale,
+      offsetY + (node.y - node.h / 2) * scale,
+      node.w * scale,
+      node.h * scale,
+    );
+  }
+  ctx.restore();
+}
+
+function drawNumberLinePlaceholder(
+  ctx: CanvasRenderingContext2D,
+  block: SlideNumberLineBlock,
+  box: LayoutBox,
+  theme: SlideTheme,
+  scale: number,
+): void {
+  const geometry = slideNumberLineGeometry(block, box.w, box.h, theme);
+  if (!geometry.valid) return;
+  const offsetX = box.x * scale;
+  const offsetY = box.y * scale;
+  ctx.save();
+  ctx.strokeStyle = theme.textColor;
+  ctx.lineWidth = Math.max(0.75, scale);
+  ctx.globalAlpha = 0.45;
+  ctx.beginPath();
+  ctx.moveTo(offsetX + geometry.x0 * scale, offsetY + geometry.y * scale);
+  ctx.lineTo(offsetX + geometry.x1 * scale, offsetY + geometry.y * scale);
+  for (const tick of geometry.ticks.slice(0, 24)) {
+    const x = offsetX + tick.x * scale;
+    const y = offsetY + geometry.y * scale;
+    ctx.moveTo(x, y - 3 * scale);
+    ctx.lineTo(x, y + 3 * scale);
+  }
+  ctx.stroke();
+  ctx.restore();
+}
+
 export function renderSlideBackground(
   ctx: CanvasRenderingContext2D,
   slide: Slide,
@@ -84,6 +153,14 @@ export function renderSlideBackground(
     const h = box.h * scale;
     if (block.kind === 'mapping') {
       drawMappingPlaceholder(ctx, block, box, safeTheme, scale);
+      continue;
+    }
+    if (block.kind === 'diagram') {
+      drawDiagramPlaceholder(ctx, block, box, safeTheme, scale);
+      continue;
+    }
+    if (block.kind === 'numberline') {
+      drawNumberLinePlaceholder(ctx, block, box, safeTheme, scale);
       continue;
     }
     ctx.fillStyle = block.kind === 'callout' ? safeTheme.accent : safeTheme.textColor;

--- a/src/lib/slides/render/renderSlideToCanvas.ts
+++ b/src/lib/slides/render/renderSlideToCanvas.ts
@@ -1,0 +1,53 @@
+import type { Slide, SlideTheme } from '$lib/types';
+import { layoutSlide } from '../layout';
+import { resolveTheme } from '../theme';
+
+export function renderSlideBackground(
+  ctx: CanvasRenderingContext2D,
+  slide: Slide,
+  theme: SlideTheme,
+  width: number,
+  height: number,
+  ptToPx: number,
+): void {
+  const scale = Number.isFinite(ptToPx) && ptToPx > 0 ? ptToPx : 1;
+  const pageWidth = Math.max(0, width / scale);
+  const pageHeight = Math.max(0, height / scale);
+  const safeTheme = resolveTheme(theme, slide.theme);
+  const layout = layoutSlide(slide, safeTheme, pageWidth, pageHeight);
+
+  ctx.save();
+  ctx.fillStyle = safeTheme.background;
+  ctx.fillRect(0, 0, Math.max(0, width), Math.max(0, height));
+
+  if (layout.title) {
+    const title = layout.title.box;
+    ctx.fillStyle = safeTheme.accent;
+    ctx.globalAlpha = slide.layout === 'title' ? 0.12 : 0.85;
+    const barHeight = slide.layout === 'title' ? title.h * scale : Math.max(2, 2 * scale);
+    const barY = slide.layout === 'title' ? title.y * scale : (title.y + title.h) * scale;
+    ctx.fillRect(title.x * scale, barY, title.w * scale, barHeight);
+    ctx.globalAlpha = 1;
+  }
+
+  for (const { block, box } of [...layout.blocks, ...layout.asides]) {
+    if (block.kind === 'spacer') continue;
+    const x = box.x * scale;
+    const y = box.y * scale;
+    const w = box.w * scale;
+    const h = box.h * scale;
+    ctx.fillStyle = block.kind === 'callout' ? safeTheme.accent : safeTheme.textColor;
+    ctx.globalAlpha = block.kind === 'callout' ? 0.14 : 0.18;
+    if (block.kind === 'graph' || block.kind === 'image' || block.kind === 'table') {
+      ctx.fillRect(x, y, w, h);
+    } else {
+      const lineHeight = Math.max(1, Math.min(h, safeTheme.bodySize * scale * 0.35));
+      const lines = Math.max(1, Math.min(4, Math.ceil(h / Math.max(1, lineHeight * 3))));
+      for (let line = 0; line < lines; line += 1) {
+        const lineWidth = w * (line === lines - 1 ? 0.68 : 0.92);
+        ctx.fillRect(x, y + line * lineHeight * 2.4, lineWidth, lineHeight);
+      }
+    }
+  }
+  ctx.restore();
+}

--- a/src/lib/slides/templates.ts
+++ b/src/lib/slides/templates.ts
@@ -1,0 +1,268 @@
+import type { Slide, SlideSpacerBlock, SlideTextBlock } from '$lib/types';
+import { createBlock, createSlide } from './deck';
+
+export interface SlideTemplate {
+  id: string;
+  name: string;
+  description: string;
+  group: string;
+  build(): Slide;
+}
+
+function block<T>(kind: T): Extract<ReturnType<typeof createBlock>, { kind: T }> {
+  return createBlock(kind as Parameters<typeof createBlock>[0]) as Extract<
+    ReturnType<typeof createBlock>,
+    { kind: T }
+  >;
+}
+
+function titleSlide(): Slide {
+  return { ...createSlide('title', 'Heading'), subtitle: 'Add a subtitle' };
+}
+
+function agenda(): Slide {
+  const list = block<'list'>('list');
+  list.marker = 'none';
+  list.items = [
+    { text: 'Topic one', level: 0 },
+    { text: 'Topic two', level: 0 },
+    { text: 'Topic three', level: 0 },
+  ];
+  return { ...createSlide('content', 'Topics'), blocks: [list] };
+}
+
+function sectionDivider(): Slide {
+  return { ...createSlide('title', 'Section heading'), subtitle: 'Add a short introduction' };
+}
+
+function definitions(): Slide {
+  const definitionsBlock = block<'definitions'>('definitions');
+  definitionsBlock.items = [
+    { term: 'Key term', text: 'Add a description' },
+    { term: 'Key term', text: 'Add a description' },
+  ];
+  return { ...createSlide('content', 'Definitions'), blocks: [definitionsBlock] };
+}
+
+function bulletedConcept(): Slide {
+  const list = block<'list'>('list');
+  list.marker = 'bullet';
+  list.items = [
+    { text: 'Main idea', level: 0 },
+    { text: 'Supporting detail', level: 1 },
+    { text: 'Another main idea', level: 0 },
+  ];
+  return { ...createSlide('content', 'Concept heading'), blocks: [list] };
+}
+
+function numberedSteps(): Slide {
+  const list = block<'list'>('list');
+  list.marker = 'decimal';
+  list.items = [
+    { text: 'First step', level: 0 },
+    { text: 'Second step', level: 0 },
+    { text: 'Third step', level: 0 },
+  ];
+  return { ...createSlide('content', 'Steps'), blocks: [list] };
+}
+
+function tableSlide(): Slide {
+  const table = block<'table'>('table');
+  table.header = ['Heading', 'Heading'];
+  table.rows = [
+    ['Value', 'Value'],
+    ['Value', 'Value'],
+  ];
+  return { ...createSlide('content', 'Table heading'), blocks: [table] };
+}
+
+function twoTables(): Slide {
+  const left = block<'table'>('table');
+  left.caption = 'First table';
+  left.header = ['Heading', 'Heading'];
+  left.rows = [['Value', 'Value']];
+  const right = block<'table'>('table');
+  right.caption = 'Second table';
+  right.header = ['Heading', 'Heading'];
+  right.rows = [['Value', 'Value']];
+  return {
+    ...createSlide('columns', 'Compare'),
+    columnCount: 2,
+    blocks: [left, right],
+  };
+}
+
+function equationAndGraph(): Slide {
+  const equation = block<'math'>('math');
+  equation.latex = 'y = f(x)';
+  const graph = block<'graph'>('graph');
+  graph.caption = 'Graph';
+  graph.graph.functions[0].expr = 'x';
+  return {
+    ...createSlide('columns', 'Equation and graph'),
+    columnCount: 2,
+    blocks: [equation, graph],
+  };
+}
+
+function graphTrio(): Slide {
+  const graphs = ['x', 'x^2', 'x^3'].map((expression) => {
+    const graph = block<'graph'>('graph');
+    graph.graph.functions[0].expr = expression;
+    graph.height = 210;
+    return graph;
+  });
+  return {
+    ...createSlide('columns', 'Graphs'),
+    columnCount: 3,
+    blocks: graphs,
+  };
+}
+
+function workedExample(): Slide {
+  const equation = block<'math'>('math');
+  equation.latex = 'Add an equation';
+  const space = block<'spacer'>('spacer');
+  space.height = 280;
+  return { ...createSlide('content', 'Worked example'), blocks: [equation, space] };
+}
+
+function practiceGrid(): Slide {
+  const blocks: (SlideTextBlock | SlideSpacerBlock)[] = [];
+  for (let index = 1; index <= 4; index += 1) {
+    const prompt = block<'text'>('text');
+    prompt.text = `${index}. Add a problem`;
+    prompt.bold = true;
+    const space = block<'spacer'>('spacer');
+    space.height = 150;
+    blocks.push(prompt, space);
+  }
+  return {
+    ...createSlide('grid', 'Practice'),
+    columnCount: 2,
+    blocks,
+  };
+}
+
+function conceptAndTip(): Slide {
+  const list = block<'list'>('list');
+  list.items = [
+    { text: 'Main idea', level: 0 },
+    { text: 'Supporting detail', level: 1 },
+  ];
+  const tip = block<'callout'>('callout');
+  tip.tone = 'tip';
+  tip.text = 'Add a helpful tip';
+  return { ...createSlide('content', 'Concept heading'), blocks: [list], aside: [tip] };
+}
+
+function blankWorkspace(): Slide {
+  const space = block<'spacer'>('spacer');
+  space.height = 420;
+  return { ...createSlide('blank'), blocks: [space] };
+}
+
+export const slideTemplates: SlideTemplate[] = [
+  {
+    id: 'title',
+    name: 'Title slide',
+    description: 'Hero title and subtitle',
+    group: 'Structure',
+    build: titleSlide,
+  },
+  {
+    id: 'agenda',
+    name: 'Agenda / topics',
+    description: 'A simple topic list without markers',
+    group: 'Structure',
+    build: agenda,
+  },
+  {
+    id: 'section-divider',
+    name: 'Section divider',
+    description: 'A chapter break between lesson sections',
+    group: 'Structure',
+    build: sectionDivider,
+  },
+  {
+    id: 'definitions',
+    name: 'Definitions',
+    description: 'Key terms paired with descriptions',
+    group: 'Concepts',
+    build: definitions,
+  },
+  {
+    id: 'bulleted-concept',
+    name: 'Bulleted concept',
+    description: 'Nested bullets for an idea and supporting details',
+    group: 'Concepts',
+    build: bulletedConcept,
+  },
+  {
+    id: 'numbered-steps',
+    name: 'Numbered steps',
+    description: 'An ordered sequence of steps',
+    group: 'Concepts',
+    build: numberedSteps,
+  },
+  {
+    id: 'table',
+    name: 'Table',
+    description: 'A single table with a header row',
+    group: 'Data',
+    build: tableSlide,
+  },
+  {
+    id: 'two-tables',
+    name: 'Two tables',
+    description: 'Side-by-side tables for comparison',
+    group: 'Data',
+    build: twoTables,
+  },
+  {
+    id: 'equation-graph',
+    name: 'Equation + graph',
+    description: 'An equation beside its graph',
+    group: 'Math',
+    build: equationAndGraph,
+  },
+  {
+    id: 'graph-trio',
+    name: 'Graph trio',
+    description: 'Three graphs displayed in columns',
+    group: 'Math',
+    build: graphTrio,
+  },
+  {
+    id: 'worked-example',
+    name: 'Worked example',
+    description: 'An equation with room for live working',
+    group: 'Practice',
+    build: workedExample,
+  },
+  {
+    id: 'practice-grid',
+    name: 'Practice grid',
+    description: 'Four problems with generous writing space',
+    group: 'Practice',
+    build: practiceGrid,
+  },
+  {
+    id: 'concept-tip',
+    name: 'Concept + tip callout',
+    description: 'A concept list with a corner tip',
+    group: 'Concepts',
+    build: conceptAndTip,
+  },
+  {
+    id: 'blank-workspace',
+    name: 'Blank workspace',
+    description: 'An open slide reserved for live writing',
+    group: 'Practice',
+    build: blankWorkspace,
+  },
+];
+
+export function applyTemplate(templateId: string): Slide | null {
+  return slideTemplates.find((template) => template.id === templateId)?.build() ?? null;
+}

--- a/src/lib/slides/templates.ts
+++ b/src/lib/slides/templates.ts
@@ -127,6 +127,31 @@ function workedExample(): Slide {
   return { ...createSlide('content', 'Worked example'), blocks: [equation, space] };
 }
 
+function mappingDiagram(): Slide {
+  const mapping = block<'mapping'>('mapping');
+  mapping.left = ['Input', 'Input'];
+  mapping.right = ['Output', 'Output'];
+  const prompt = block<'text'>('text');
+  prompt.text = 'Add a short prompt';
+  return { ...createSlide('content', 'Mapping diagram'), blocks: [mapping, prompt] };
+}
+
+function relationPractice(): Slide {
+  const mapping = block<'mapping'>('mapping');
+  const questions = block<'list'>('list');
+  questions.marker = 'decimal';
+  questions.items = [
+    { text: 'Find the domain.', level: 0 },
+    { text: 'Find the range.', level: 0 },
+    { text: 'Is it a function?', level: 0 },
+  ];
+  return {
+    ...createSlide('columns', 'Relation practice'),
+    columnCount: 2,
+    blocks: [mapping, questions],
+  };
+}
+
 function practiceGrid(): Slide {
   const blocks: (SlideTextBlock | SlideSpacerBlock)[] = [];
   for (let index = 1; index <= 4; index += 1) {
@@ -239,6 +264,20 @@ export const slideTemplates: SlideTemplate[] = [
     description: 'An equation with room for live working',
     group: 'Practice',
     build: workedExample,
+  },
+  {
+    id: 'mapping-diagram',
+    name: 'Mapping diagram',
+    description: 'A domain-to-range mapping with a short prompt',
+    group: 'Math',
+    build: mappingDiagram,
+  },
+  {
+    id: 'relation-practice',
+    name: 'Relation practice',
+    description: 'A mapping beside domain and range questions',
+    group: 'Practice',
+    build: relationPractice,
   },
   {
     id: 'practice-grid',

--- a/src/lib/slides/templates.ts
+++ b/src/lib/slides/templates.ts
@@ -152,6 +152,87 @@ function relationPractice(): Slide {
   };
 }
 
+function functionMachine(): Slide {
+  const diagram = block<'diagram'>('diagram');
+  diagram.nodes = [
+    { id: 'forward-input', text: 'Input', x: 0.08, y: 0.25, shape: 'plain' },
+    { id: 'forward-first', text: 'Operation 1', x: 0.35, y: 0.25, shape: 'box' },
+    { id: 'forward-second', text: 'Operation 2', x: 0.65, y: 0.25, shape: 'box' },
+    { id: 'forward-output', text: 'Output', x: 0.92, y: 0.25, shape: 'plain' },
+    { id: 'reverse-output', text: 'Output', x: 0.92, y: 0.75, shape: 'plain' },
+    { id: 'reverse-second', text: 'Undo operation 2', x: 0.65, y: 0.75, shape: 'box' },
+    { id: 'reverse-first', text: 'Undo operation 1', x: 0.35, y: 0.75, shape: 'box' },
+    { id: 'reverse-input', text: 'Input', x: 0.08, y: 0.75, shape: 'plain' },
+  ];
+  diagram.edges = [
+    { from: 'forward-input', to: 'forward-first' },
+    { from: 'forward-first', to: 'forward-second' },
+    { from: 'forward-second', to: 'forward-output' },
+    { from: 'reverse-output', to: 'reverse-second' },
+    { from: 'reverse-second', to: 'reverse-first' },
+    { from: 'reverse-first', to: 'reverse-input' },
+  ];
+  diagram.height = 300;
+  return { ...createSlide('content', 'Function machine'), blocks: [diagram] };
+}
+
+function labelledExpression(): Slide {
+  const expression = block<'math'>('math');
+  expression.latex = 'a(b + c)';
+  const diagram = block<'diagram'>('diagram');
+  diagram.nodes = [
+    { id: 'label-one', text: 'Label', x: 0.2, y: 0.8, shape: 'plain' },
+    { id: 'target-one', text: 'Part', x: 0.4, y: 0.2, shape: 'plain' },
+    { id: 'label-two', text: 'Label', x: 0.8, y: 0.8, shape: 'plain' },
+    { id: 'target-two', text: 'Part', x: 0.6, y: 0.2, shape: 'plain' },
+  ];
+  diagram.edges = [
+    { from: 'label-one', to: 'target-one' },
+    { from: 'label-two', to: 'target-two' },
+  ];
+  diagram.height = 180;
+  return { ...createSlide('content', 'Labelled expression'), blocks: [expression, diagram] };
+}
+
+function numberLineSlide(): Slide {
+  const numberline = block<'numberline'>('numberline');
+  const prompt = block<'text'>('text');
+  prompt.text = 'Add a short prompt';
+  return { ...createSlide('content', 'Number line'), blocks: [numberline, prompt] };
+}
+
+function subNumberedSteps(): Slide {
+  const list = block<'list'>('list');
+  list.marker = 'decimal';
+  list.markerByLevel = ['decimal', 'alpha'];
+  list.items = [
+    { text: 'First step', level: 0 },
+    { text: 'Sub-step', level: 1 },
+    { text: 'Second step', level: 0 },
+  ];
+  return { ...createSlide('content', 'Steps'), blocks: [list] };
+}
+
+function dataTable(): Slide {
+  const table = block<'table'>('table');
+  table.headerOrientation = 'column';
+  table.header = ['Label', 'Value', 'Value'];
+  table.rows = [
+    ['Category', 'Value', 'Value'],
+    ['Category', 'Value', 'Value'],
+  ];
+  const firstPrompt = block<'text'>('text');
+  firstPrompt.text = 'Add a question about the data';
+  const secondPrompt = block<'text'>('text');
+  secondPrompt.text = 'Add a follow-up question';
+  const space = block<'spacer'>('spacer');
+  space.height = 180;
+  return {
+    ...createSlide('content', 'Data table'),
+    blocks: [table, firstPrompt, secondPrompt, space],
+  };
+}
+
 function practiceGrid(): Slide {
   const blocks: (SlideTextBlock | SlideSpacerBlock)[] = [];
   for (let index = 1; index <= 4; index += 1) {
@@ -278,6 +359,41 @@ export const slideTemplates: SlideTemplate[] = [
     description: 'A mapping beside domain and range questions',
     group: 'Practice',
     build: relationPractice,
+  },
+  {
+    id: 'function-machine',
+    name: 'Function machine',
+    description: 'Forward and reverse operation chains',
+    group: 'Math',
+    build: functionMachine,
+  },
+  {
+    id: 'labelled-expression',
+    name: 'Labelled expression',
+    description: 'An expression with leader-line labels',
+    group: 'Math',
+    build: labelledExpression,
+  },
+  {
+    id: 'number-line',
+    name: 'Number line',
+    description: 'A number line with a short prompt',
+    group: 'Math',
+    build: numberLineSlide,
+  },
+  {
+    id: 'sub-numbered-steps',
+    name: 'Sub-numbered steps',
+    description: 'Numbered steps with alphabetic sub-steps',
+    group: 'Concepts',
+    build: subNumberedSteps,
+  },
+  {
+    id: 'data-table',
+    name: 'Data table',
+    description: 'Column-headed data with prompts and writing space',
+    group: 'Data',
+    build: dataTable,
   },
   {
     id: 'practice-grid',

--- a/src/lib/slides/theme.ts
+++ b/src/lib/slides/theme.ts
@@ -1,0 +1,108 @@
+import { isSafeHexColor } from '$lib/color';
+import type { SlideTheme } from '$lib/types';
+
+const SAFE_FONT_FAMILY_RE = /^[A-Za-z0-9 ,_'’-]+$/;
+const FORBIDDEN_FONT_TOKEN_RE = /(?:url|expression)\s*\(/i;
+const MIN_FONT_SIZE = 6;
+const MAX_FONT_SIZE = 144;
+
+export const defaultSlideTheme: SlideTheme = Object.freeze({
+  fontFamily: 'system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif',
+  background: '#fbfbf8',
+  titleColor: '#25282d',
+  textColor: '#34383f',
+  accent: '#356f8a',
+  titleSize: 34,
+  headingSize: 20,
+  bodySize: 13,
+});
+
+function isSafeFontFamily(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    value.length <= 200 &&
+    SAFE_FONT_FAMILY_RE.test(value) &&
+    !FORBIDDEN_FONT_TOKEN_RE.test(value)
+  );
+}
+
+function isSafeFontSize(value: unknown): value is number {
+  return (
+    typeof value === 'number' &&
+    Number.isFinite(value) &&
+    value >= MIN_FONT_SIZE &&
+    value <= MAX_FONT_SIZE
+  );
+}
+
+function safeColor(value: unknown, fallback: string): string {
+  return isSafeHexColor(value) ? value : fallback;
+}
+
+function safeFontFamily(value: unknown, fallback: string): string {
+  return isSafeFontFamily(value) ? value : fallback;
+}
+
+function safeFontSize(value: unknown, fallback: number): number {
+  return isSafeFontSize(value) ? value : fallback;
+}
+
+/** Resolve untrusted deck and slide values without allowing CSS injection. */
+export function resolveTheme(
+  base: SlideTheme | undefined,
+  override: Partial<SlideTheme> | undefined,
+): SlideTheme {
+  const resolvedBase: SlideTheme = {
+    fontFamily: safeFontFamily(base?.fontFamily, defaultSlideTheme.fontFamily),
+    background: safeColor(base?.background, defaultSlideTheme.background),
+    titleColor: safeColor(base?.titleColor, defaultSlideTheme.titleColor),
+    textColor: safeColor(base?.textColor, defaultSlideTheme.textColor),
+    accent: safeColor(base?.accent, defaultSlideTheme.accent),
+    titleSize: safeFontSize(base?.titleSize, defaultSlideTheme.titleSize),
+    headingSize: safeFontSize(base?.headingSize, defaultSlideTheme.headingSize),
+    bodySize: safeFontSize(base?.bodySize, defaultSlideTheme.bodySize),
+  };
+
+  return {
+    fontFamily: safeFontFamily(override?.fontFamily, resolvedBase.fontFamily),
+    background: safeColor(override?.background, resolvedBase.background),
+    titleColor: safeColor(override?.titleColor, resolvedBase.titleColor),
+    textColor: safeColor(override?.textColor, resolvedBase.textColor),
+    accent: safeColor(override?.accent, resolvedBase.accent),
+    titleSize: safeFontSize(override?.titleSize, resolvedBase.titleSize),
+    headingSize: safeFontSize(override?.headingSize, resolvedBase.headingSize),
+    bodySize: safeFontSize(override?.bodySize, resolvedBase.bodySize),
+  };
+}
+
+export function isSafeSlideTheme(value: unknown): value is SlideTheme {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const theme = value as Record<string, unknown>;
+  const expectedKeys = [
+    'fontFamily',
+    'background',
+    'titleColor',
+    'textColor',
+    'accent',
+    'titleSize',
+    'headingSize',
+    'bodySize',
+  ];
+  if (
+    Object.keys(theme).length !== expectedKeys.length ||
+    expectedKeys.some((key) => !Object.hasOwn(theme, key))
+  ) {
+    return false;
+  }
+  return (
+    isSafeFontFamily(theme.fontFamily) &&
+    isSafeHexColor(theme.background) &&
+    isSafeHexColor(theme.titleColor) &&
+    isSafeHexColor(theme.textColor) &&
+    isSafeHexColor(theme.accent) &&
+    isSafeFontSize(theme.titleSize) &&
+    isSafeFontSize(theme.headingSize) &&
+    isSafeFontSize(theme.bodySize)
+  );
+}

--- a/src/lib/store/document.ts
+++ b/src/lib/store/document.ts
@@ -31,6 +31,11 @@ function commandToMutations(pageIndex: number, cmd: Command): MutationEvent[] {
         id: e.objectId,
         after: e.after,
       }));
+    case 'reorder':
+      return [
+        { kind: 'remove', pageIndex, ids: cmd.before.map((o) => o.id) },
+        ...cmd.after.map((object) => ({ kind: 'add' as const, pageIndex, object })),
+      ];
     case 'clearPage':
       return [{ kind: 'remove', pageIndex, ids: cmd.objects.map((o) => o.id) }];
     case 'restorePage':
@@ -52,6 +57,7 @@ export interface DocumentStore {
   addObject(pageIndex: number, obj: AnyObject): void;
   removeObject(pageIndex: number, id: ObjectId): void;
   removeObjects(pageIndex: number, ids: readonly ObjectId[]): void;
+  reorderObjects(pageIndex: number, objects: readonly AnyObject[]): void;
   updateObject(pageIndex: number, id: ObjectId, patch: Partial<AnyObject>): void;
   /**
    * Apply a batch of object replacements under a single history entry. The
@@ -272,6 +278,20 @@ export function createDocumentStore(): DocumentStore {
         .filter(({ object }) => wanted.has(object.id));
       if (items.length === 0) return;
       pushAndApply(pageIndex, { type: 'removeMany', items });
+    },
+
+    reorderObjects(pageIndex, objects) {
+      const doc = get(state);
+      if (!doc) return;
+      const page = doc.pages[pageIndex];
+      if (!page || page.objects.length !== objects.length) return;
+      const currentIds = new Set(page.objects.map((object) => object.id));
+      if (objects.some((object) => !currentIds.has(object.id))) return;
+      pushAndApply(pageIndex, {
+        type: 'reorder',
+        before: [...page.objects],
+        after: [...objects],
+      });
     },
 
     updateObject(pageIndex, id, patch) {

--- a/src/lib/store/document.ts
+++ b/src/lib/store/document.ts
@@ -17,7 +17,7 @@ function commandToMutations(pageIndex: number, cmd: Command): MutationEvent[] {
     case 'add':
       return [{ kind: 'add', pageIndex, object: cmd.object }];
     case 'remove':
-      return [{ kind: 'remove', pageIndex, ids: [cmd.object.id] }];
+      return [{ kind: 'remove', pageIndex, ids: [cmd.item.object.id] }];
     case 'removeMany':
       return [{ kind: 'remove', pageIndex, ids: cmd.items.map((i) => i.object.id) }];
     case 'insertMany':
@@ -261,9 +261,12 @@ export function createDocumentStore(): DocumentStore {
       if (!doc) return;
       const page = doc.pages[pageIndex];
       if (!page) return;
-      const obj = page.objects.find((o) => o.id === id);
-      if (!obj) return;
-      pushAndApply(pageIndex, { type: 'remove', object: obj });
+      const index = page.objects.findIndex((o) => o.id === id);
+      if (index < 0) return;
+      pushAndApply(pageIndex, {
+        type: 'remove',
+        item: { object: page.objects[index], index },
+      });
     },
 
     removeObjects(pageIndex, ids) {

--- a/src/lib/store/document.ts
+++ b/src/lib/store/document.ts
@@ -1,6 +1,7 @@
 import { derived, get, writable, type Readable } from 'svelte/store';
-import type { AnyObject, EldrawDocument, ObjectId, Page } from '$lib/types';
+import type { AnyObject, EldrawDocument, ObjectId, Page, Slide } from '$lib/types';
 import { isSafeHexColor } from '$lib/color';
+import { sanitizeSlide } from '$lib/slides/deck';
 import { applyCommand, createHistory, invertCommand, type Command, type History } from './history';
 
 export type PageCommitListener = (pageIndex: number) => void;
@@ -72,6 +73,10 @@ export interface DocumentStore {
     height: number,
     background?: string,
   ): void;
+  /** Insert an authored slide as a new page after the given array position. */
+  insertSlidePageAfter(afterArrayIndex: number, slide: Slide, width: number, height: number): void;
+  /** Replace the slide content of a slide page. Not undoable via page history. */
+  updateSlide(pageIndex: number, slide: Slide): void;
   movePage(from: number, to: number): void;
   duplicatePage(index: number): void;
   deletePage(index: number): void;
@@ -142,7 +147,7 @@ function lastPdfIndexAtOrBefore(pages: readonly Page[], arrayIndex: number): num
 function normalizeLoaded(doc: EldrawDocument): EldrawDocument {
   let nextDerived = 0;
   const pages = doc.pages.map((p, i) => {
-    const withBg = sanitizePageBackground(p);
+    const withBg = sanitizeLoadedPage(p);
     const base = withBg.pageIndex === i ? withBg : { ...withBg, pageIndex: i };
     if (base.type === 'pdf' && typeof base.pdfSourceIndex !== 'number') {
       const withSource = { ...base, pdfSourceIndex: nextDerived };
@@ -168,6 +173,22 @@ function sanitizePageBackground(page: Page): Page {
   const { background: _drop, ...rest } = page;
   void _drop;
   return rest as Page;
+}
+
+/**
+ * Apply every load-time trust boundary to a page. Slide content reaches the
+ * DOM through `{@html}` and inline styles, so it is sanitized here rather
+ * than at render time. A slide page whose content fails validation degrades
+ * to a blank page instead of being dropped, so annotations are never lost.
+ */
+function sanitizeLoadedPage(page: Page): Page {
+  const withBg = sanitizePageBackground(page);
+  if (withBg.type !== 'slide') return withBg;
+  const slide = sanitizeSlide(withBg.slide);
+  if (slide) return { ...withBg, slide };
+  const { slide: _drop, ...rest } = withBg;
+  void _drop;
+  return { ...(rest as Page), type: 'blank' };
 }
 
 function reindex(pages: Page[]): Page[] {
@@ -344,6 +365,39 @@ export function createDocumentStore(): DocumentStore {
         pages.splice(insertIdx, 0, blank);
         history.shiftPageIndicesFrom(insertIdx);
         return { ...doc, pages: reindex(pages) };
+      });
+    },
+
+    insertSlidePageAfter(afterArrayIndex, slide, width, height) {
+      const safe = sanitizeSlide(slide);
+      if (!safe) return;
+      state.update((doc) => {
+        if (!doc) return doc;
+        const insertIdx = afterArrayIndex + 1;
+        const page: Page = {
+          pageIndex: insertIdx,
+          type: 'slide',
+          insertedAfterPdfPage: lastPdfIndexAtOrBefore(doc.pages, afterArrayIndex),
+          width,
+          height,
+          slide: safe,
+          objects: [],
+        };
+        const pages = [...doc.pages];
+        pages.splice(insertIdx, 0, page);
+        history.shiftPageIndicesFrom(insertIdx);
+        return { ...doc, pages: reindex(pages) };
+      });
+    },
+
+    updateSlide(pageIndex, slide) {
+      const safe = sanitizeSlide(slide);
+      if (!safe) return;
+      state.update((doc) => {
+        if (!doc) return doc;
+        const page = doc.pages[pageIndex];
+        if (!page || page.type !== 'slide') return doc;
+        return replacePage(doc, pageIndex, { ...page, slide: safe });
       });
     },
 

--- a/src/lib/store/document.ts
+++ b/src/lib/store/document.ts
@@ -309,6 +309,11 @@ export function createDocumentStore(): DocumentStore {
       if (!doc) return;
       const page = doc.pages[pageIndex];
       if (!page || page.objects.length !== objects.length) return;
+      // The new order must be a permutation of the current one. Matching only
+      // length and membership would let a duplicated id silently drop another
+      // object from the page.
+      const nextIds = new Set(objects.map((object) => object.id));
+      if (nextIds.size !== objects.length) return;
       const currentIds = new Set(page.objects.map((object) => object.id));
       if (objects.some((object) => !currentIds.has(object.id))) return;
       pushAndApply(pageIndex, {

--- a/src/lib/store/graphPreview.ts
+++ b/src/lib/store/graphPreview.ts
@@ -1,0 +1,19 @@
+import { writable, type Readable } from 'svelte/store';
+import type { GraphObject } from '$lib/types';
+
+export interface GraphPreview {
+  pageIndex: number;
+  graph: GraphObject;
+}
+
+const store = writable<GraphPreview | null>(null);
+
+export const graphPreview: Readable<GraphPreview | null> = { subscribe: store.subscribe };
+
+export function setGraphPreview(preview: GraphPreview): void {
+  store.set(preview);
+}
+
+export function clearGraphPreview(): void {
+  store.set(null);
+}

--- a/src/lib/store/history.ts
+++ b/src/lib/store/history.ts
@@ -19,7 +19,7 @@ export interface UpdateEntry {
 
 export type Command =
   | { type: 'add'; object: AnyObject }
-  | { type: 'remove'; object: AnyObject }
+  | { type: 'remove'; item: IndexedObject }
   | { type: 'removeMany'; items: IndexedObject[] }
   | { type: 'insertMany'; items: IndexedObject[] }
   | { type: 'update'; objectId: ObjectId; before: AnyObject; after: AnyObject }
@@ -35,7 +35,7 @@ export function applyCommand(page: Page, cmd: Command): Page {
     case 'add':
       return { ...page, objects: [...page.objects, cmd.object] };
     case 'remove':
-      return { ...page, objects: page.objects.filter((o) => o.id !== cmd.object.id) };
+      return { ...page, objects: page.objects.filter((o) => o.id !== cmd.item.object.id) };
     case 'removeMany': {
       const drop = new Set(cmd.items.map((i) => i.object.id));
       return { ...page, objects: page.objects.filter((o) => !drop.has(o.id)) };
@@ -72,9 +72,9 @@ export function applyCommand(page: Page, cmd: Command): Page {
 export function invertCommand(cmd: Command): Command {
   switch (cmd.type) {
     case 'add':
-      return { type: 'remove', object: cmd.object };
+      return { type: 'removeMany', items: [{ object: cmd.object, index: 0 }] };
     case 'remove':
-      return { type: 'add', object: cmd.object };
+      return { type: 'insertMany', items: [cmd.item] };
     case 'removeMany':
       return { type: 'insertMany', items: cmd.items };
     case 'insertMany':

--- a/src/lib/store/history.ts
+++ b/src/lib/store/history.ts
@@ -24,6 +24,7 @@ export type Command =
   | { type: 'insertMany'; items: IndexedObject[] }
   | { type: 'update'; objectId: ObjectId; before: AnyObject; after: AnyObject }
   | { type: 'updateMany'; entries: UpdateEntry[] }
+  | { type: 'reorder'; before: AnyObject[]; after: AnyObject[] }
   | { type: 'clearPage'; objects: AnyObject[] }
   | { type: 'restorePage'; objects: AnyObject[] };
 
@@ -59,6 +60,8 @@ export function applyCommand(page: Page, cmd: Command): Page {
         objects: page.objects.map((o) => byId.get(o.id) ?? o),
       };
     }
+    case 'reorder':
+      return { ...page, objects: [...cmd.after] };
     case 'clearPage':
       return { ...page, objects: [] };
     case 'restorePage':
@@ -92,6 +95,8 @@ export function invertCommand(cmd: Command): Command {
           after: e.before,
         })),
       };
+    case 'reorder':
+      return { type: 'reorder', before: cmd.after, after: cmd.before };
     case 'clearPage':
       return { type: 'restorePage', objects: cmd.objects };
     case 'restorePage':

--- a/src/lib/store/sidebar.ts
+++ b/src/lib/store/sidebar.ts
@@ -1,6 +1,7 @@
 import { derived, get, writable, type Readable } from 'svelte/store';
 import type { ColorPalette, DashStyle, StrokeStyle, ToolKind, ToolPreset } from '$lib/types';
 import { clampFadeMs, DEFAULT_TEMP_INK_FADE_MS } from '$lib/tools/tempInk';
+import { isSafeHexColor } from '$lib/color';
 import { DEFAULT_STRAIGHT_EDGE_SNAP_STEP } from '$lib/tools/straightEdge';
 import type { SnapEdge } from '$lib/sidebar/snap';
 
@@ -696,7 +697,7 @@ function isStrokeStyle(value: unknown): value is StrokeStyle {
   if (!value || typeof value !== 'object') return false;
   const s = value as Record<string, unknown>;
   return (
-    typeof s.color === 'string' &&
+    isSafeHexColor(s.color) &&
     typeof s.width === 'number' &&
     Number.isFinite(s.width) &&
     typeof s.dash === 'string' &&
@@ -711,7 +712,7 @@ function isColorPalette(value: unknown): value is ColorPalette {
   const p = value as Record<string, unknown>;
   if (typeof p.id !== 'string' || typeof p.name !== 'string') return false;
   if (!Array.isArray(p.colors)) return false;
-  return p.colors.every((c): c is string => typeof c === 'string');
+  return p.colors.every(isSafeHexColor);
 }
 
 function sanitizeImportedSidebar(raw: Record<string, unknown>): Partial<SyncableSidebarState> {
@@ -745,10 +746,10 @@ function sanitizeImportedSidebar(raw: Record<string, unknown>): Partial<Syncable
   if (Array.isArray(raw.palettes) && raw.palettes.every(isColorPalette)) {
     out.palettes = raw.palettes.map((p) => ({ ...p, colors: [...p.colors] }));
   }
-  if (typeof raw.activeColor === 'string') out.activeColor = raw.activeColor;
+  if (isSafeHexColor(raw.activeColor)) out.activeColor = raw.activeColor;
   if (raw.laser && typeof raw.laser === 'object') {
     const l = raw.laser as Record<string, unknown>;
-    if (typeof l.color === 'string' && typeof l.radius === 'number' && Number.isFinite(l.radius)) {
+    if (isSafeHexColor(l.color) && typeof l.radius === 'number' && Number.isFinite(l.radius)) {
       out.laser = { color: l.color, radius: clamp(l.radius, MIN_LASER_RADIUS, MAX_LASER_RADIUS) };
     }
   }

--- a/src/lib/text/autodetect.ts
+++ b/src/lib/text/autodetect.ts
@@ -1,0 +1,404 @@
+import { segmentLatex, type TextSegment } from './segment';
+
+const FUNCTION_NAMES = new Set([
+  'sin',
+  'cos',
+  'tan',
+  'sec',
+  'csc',
+  'cot',
+  'log',
+  'ln',
+  'exp',
+  'sqrt',
+  'abs',
+  'min',
+  'max',
+]);
+
+const GREEK_NAMES = new Set([
+  'alpha',
+  'beta',
+  'gamma',
+  'delta',
+  'epsilon',
+  'zeta',
+  'eta',
+  'theta',
+  'iota',
+  'kappa',
+  'lambda',
+  'mu',
+  'nu',
+  'xi',
+  'omicron',
+  'pi',
+  'rho',
+  'sigma',
+  'tau',
+  'upsilon',
+  'phi',
+  'chi',
+  'psi',
+  'omega',
+]);
+
+const CONSTANT_NAMES = new Set(['oo', 'infty']);
+const RELATIONS = new Set(['=', '<', '>', '<=', '>=', '!=', '=>', '≠', '≤', '≥']);
+const OPERATORS = [
+  '<=',
+  '>=',
+  '!=',
+  '=>',
+  '->',
+  '+-',
+  '+',
+  '-',
+  '*',
+  '/',
+  '^',
+  '_',
+  '=',
+  '<',
+  '>',
+  '≤',
+  '≥',
+  '≠',
+  '±',
+];
+
+type TokenKind =
+  | 'number'
+  | 'word'
+  | 'control'
+  | 'operator'
+  | 'bracket'
+  | 'punctuation'
+  | 'space'
+  | 'other';
+
+interface Token {
+  kind: TokenKind;
+  value: string;
+  start: number;
+  end: number;
+  recognizedWord?: boolean;
+  scriptOperand?: boolean;
+}
+
+function tokenize(source: string): Token[] {
+  const tokens: Token[] = [];
+  let index = 0;
+
+  while (index < source.length) {
+    const start = index;
+    const char = source[index];
+
+    if (char === '\n' || char === '\r') {
+      tokens.push({ kind: 'other', value: char, start, end: ++index });
+      continue;
+    }
+
+    if (char === ' ' || char === '\t') {
+      while (source[index] === ' ' || source[index] === '\t') index += 1;
+      tokens.push({ kind: 'space', value: source.slice(start, index), start, end: index });
+      continue;
+    }
+
+    if (char === '\\' && /[A-Za-z]/.test(source[index + 1] ?? '')) {
+      index += 2;
+      while (/[A-Za-z]/.test(source[index] ?? '')) index += 1;
+      tokens.push({ kind: 'control', value: source.slice(start, index), start, end: index });
+      continue;
+    }
+
+    if (/\d/.test(char) || (char === '.' && /\d/.test(source[index + 1] ?? ''))) {
+      if (char === '.') index += 1;
+      while (/\d/.test(source[index] ?? '')) index += 1;
+      if (source[index] === '.' && /\d/.test(source[index + 1] ?? '')) {
+        index += 1;
+        while (/\d/.test(source[index] ?? '')) index += 1;
+      }
+      tokens.push({ kind: 'number', value: source.slice(start, index), start, end: index });
+      continue;
+    }
+
+    if (/[A-Za-z]/.test(char)) {
+      index += 1;
+      while (/[A-Za-z]/.test(source[index] ?? '')) index += 1;
+      const value = source.slice(start, index);
+      const lower = value.toLowerCase();
+      tokens.push({
+        kind: 'word',
+        value,
+        start,
+        end: index,
+        recognizedWord:
+          value.length === 1 ||
+          FUNCTION_NAMES.has(lower) ||
+          GREEK_NAMES.has(lower) ||
+          CONSTANT_NAMES.has(lower),
+      });
+      continue;
+    }
+
+    const operator = OPERATORS.find((candidate) => source.startsWith(candidate, index));
+    if (operator) {
+      index += operator.length;
+      tokens.push({ kind: 'operator', value: operator, start, end: index });
+      continue;
+    }
+
+    if ('()[]{}'.includes(char)) {
+      tokens.push({ kind: 'bracket', value: char, start, end: ++index });
+      continue;
+    }
+
+    if (char === ',' || char === '.') {
+      tokens.push({ kind: 'punctuation', value: char, start, end: ++index });
+      continue;
+    }
+
+    tokens.push({ kind: 'other', value: char, start, end: ++index });
+  }
+
+  return tokens;
+}
+
+function previousSignificant(tokens: Token[], from: number): Token | undefined {
+  for (let index = from; index >= 0; index -= 1) {
+    if (tokens[index].kind !== 'space' && tokens[index].kind !== 'punctuation') {
+      return tokens[index];
+    }
+  }
+  return undefined;
+}
+
+function nextSignificant(tokens: Token[], from: number): Token | undefined {
+  for (let index = from; index < tokens.length; index += 1) {
+    if (tokens[index].kind !== 'space' && tokens[index].kind !== 'punctuation') {
+      return tokens[index];
+    }
+  }
+  return undefined;
+}
+
+function isLeftOperand(token: Token | undefined): boolean {
+  if (!token) return false;
+  if (token.kind === 'number' || token.kind === 'control') return true;
+  if (token.kind === 'word') return token.recognizedWord === true || token.scriptOperand === true;
+  return token.kind === 'bracket' && ')]}'.includes(token.value);
+}
+
+function isRightOperand(token: Token | undefined): boolean {
+  if (!token) return false;
+  if (token.kind === 'number' || token.kind === 'control') return true;
+  if (token.kind === 'word') return token.recognizedWord === true || token.scriptOperand === true;
+  return token.kind === 'bracket' && '([{'.includes(token.value);
+}
+
+function hasOperandAfter(tokens: Token[], from: number): boolean {
+  let token = nextSignificant(tokens, from);
+  if (token?.kind === 'operator' && (token.value === '+' || token.value === '-')) {
+    const signIndex = tokens.indexOf(token);
+    token = nextSignificant(tokens, signIndex + 1);
+  }
+  return isRightOperand(token);
+}
+
+function hasStrongSignal(source: string, tokens: Token[]): boolean {
+  if (tokens.some((token) => token.kind === 'control')) return true;
+  if (/\d[A-Za-z]/.test(source) || source.includes(')(')) return true;
+
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (token.kind !== 'operator') continue;
+
+    if (
+      RELATIONS.has(token.value) &&
+      isLeftOperand(previousSignificant(tokens, index - 1)) &&
+      hasOperandAfter(tokens, index + 1)
+    ) {
+      return true;
+    }
+
+    if (
+      (token.value === '^' || token.value === '_') &&
+      isLeftOperand(previousSignificant(tokens, index - 1)) &&
+      hasOperandAfter(tokens, index + 1)
+    ) {
+      return true;
+    }
+  }
+
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    const callable =
+      token.kind === 'control' ||
+      (token.kind === 'word' &&
+        (token.value.length === 1 || FUNCTION_NAMES.has(token.value.toLowerCase())));
+    if (!callable) continue;
+    const next = nextSignificant(tokens, index + 1);
+    if (next?.kind === 'bracket' && next.value === '(') return true;
+  }
+
+  return false;
+}
+
+function hasProseSequence(tokens: Token[]): boolean {
+  let consecutive = 0;
+  for (const token of tokens) {
+    if (
+      token.kind === 'word' &&
+      token.value.length >= 3 &&
+      token.recognizedWord !== true &&
+      token.scriptOperand !== true
+    ) {
+      consecutive += 1;
+      if (consecutive >= 2) return true;
+    } else if (token.kind !== 'space') {
+      consecutive = 0;
+    }
+  }
+  return false;
+}
+
+function candidateLooksLikeMath(source: string, tokens: Token[]): boolean {
+  const meaningful = tokens.filter(
+    (token) =>
+      token.kind !== 'space' &&
+      token.kind !== 'punctuation' &&
+      !(token.kind === 'bracket' && '()[]{}'.includes(token.value)),
+  );
+  if (meaningful.length === 0 || hasProseSequence(tokens) || !hasBalancedBrackets(tokens)) {
+    return false;
+  }
+  return hasStrongSignal(source, tokens);
+}
+
+function hasBalancedBrackets(tokens: Token[]): boolean {
+  const stack: string[] = [];
+  const pairs: Record<string, string> = { ')': '(', ']': '[', '}': '{' };
+  for (const token of tokens) {
+    if (token.kind !== 'bracket') continue;
+    if ('([{'.includes(token.value)) {
+      stack.push(token.value);
+    } else if (stack.pop() !== pairs[token.value]) {
+      return false;
+    }
+  }
+  return stack.length === 0;
+}
+
+function trimCandidate(tokens: Token[]): Token[] {
+  let start = 0;
+  let end = tokens.length;
+
+  while (start < end && (tokens[start].kind === 'space' || tokens[start].kind === 'punctuation')) {
+    start += 1;
+  }
+  while (
+    end > start &&
+    (tokens[end - 1].kind === 'space' || tokens[end - 1].kind === 'punctuation')
+  ) {
+    end -= 1;
+  }
+
+  return tokens.slice(start, end);
+}
+
+function canJoinCandidate(token: Token, candidate: Token[]): boolean {
+  if (token.kind === 'other') return false;
+  if (token.kind !== 'word' || token.recognizedWord) return true;
+
+  const previous = previousSignificant(candidate, candidate.length - 1);
+  if (previous?.kind === 'operator' && (previous.value === '^' || previous.value === '_')) {
+    token.scriptOperand = true;
+    return true;
+  }
+  const significant = candidate.filter(
+    (candidateToken) => candidateToken.kind !== 'space' && candidateToken.kind !== 'punctuation',
+  );
+  const beforePrevious = significant[significant.length - 2];
+  if (
+    previous?.kind === 'bracket' &&
+    previous.value === '{' &&
+    beforePrevious?.kind === 'operator' &&
+    (beforePrevious.value === '^' || beforePrevious.value === '_')
+  ) {
+    token.scriptOperand = true;
+    return true;
+  }
+  return false;
+}
+
+function pushSegment(out: TextSegment[], segment: TextSegment): void {
+  if (segment.value.length === 0) return;
+  const previous = out[out.length - 1];
+  if (previous?.kind === 'text' && segment.kind === 'text') {
+    previous.value += segment.value;
+    return;
+  }
+  out.push(segment);
+}
+
+/** Detect conservative, undelimited math runs while leaving prose untouched. */
+export function detectMathSegments(source: string): TextSegment[] {
+  const tokens = tokenize(source);
+  const ranges: Array<{ start: number; end: number }> = [];
+  let candidate: Token[] = [];
+
+  const flush = () => {
+    const trimmed = trimCandidate(candidate);
+    if (trimmed.length > 0) {
+      const start = trimmed[0].start;
+      const end = trimmed[trimmed.length - 1].end;
+      if (candidateLooksLikeMath(source.slice(start, end), trimmed)) ranges.push({ start, end });
+    }
+    candidate = [];
+  };
+
+  for (const token of tokens) {
+    if (canJoinCandidate(token, candidate)) {
+      if (token.kind !== 'space' || candidate.length > 0) candidate.push(token);
+    } else {
+      flush();
+    }
+  }
+  flush();
+
+  if (ranges.length === 0) return source.length === 0 ? [] : [{ kind: 'text', value: source }];
+
+  const out: TextSegment[] = [];
+  let cursor = 0;
+  for (const range of ranges) {
+    pushSegment(out, { kind: 'text', value: source.slice(cursor, range.start) });
+    pushSegment(out, {
+      kind: 'math',
+      value: source.slice(range.start, range.end),
+      display: false,
+    });
+    cursor = range.end;
+  }
+  pushSegment(out, { kind: 'text', value: source.slice(cursor) });
+  return out;
+}
+
+/** Explicit delimiters take precedence; auto-detection only visits literal runs. */
+export function autoSegment(source: string): TextSegment[] {
+  const out: TextSegment[] = [];
+  for (const segment of segmentLatex(source)) {
+    if (segment.kind === 'math') {
+      pushSegment(out, segment);
+      continue;
+    }
+    for (const detected of detectMathSegments(segment.value)) pushSegment(out, detected);
+  }
+  return out;
+}
+
+export function looksLikeMath(candidate: string): boolean {
+  const trimmed = candidate.trim();
+  const segments = detectMathSegments(trimmed);
+  return segments.length === 1 && segments[0].kind === 'math' && segments[0].value === trimmed;
+}

--- a/src/lib/text/autodetect.ts
+++ b/src/lib/text/autodetect.ts
@@ -44,6 +44,35 @@ const GREEK_NAMES = new Set([
 ]);
 
 const CONSTANT_NAMES = new Set(['oo', 'infty']);
+const SHORT_PROSE_WORDS = new Set([
+  'am',
+  'an',
+  'as',
+  'at',
+  'be',
+  'by',
+  'do',
+  'go',
+  'he',
+  'if',
+  'in',
+  'is',
+  'it',
+  'me',
+  'my',
+  'no',
+  'of',
+  'oh',
+  'ok',
+  'on',
+  'or',
+  'so',
+  'to',
+  'up',
+  'us',
+  'we',
+]);
+const COMPACT_VARIABLE_FOLLOWERS = new Set(['+', '-', '*', '/', '^', '_']);
 const RELATIONS = new Set(['=', '<', '>', '<=', '>=', '!=', '=>', '≠', '≤', '≥']);
 const OPERATORS = [
   '<=',
@@ -83,6 +112,7 @@ interface Token {
   start: number;
   end: number;
   recognizedWord?: boolean;
+  compactVariable?: boolean;
   scriptOperand?: boolean;
 }
 
@@ -138,6 +168,7 @@ function tokenize(source: string): Token[] {
           FUNCTION_NAMES.has(lower) ||
           GREEK_NAMES.has(lower) ||
           CONSTANT_NAMES.has(lower),
+        compactVariable: value.length === 2 && value === lower && !SHORT_PROSE_WORDS.has(lower),
       });
       continue;
     }
@@ -186,14 +217,26 @@ function nextSignificant(tokens: Token[], from: number): Token | undefined {
 function isLeftOperand(token: Token | undefined): boolean {
   if (!token) return false;
   if (token.kind === 'number' || token.kind === 'control') return true;
-  if (token.kind === 'word') return token.recognizedWord === true || token.scriptOperand === true;
+  if (token.kind === 'word') {
+    return (
+      token.recognizedWord === true ||
+      token.compactVariable === true ||
+      token.scriptOperand === true
+    );
+  }
   return token.kind === 'bracket' && ')]}'.includes(token.value);
 }
 
 function isRightOperand(token: Token | undefined): boolean {
   if (!token) return false;
   if (token.kind === 'number' || token.kind === 'control') return true;
-  if (token.kind === 'word') return token.recognizedWord === true || token.scriptOperand === true;
+  if (token.kind === 'word') {
+    return (
+      token.recognizedWord === true ||
+      token.compactVariable === true ||
+      token.scriptOperand === true
+    );
+  }
   return token.kind === 'bracket' && '([{'.includes(token.value);
 }
 
@@ -307,9 +350,75 @@ function trimCandidate(tokens: Token[]): Token[] {
   return tokens.slice(start, end);
 }
 
-function canJoinCandidate(token: Token, candidate: Token[]): boolean {
+function sourceForTokens(tokens: Token[]): string {
+  return tokens.map((token) => token.value).join('');
+}
+
+function lastTopLevelComma(tokens: Token[]): number {
+  const stack: string[] = [];
+  const pairs: Record<string, string> = { ')': '(', ']': '[', '}': '{' };
+  let comma = -1;
+
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (token.kind === 'bracket') {
+      if ('([{'.includes(token.value)) {
+        stack.push(token.value);
+      } else if (stack[stack.length - 1] === pairs[token.value]) {
+        stack.pop();
+      }
+    } else if (token.kind === 'punctuation' && token.value === ',' && stack.length === 0) {
+      comma = index;
+    }
+  }
+
+  return comma;
+}
+
+function trimIncompleteTail(tokens: Token[]): Token[] {
+  let trimmed = trimCandidate(tokens);
+
+  while (trimmed.length > 0) {
+    const last = trimmed[trimmed.length - 1];
+    if (last.kind === 'operator') {
+      trimmed = trimCandidate(trimmed.slice(0, -1));
+      continue;
+    }
+
+    const comma = lastTopLevelComma(trimmed);
+    if (comma >= 0) {
+      const suffix = trimCandidate(trimmed.slice(comma + 1));
+      if (suffix.length === 0 || !candidateLooksLikeMath(sourceForTokens(suffix), suffix)) {
+        trimmed = trimCandidate(trimmed.slice(0, comma));
+        continue;
+      }
+    }
+    break;
+  }
+
+  return trimmed;
+}
+
+function hasRelationWithLeftOperand(tokens: Token[]): boolean {
+  return tokens.some(
+    (token, index) =>
+      token.kind === 'operator' &&
+      RELATIONS.has(token.value) &&
+      isLeftOperand(previousSignificant(tokens, index - 1)),
+  );
+}
+
+function canJoinCandidate(token: Token, candidate: Token[], following: Token | undefined): boolean {
   if (token.kind === 'other') return false;
   if (token.kind !== 'word' || token.recognizedWord) return true;
+  if (
+    token.compactVariable &&
+    hasRelationWithLeftOperand(candidate) &&
+    following?.kind === 'operator' &&
+    COMPACT_VARIABLE_FOLLOWERS.has(following.value)
+  ) {
+    return true;
+  }
 
   const previous = previousSignificant(candidate, candidate.length - 1);
   if (previous?.kind === 'operator' && (previous.value === '^' || previous.value === '_')) {
@@ -349,7 +458,7 @@ export function detectMathSegments(source: string): TextSegment[] {
   let candidate: Token[] = [];
 
   const flush = () => {
-    const trimmed = trimCandidate(candidate);
+    const trimmed = trimIncompleteTail(candidate);
     if (trimmed.length > 0) {
       const start = trimmed[0].start;
       const end = trimmed[trimmed.length - 1].end;
@@ -358,8 +467,9 @@ export function detectMathSegments(source: string): TextSegment[] {
     candidate = [];
   };
 
-  for (const token of tokens) {
-    if (canJoinCandidate(token, candidate)) {
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (canJoinCandidate(token, candidate, nextSignificant(tokens, index + 1))) {
       if (token.kind !== 'space' || candidate.length > 0) candidate.push(token);
     } else {
       flush();

--- a/src/lib/text/index.ts
+++ b/src/lib/text/index.ts
@@ -1,4 +1,10 @@
 export { renderLatex, escapeHtml } from './latex';
 export type { LatexRender, RenderLatexOptions, KatexRenderFn } from './latex';
+export { autoSegment, detectMathSegments, looksLikeMath } from './autodetect';
+export { normalizeMathSource } from './normalize';
+export { renderMixed } from './render';
+export type { MixedRender, RenderedRun } from './render';
+export { hasExplicitMath, segmentLatex, unescapeDollars } from './segment';
+export type { TextSegment } from './segment';
 export { estimateTextBounds, hitTestTextObject, hitTestTextObjects } from './hitTest';
 export type { TextBounds } from './hitTest';

--- a/src/lib/text/normalize.ts
+++ b/src/lib/text/normalize.ts
@@ -1,0 +1,143 @@
+const FUNCTION_NAMES = [
+  'sin',
+  'cos',
+  'tan',
+  'sec',
+  'csc',
+  'cot',
+  'log',
+  'ln',
+  'exp',
+  'sqrt',
+  'abs',
+  'min',
+  'max',
+];
+const GREEK_NAMES = [
+  'alpha',
+  'beta',
+  'gamma',
+  'delta',
+  'epsilon',
+  'zeta',
+  'eta',
+  'theta',
+  'iota',
+  'kappa',
+  'lambda',
+  'mu',
+  'nu',
+  'xi',
+  'omicron',
+  'pi',
+  'rho',
+  'sigma',
+  'tau',
+  'upsilon',
+  'phi',
+  'chi',
+  'psi',
+  'omega',
+];
+
+function replaceBareWords(
+  source: string,
+  words: string[],
+  replacement: (word: string) => string,
+): string {
+  const pattern = new RegExp(`(^|[^\\\\A-Za-z])(${words.join('|')})(?![A-Za-z])`, 'g');
+  return source.replace(
+    pattern,
+    (_match, prefix: string, word: string) => prefix + replacement(word),
+  );
+}
+
+function normalizeBalancedSquareRoots(source: string): string {
+  let out = '';
+  let index = 0;
+
+  while (index < source.length) {
+    const isBareSqrt =
+      source.startsWith('sqrt', index) &&
+      !/[A-Za-z\\]/.test(source[index - 1] ?? '') &&
+      !/[A-Za-z]/.test(source[index + 4] ?? '');
+    if (!isBareSqrt) {
+      out += source[index++];
+      continue;
+    }
+
+    let open = index + 4;
+    while (/\s/.test(source[open] ?? '')) open += 1;
+    if (source[open] !== '(') {
+      out += source[index++];
+      continue;
+    }
+
+    let depth = 0;
+    let close = -1;
+    for (let cursor = open; cursor < source.length; cursor += 1) {
+      if (source[cursor] === '(') depth += 1;
+      if (source[cursor] === ')') depth -= 1;
+      if (depth === 0) {
+        close = cursor;
+        break;
+      }
+    }
+    if (close === -1) {
+      out += source[index++];
+      continue;
+    }
+
+    out += `\\sqrt{${normalizeMathSource(source.slice(open + 1, close))}}`;
+    index = close + 1;
+  }
+
+  return out;
+}
+
+function wrapMultiCharacterScripts(source: string): string {
+  return source.replace(/([_^])([A-Za-z0-9]+)/g, (_match, operator: string, operand: string) =>
+    operand.length > 1 ? `${operator}{${operand}}` : `${operator}${operand}`,
+  );
+}
+
+function normalizeFunctions(source: string): string {
+  const pattern = new RegExp(
+    `(^|[^\\\\A-Za-z])(${FUNCTION_NAMES.join('|')})(?=\\(|\\s+(?:[({\\\\]|[A-Za-z0-9]))`,
+    'g',
+  );
+  return source.replace(pattern, (_match, prefix: string, name: string) => {
+    const command = name === 'abs' ? '\\operatorname{abs}' : `\\${name}`;
+    return prefix + command;
+  });
+}
+
+function escapeSpecialCharacters(source: string): string {
+  let out = '';
+  for (let index = 0; index < source.length; index += 1) {
+    const char = source[index];
+    if ((char === '%' || char === '#' || char === '&') && source[index - 1] !== '\\') {
+      out += '\\';
+    }
+    out += char;
+  }
+  return out;
+}
+
+/** Convert teacher-typed bare math to conservative, idempotent LaTeX. */
+export function normalizeMathSource(raw: string): string {
+  let source = normalizeBalancedSquareRoots(raw);
+  source = wrapMultiCharacterScripts(source);
+  source = source
+    .replace(/\.\.\./g, '\\dots')
+    .replace(/<=/g, '\\le')
+    .replace(/>=/g, '\\ge')
+    .replace(/!=/g, '\\ne')
+    .replace(/\+-/g, '\\pm')
+    .replace(/->/g, '\\to')
+    .replace(/\*/g, '\\cdot');
+  source = replaceBareWords(source, ['oo', 'infty'], () => '\\infty');
+  source = replaceBareWords(source, GREEK_NAMES, (name) => `\\${name}`);
+  source = normalizeFunctions(source);
+  return escapeSpecialCharacters(source);
+}

--- a/src/lib/text/normalize.ts
+++ b/src/lib/text/normalize.ts
@@ -95,10 +95,33 @@ function normalizeBalancedSquareRoots(source: string): string {
   return out;
 }
 
+/**
+ * Wrap multi-character sub/superscripts in braces.
+ *
+ * Digit runs and letter runs are handled separately and mixed runs are left
+ * alone: TeX reads `x^2y` as `x²y`, so greedily wrapping it to `x^{2y}` would
+ * silently change the formula's meaning rather than fix it.
+ */
 function wrapMultiCharacterScripts(source: string): string {
-  return source.replace(/([_^])([A-Za-z0-9]+)/g, (_match, operator: string, operand: string) =>
-    operand.length > 1 ? `${operator}{${operand}}` : `${operator}${operand}`,
-  );
+  return source
+    .replace(/([_^])(\d{2,})(?![A-Za-z0-9])/g, '$1{$2}')
+    .replace(/([_^])([A-Za-z]{2,})(?![A-Za-z0-9])/g, '$1{$2}');
+}
+
+/**
+ * Replace shorthand with a LaTeX command.
+ *
+ * A control sequence swallows every letter that follows it, so `x<=y` would
+ * become the undefined `\ley`. A separating space is emitted when the next
+ * character is a letter; TeX discards it and the command terminates cleanly.
+ */
+function replaceOperator(source: string, pattern: RegExp, command: string): string {
+  return source.replace(pattern, (match, ...rest) => {
+    const offset = rest[rest.length - 2] as number;
+    const input = rest[rest.length - 1] as string;
+    const next = input[offset + match.length] ?? '';
+    return /[A-Za-z]/.test(next) ? `${command} ` : command;
+  });
 }
 
 function normalizeFunctions(source: string): string {
@@ -128,14 +151,13 @@ function escapeSpecialCharacters(source: string): string {
 export function normalizeMathSource(raw: string): string {
   let source = normalizeBalancedSquareRoots(raw);
   source = wrapMultiCharacterScripts(source);
-  source = source
-    .replace(/\.\.\./g, '\\dots')
-    .replace(/<=/g, '\\le')
-    .replace(/>=/g, '\\ge')
-    .replace(/!=/g, '\\ne')
-    .replace(/\+-/g, '\\pm')
-    .replace(/->/g, '\\to')
-    .replace(/\*/g, '\\cdot');
+  source = replaceOperator(source, /\.\.\./g, '\\dots');
+  source = replaceOperator(source, /<=/g, '\\le');
+  source = replaceOperator(source, />=/g, '\\ge');
+  source = replaceOperator(source, /!=/g, '\\ne');
+  source = replaceOperator(source, /\+-/g, '\\pm');
+  source = replaceOperator(source, /->/g, '\\to');
+  source = replaceOperator(source, /\*/g, '\\cdot');
   source = replaceBareWords(source, ['oo', 'infty'], () => '\\infty');
   source = replaceBareWords(source, GREEK_NAMES, (name) => `\\${name}`);
   source = normalizeFunctions(source);

--- a/src/lib/text/render.ts
+++ b/src/lib/text/render.ts
@@ -1,0 +1,110 @@
+import type { TextMathMode } from '$lib/types';
+import { detectMathSegments } from './autodetect';
+import { escapeHtml, renderLatex, type KatexRenderFn } from './latex';
+import { normalizeMathSource } from './normalize';
+import { segmentLatex, type TextSegment } from './segment';
+
+export type RenderedRun =
+  | { kind: 'text'; value: string }
+  | {
+      kind: 'math';
+      source: string;
+      html: string;
+      display: boolean;
+      errored: boolean;
+      error?: string;
+    };
+
+export interface MixedRender {
+  runs: RenderedRun[];
+  errored: boolean;
+}
+
+function renderMath(
+  source: string,
+  display: boolean,
+  render: KatexRenderFn | undefined,
+  normalized = source,
+): RenderedRun {
+  const result = renderLatex(normalized, { displayMode: display }, render);
+  if (result.ok) {
+    return { kind: 'math', source, html: result.html, display, errored: false };
+  }
+  return {
+    kind: 'math',
+    source,
+    html: escapeHtml(source),
+    display,
+    errored: true,
+    error: result.error,
+  };
+}
+
+function appendRun(runs: RenderedRun[], run: RenderedRun): void {
+  if (run.kind === 'text' && run.value.length === 0) return;
+  const previous = runs[runs.length - 1];
+  if (previous?.kind === 'text' && run.kind === 'text') {
+    previous.value += run.value;
+    return;
+  }
+  runs.push(run);
+}
+
+function renderSegments(
+  segments: TextSegment[],
+  render: KatexRenderFn | undefined,
+  normalize: boolean,
+): RenderedRun[] {
+  const runs: RenderedRun[] = [];
+  for (const segment of segments) {
+    if (segment.kind === 'text') {
+      appendRun(runs, { kind: 'text', value: segment.value });
+    } else {
+      appendRun(
+        runs,
+        renderMath(
+          segment.value,
+          segment.display,
+          render,
+          normalize ? normalizeMathSource(segment.value) : segment.value,
+        ),
+      );
+    }
+  }
+  return runs;
+}
+
+function renderAuto(source: string, render: KatexRenderFn | undefined): RenderedRun[] {
+  const runs: RenderedRun[] = [];
+  for (const segment of segmentLatex(source)) {
+    const rendered =
+      segment.kind === 'math'
+        ? renderSegments([segment], render, false)
+        : renderSegments(detectMathSegments(segment.value), render, true);
+    for (const run of rendered) appendRun(runs, run);
+  }
+  return runs;
+}
+
+export function renderMixed(
+  source: string,
+  mode: TextMathMode,
+  render?: KatexRenderFn,
+): MixedRender {
+  let runs: RenderedRun[];
+  switch (mode) {
+    case 'plain':
+      runs = [{ kind: 'text', value: source }];
+      break;
+    case 'latex':
+      runs = [renderMath(source, false, render)];
+      break;
+    case 'mixed':
+      runs = renderSegments(segmentLatex(source), render, false);
+      break;
+    case 'auto':
+      runs = renderAuto(source, render);
+      break;
+  }
+  return { runs, errored: runs.some((run) => run.kind === 'math' && run.errored) };
+}

--- a/src/lib/text/segment.ts
+++ b/src/lib/text/segment.ts
@@ -1,0 +1,115 @@
+/**
+ * Splits text containing LaTeX delimiters into literal and math runs.
+ *
+ * Supported delimiters, in precedence order:
+ *   `$$ … $$`  and  `\[ … \]`  -> display math
+ *   `$ … $`    and  `\( … \)`  -> inline math
+ *
+ * A backslash-escaped `\$` is a literal dollar sign and never opens a run.
+ * An unterminated delimiter is treated as literal text rather than swallowing
+ * the rest of the string, so a stray `$` in prose stays readable.
+ */
+
+export type TextSegment =
+  | { kind: 'text'; value: string }
+  | { kind: 'math'; value: string; display: boolean };
+
+interface Delimiter {
+  open: string;
+  close: string;
+  display: boolean;
+}
+
+const DELIMITERS: Delimiter[] = [
+  { open: '$$', close: '$$', display: true },
+  { open: '\\[', close: '\\]', display: true },
+  { open: '\\(', close: '\\)', display: false },
+  { open: '$', close: '$', display: false },
+];
+
+/** True when the character at `index` is escaped by an odd run of backslashes. */
+function isEscaped(source: string, index: number): boolean {
+  let backslashes = 0;
+  for (let i = index - 1; i >= 0 && source[i] === '\\'; i -= 1) backslashes += 1;
+  return backslashes % 2 === 1;
+}
+
+function matchDelimiterAt(source: string, index: number): Delimiter | null {
+  for (const delim of DELIMITERS) {
+    if (!source.startsWith(delim.open, index)) continue;
+    // `\(` and `\[` are themselves backslash sequences, so only the bare
+    // dollar forms can be escaped by a preceding backslash.
+    if (delim.open.startsWith('$') && isEscaped(source, index)) continue;
+    return delim;
+  }
+  return null;
+}
+
+function findClose(source: string, from: number, delim: Delimiter): number {
+  for (let i = from; i <= source.length - delim.close.length; i += 1) {
+    if (!source.startsWith(delim.close, i)) continue;
+    if (delim.close.startsWith('$') && isEscaped(source, i)) continue;
+    return i;
+  }
+  return -1;
+}
+
+function pushText(out: TextSegment[], value: string): void {
+  if (value.length === 0) return;
+  const last = out[out.length - 1];
+  if (last && last.kind === 'text') {
+    last.value += value;
+    return;
+  }
+  out.push({ kind: 'text', value });
+}
+
+/**
+ * Replace `\$` with a literal `$` in text runs. Math runs keep their source
+ * verbatim because KaTeX has its own escaping rules.
+ */
+export function unescapeDollars(value: string): string {
+  return value.replace(/\\\$/g, '$');
+}
+
+export function segmentLatex(source: string): TextSegment[] {
+  const out: TextSegment[] = [];
+  let literalStart = 0;
+  let i = 0;
+
+  while (i < source.length) {
+    const delim = matchDelimiterAt(source, i);
+    if (!delim) {
+      i += 1;
+      continue;
+    }
+
+    const contentStart = i + delim.open.length;
+    const closeAt = findClose(source, contentStart, delim);
+    if (closeAt === -1) {
+      // Unterminated: treat the opener as literal and keep scanning after it.
+      i += delim.open.length;
+      continue;
+    }
+
+    const content = source.slice(contentStart, closeAt);
+    if (content.trim().length === 0) {
+      // `$$` / `$ $` with nothing inside is almost certainly literal currency.
+      i = closeAt + delim.close.length;
+      continue;
+    }
+
+    pushText(out, unescapeDollars(source.slice(literalStart, i)));
+    out.push({ kind: 'math', value: content, display: delim.display });
+    i = closeAt + delim.close.length;
+    literalStart = i;
+  }
+
+  pushText(out, unescapeDollars(source.slice(literalStart)));
+  return out;
+}
+
+/** True when the source contains at least one explicit math delimiter run. */
+export function hasExplicitMath(source: string): boolean {
+  return segmentLatex(source).some((s) => s.kind === 'math');
+}

--- a/src/lib/tools/tempInk.ts
+++ b/src/lib/tools/tempInk.ts
@@ -70,10 +70,14 @@ export function fadeOpacity(stroke: TempInkStroke, now: number): number {
 }
 
 export function pruneStrokes(strokes: TempInkStroke[], now: number): TempInkStroke[] {
-  let expired = 0;
-  for (const s of strokes) {
-    if (fadeOpacity(s, now) <= 0) expired++;
-    else break;
+  let kept: TempInkStroke[] | null = null;
+  for (let index = 0; index < strokes.length; index += 1) {
+    const stroke = strokes[index];
+    if (fadeOpacity(stroke, now) <= 0) {
+      kept ??= strokes.slice(0, index);
+    } else {
+      kept?.push(stroke);
+    }
   }
-  return expired === 0 ? strokes : strokes.slice(expired);
+  return kept ?? strokes;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -226,11 +226,19 @@ export interface SlideTextBlock extends SlideBlockBase {
   color?: string;
 }
 
+export type SlideListMarker = 'bullet' | 'decimal' | 'alpha' | 'roman' | 'none';
+
 export interface SlideListBlock extends SlideBlockBase {
   kind: 'list';
   items: SlideListItem[];
-  /** `decimal` numbers top-level items; `none` renders a bare stack. */
-  marker: 'bullet' | 'decimal' | 'none';
+  /** Marker for top-level items. */
+  marker: SlideListMarker;
+  /**
+   * Per-depth marker overrides. Index 0 is the top level. When absent, nested
+   * levels step down automatically (decimal to alpha to roman, bullet to
+   * hollow bullet), matching how worked steps are normally sub-numbered.
+   */
+  markerByLevel?: SlideListMarker[];
   fontSize?: number;
 }
 
@@ -246,6 +254,11 @@ export interface SlideTableBlock extends SlideBlockBase {
   /** Empty array renders a table with no header row. */
   header: string[];
   rows: string[][];
+  /**
+   * `row` treats `header` as the top row. `column` treats the first cell of
+   * each row as that row's header, for data laid out left-to-right.
+   */
+  headerOrientation?: 'row' | 'column';
   fontSize?: number;
   /** Relative column widths. Equal widths when omitted or length-mismatched. */
   columnWeights?: number[];
@@ -313,6 +326,50 @@ export interface SlideMappingBlock extends SlideBlockBase {
   caption?: string;
 }
 
+/**
+ * A node-and-arrow diagram: labelled boxes joined by arrows. Covers function
+ * machines and leader-line labels pointing at parts of an expression.
+ *
+ * Node positions are fractions of the block box in [0, 1] so a diagram keeps
+ * its proportions at any page size.
+ */
+export interface SlideDiagramNode {
+  id: string;
+  text: string;
+  x: number;
+  y: number;
+  /** Fractions of the block box. Sized to the text when omitted. */
+  w?: number;
+  h?: number;
+  shape?: 'box' | 'plain';
+}
+
+export interface SlideDiagramEdge {
+  from: string;
+  to: string;
+  label?: string;
+}
+
+export interface SlideDiagramBlock extends SlideBlockBase {
+  kind: 'diagram';
+  nodes: SlideDiagramNode[];
+  edges: SlideDiagramEdge[];
+  height: number;
+  caption?: string;
+}
+
+/** A number line drawn as slide content, distinct from the annotation tool. */
+export interface SlideNumberLineBlock extends SlideBlockBase {
+  kind: 'numberline';
+  min: number;
+  max: number;
+  tickStep: number;
+  labelStep: number;
+  marks: NumberLineMark[];
+  height: number;
+  caption?: string;
+}
+
 export type SlideBlock =
   | SlideTextBlock
   | SlideListBlock
@@ -323,6 +380,8 @@ export type SlideBlock =
   | SlideCalloutBlock
   | SlideImageBlock
   | SlideMappingBlock
+  | SlideDiagramBlock
+  | SlideNumberLineBlock
   | SlideSpacerBlock;
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -291,6 +291,28 @@ export interface SlideSpacerBlock extends SlideBlockBase {
   height: number;
 }
 
+/**
+ * A relation drawn as two labelled ovals joined by arrows — the standard
+ * way domain/range mappings are introduced in algebra.
+ */
+export interface SlideMappingPair {
+  /** Index into `left`. */
+  from: number;
+  /** Index into `right`. */
+  to: number;
+}
+
+export interface SlideMappingBlock extends SlideBlockBase {
+  kind: 'mapping';
+  leftLabel: string;
+  rightLabel: string;
+  left: string[];
+  right: string[];
+  pairs: SlideMappingPair[];
+  height: number;
+  caption?: string;
+}
+
 export type SlideBlock =
   | SlideTextBlock
   | SlideListBlock
@@ -300,6 +322,7 @@ export type SlideBlock =
   | SlideGraphBlock
   | SlideCalloutBlock
   | SlideImageBlock
+  | SlideMappingBlock
   | SlideSpacerBlock;
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -114,6 +114,16 @@ export interface GraphFunction {
   domain: [number, number] | null;
 }
 
+export interface GraphParameter {
+  name: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  /** Render a `a = 1.3` chip inside the graph area for the projected view. */
+  showChip?: boolean;
+}
+
 export interface GraphObject extends ObjectBase {
   type: 'graph';
   bounds: { x: number; y: number; w: number; h: number };
@@ -124,6 +134,7 @@ export interface GraphObject extends ObjectBase {
   showAxes: boolean;
   showGrid: boolean;
   functions: GraphFunction[];
+  parameters?: GraphParameter[];
 }
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -126,13 +126,33 @@ export interface GraphObject extends ObjectBase {
   functions: GraphFunction[];
 }
 
+/**
+ * How a text object's content is interpreted.
+ *
+ * - `plain`  — no math rendering at all.
+ * - `latex`  — the entire content is one LaTeX expression.
+ * - `mixed`  — only explicitly delimited runs (`$…$`, `\(…\)`, `\[…\]`) are math.
+ * - `auto`   — explicit delimiters plus heuristically detected bare math.
+ */
+export type TextMathMode = 'plain' | 'latex' | 'mixed' | 'auto';
+
 export interface TextObject extends ObjectBase {
   type: 'text';
   at: { x: number; y: number };
   content: string;
+  /**
+   * Legacy whole-string LaTeX flag. Kept for sidecar back-compat; `mathMode`
+   * is authoritative when present. Readers should use `textMathMode()`.
+   */
   latex: boolean;
+  mathMode?: TextMathMode;
   fontSize: number;
   color: string;
+}
+
+/** Resolve the effective math mode, honoring the legacy `latex` flag. */
+export function textMathMode(obj: Pick<TextObject, 'latex' | 'mathMode'>): TextMathMode {
+  return obj.mathMode ?? (obj.latex ? 'latex' : 'plain');
 }
 
 export interface AngleMarkObject extends ObjectBase {
@@ -158,7 +178,168 @@ export type AnyObject =
   | TextObject
   | AngleMarkObject;
 
-export type PageKind = 'pdf' | 'blank';
+export type PageKind = 'pdf' | 'blank' | 'slide';
+
+/** Horizontal alignment for slide text blocks. */
+export type SlideAlign = 'left' | 'center' | 'right';
+
+export type SlideCalloutTone = 'tip' | 'warn' | 'note';
+
+export interface SlideListItem {
+  text: string;
+  /** Indent depth; 0 is top level. Clamped to 0..3 at render time. */
+  level: number;
+}
+
+export interface SlideDefinition {
+  term: string;
+  text: string;
+}
+
+/**
+ * Plot spec embedded in a slide. Mirrors the drawable subset of
+ * `GraphObject` so slides can carry graphs without owning an annotation id.
+ */
+export interface SlideGraphSpec {
+  xRange: [number, number];
+  yRange: [number, number];
+  gridStep: number;
+  showAxes: boolean;
+  showGrid: boolean;
+  functions: GraphFunction[];
+}
+
+interface SlideBlockBase {
+  id: string;
+  /** Vertical gap in points inserted before this block. Defaults per kind. */
+  marginTop?: number;
+}
+
+export interface SlideTextBlock extends SlideBlockBase {
+  kind: 'text';
+  text: string;
+  align?: SlideAlign;
+  /** Point size override; falls back to the theme's body size. */
+  fontSize?: number;
+  bold?: boolean;
+  italic?: boolean;
+  color?: string;
+}
+
+export interface SlideListBlock extends SlideBlockBase {
+  kind: 'list';
+  items: SlideListItem[];
+  /** `decimal` numbers top-level items; `none` renders a bare stack. */
+  marker: 'bullet' | 'decimal' | 'none';
+  fontSize?: number;
+}
+
+export interface SlideDefinitionsBlock extends SlideBlockBase {
+  kind: 'definitions';
+  items: SlideDefinition[];
+  fontSize?: number;
+}
+
+export interface SlideTableBlock extends SlideBlockBase {
+  kind: 'table';
+  caption?: string;
+  /** Empty array renders a table with no header row. */
+  header: string[];
+  rows: string[][];
+  fontSize?: number;
+  /** Relative column widths. Equal widths when omitted or length-mismatched. */
+  columnWeights?: number[];
+}
+
+export interface SlideMathBlock extends SlideBlockBase {
+  kind: 'math';
+  latex: string;
+  display: boolean;
+  align?: SlideAlign;
+  fontSize?: number;
+  color?: string;
+}
+
+export interface SlideGraphBlock extends SlideBlockBase {
+  kind: 'graph';
+  graph: SlideGraphSpec;
+  /** Drawn height in points; width fills the containing column. */
+  height: number;
+  /** Optional caption rendered above the plot. */
+  caption?: string;
+}
+
+export interface SlideCalloutBlock extends SlideBlockBase {
+  kind: 'callout';
+  text: string;
+  tone: SlideCalloutTone;
+  fontSize?: number;
+}
+
+export interface SlideImageBlock extends SlideBlockBase {
+  kind: 'image';
+  /** `data:` URL. Slides stay self-contained so sidecars remain portable. */
+  src: string;
+  alt: string;
+  height: number;
+  align?: SlideAlign;
+}
+
+/** Reserved vertical whitespace — the room a teacher writes into live. */
+export interface SlideSpacerBlock extends SlideBlockBase {
+  kind: 'spacer';
+  height: number;
+}
+
+export type SlideBlock =
+  | SlideTextBlock
+  | SlideListBlock
+  | SlideDefinitionsBlock
+  | SlideTableBlock
+  | SlideMathBlock
+  | SlideGraphBlock
+  | SlideCalloutBlock
+  | SlideImageBlock
+  | SlideSpacerBlock;
+
+/**
+ * How a slide's blocks are arranged inside the content area.
+ *
+ * - `title`   — hero title/subtitle centered; blocks stack underneath.
+ * - `content` — single column beneath the heading.
+ * - `columns` — blocks distributed across `columnCount` equal columns.
+ * - `grid`    — blocks placed in a `gridColumns`-wide grid of equal cells,
+ *               each cell padded with writing room (practice-problem sheets).
+ * - `blank`   — no heading chrome; blocks stack from the top margin.
+ */
+export type SlideLayoutKind = 'title' | 'content' | 'columns' | 'grid' | 'blank';
+
+export interface SlideTheme {
+  fontFamily: string;
+  /** Slide background, strict `#rrggbb`. Untrusted input is rejected on load. */
+  background: string;
+  titleColor: string;
+  textColor: string;
+  accent: string;
+  /** Point sizes. */
+  titleSize: number;
+  headingSize: number;
+  bodySize: number;
+}
+
+export interface Slide {
+  layout: SlideLayoutKind;
+  /** Heading text; rendered as the hero title on `title` layouts. */
+  title: string;
+  subtitle?: string;
+  blocks: SlideBlock[];
+  /** Corner callouts, rendered top-right outside the main flow. */
+  aside?: SlideCalloutBlock[];
+  /** Used by `columns` (default 2) and `grid` (default 2). */
+  columnCount?: number;
+  /** Per-slide overrides merged over the document theme. */
+  theme?: Partial<SlideTheme>;
+}
 
 export interface Page {
   pageIndex: number;
@@ -185,6 +366,8 @@ export interface Page {
    * into CSS at render time.
    */
   background?: string;
+  /** Present only when `type === 'slide'`. */
+  slide?: Slide;
   objects: AnyObject[];
 }
 
@@ -213,6 +396,8 @@ export interface EldrawDocument {
   pages: Page[];
   palettes: ColorPalette[];
   prefs: Preferences;
+  /** Deck-wide slide theme. Absent on documents with no slides. */
+  slideTheme?: SlideTheme;
 }
 
 /**

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -68,8 +68,10 @@
     PdfMeta,
     ShapeObject,
     StrokeObject,
+    TextMathMode,
     TextObject,
   } from '$lib/types';
+  import { textMathMode } from '$lib/types';
 
   const ERASER_RADIUS = 4;
 
@@ -283,9 +285,21 @@
     if (!editor) return null;
     if (editor.mode === 'edit') {
       const o = editor.obj;
-      return { content: o.content, latex: o.latex, fontSize: o.fontSize, color: o.color };
+      return {
+        content: o.content,
+        latex: o.latex,
+        mathMode: textMathMode(o),
+        fontSize: o.fontSize,
+        color: o.color,
+      };
     }
-    return { content: '', latex: false, fontSize: 16, color: sidebarState.activeColor };
+    return {
+      content: '',
+      latex: false,
+      mathMode: 'auto' as const,
+      fontSize: 16,
+      color: sidebarState.activeColor,
+    };
   });
 
   function newId(): string {
@@ -305,6 +319,7 @@
   function onEditorOk(result: {
     content: string;
     latex: boolean;
+    mathMode: TextMathMode;
     fontSize: number;
     color: string;
   }): void {
@@ -321,6 +336,7 @@
         at: editor.at,
         content: result.content,
         latex: result.latex,
+        mathMode: result.mathMode,
         fontSize: result.fontSize,
         color: result.color,
       };
@@ -332,6 +348,7 @@
         documentStore.updateObject(pageIndex, editor.obj.id, {
           content: result.content,
           latex: result.latex,
+          mathMode: result.mathMode,
           fontSize: result.fontSize,
           color: result.color,
         });
@@ -824,6 +841,7 @@
     <TextEditor
       initialContent={editorInitial.content}
       initialLatex={editorInitial.latex}
+      initialMathMode={editorInitial.mathMode}
       initialFontSize={editorInitial.fontSize}
       initialColor={editorInitial.color}
       screenX={editor.screen.x}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -253,7 +253,8 @@
 
   function insertSlide(slide: Slide): void {
     documentStore.insertSlidePageAfter(pageIndex, slide, SLIDE_SIZE.width, SLIDE_SIZE.height);
-    viewport.setPage(pageIndex + 1, pages.length + 1);
+    const total = get(currentDocument)?.pages.length ?? 0;
+    viewport.setPage(pageIndexAfterDuplicate(pageIndex, total), total);
   }
 
   function onSlideCommand(action: SlideCommandAction): void {
@@ -876,6 +877,7 @@
   {#if chrome.thumbnails && !sidebarState.rightBarHidden}
     <ThumbnailStrip
       {pages}
+      {slideTheme}
       currentIndex={pageIndex}
       docKey={doc?.pdfHash ?? null}
       onpick={onThumbPick}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -37,6 +37,12 @@
   import { reloadPdf } from '$lib/app/actions';
   import OpenFromSlidesDialog from '$lib/ui/OpenFromSlidesDialog.svelte';
   import { slidesDialogOpen, openSlidesDialog } from '$lib/slides/dialog';
+  import { SlideLayer, defaultSlideTheme } from '$lib/slides';
+  import SlideEditor from '$lib/slides/editor/SlideEditor.svelte';
+  import TemplatePicker from '$lib/slides/editor/TemplatePicker.svelte';
+  import { createSlide, setLayout } from '$lib/slides/deck';
+  import { SLIDE_PAGE_SIZE } from '$lib/slides/pageOps';
+  import { SLIDE_COMMAND_EVENT, type SlideCommandAction } from '$lib/slides/commands';
   import { createSpatialIndex, type SpatialIndex } from '$lib/tools/spatialIndex';
   import SelectionLayer from '$lib/select/SelectionLayer.svelte';
   import { selection } from '$lib/select/selection';
@@ -70,6 +76,7 @@
     StrokeObject,
     TextMathMode,
     TextObject,
+    Slide,
   } from '$lib/types';
   import { textMathMode } from '$lib/types';
 
@@ -237,6 +244,52 @@
   const pageCount = $derived(doc?.pages.length ?? meta?.pageCount ?? 0);
   const pageIndex = $derived(Math.min(view.currentPageIndex, Math.max(0, pageCount - 1)));
   const currentPage = $derived(doc?.pages[pageIndex] ?? null);
+  const slideTheme = $derived(doc?.slideTheme ?? defaultSlideTheme);
+  let editingSlide = $state<Slide | null>(null);
+  let templatePickerOpen = $state(false);
+
+  const SLIDE_SIZE = SLIDE_PAGE_SIZE.widescreen;
+
+  function insertSlide(slide: Slide): void {
+    documentStore.insertSlidePageAfter(pageIndex, slide, SLIDE_SIZE.width, SLIDE_SIZE.height);
+    viewport.setPage(pageIndex + 1, pages.length + 1);
+  }
+
+  function onSlideCommand(action: SlideCommandAction): void {
+    const page = doc?.pages[pageIndex];
+    switch (action) {
+      case 'new':
+        insertSlide(createSlide('content'));
+        break;
+      case 'new-from-template':
+        templatePickerOpen = true;
+        break;
+      case 'edit':
+        if (page?.type === 'slide' && page.slide) editingSlide = page.slide;
+        break;
+      case 'duplicate':
+        documentStore.duplicatePage(pageIndex);
+        break;
+      case 'change-layout':
+        if (page?.type === 'slide' && page.slide) {
+          const order = ['content', 'title', 'columns', 'grid', 'blank'] as const;
+          const next = order[(order.indexOf(page.slide.layout) + 1) % order.length];
+          documentStore.updateSlide(pageIndex, setLayout(page.slide, next));
+        }
+        break;
+      case 'delete':
+        if (page?.type === 'slide') documentStore.deletePage(pageIndex);
+        break;
+    }
+  }
+
+  $effect(() => {
+    const handler = (event: Event) => {
+      onSlideCommand((event as CustomEvent<SlideCommandAction>).detail);
+    };
+    window.addEventListener(SLIDE_COMMAND_EVENT, handler);
+    return () => window.removeEventListener(SLIDE_COMMAND_EVENT, handler);
+  });
   const pdfPageIndex = $derived(doc ? pdfPageIndexAt(doc.pages, pageIndex) : pageIndex);
   const pageObjects = $derived<AnyObject[]>(currentPage?.objects ?? []);
   const pageStrokes = $derived<StrokeObject[]>(
@@ -679,7 +732,17 @@
           class="page-frame"
           style="width: {size.width}px; height: {size.height}px; transform: translate({view.offsetX}px, {view.offsetY}px);"
         >
-          {#if meta && currentPage?.type !== 'blank' && pdfPageIndex !== null}
+          {#if currentPage?.type === 'slide' && currentPage.slide}
+            <div class="slide-slot" style="width: {size.width}px; height: {size.height}px;">
+              <SlideLayer
+                slide={currentPage.slide}
+                theme={slideTheme}
+                width={size.width}
+                height={size.height}
+                ptToPx={size.ptToPx}
+              />
+            </div>
+          {:else if meta && currentPage?.type !== 'blank' && pdfPageIndex !== null}
             <div class="pdf-slot">
               <PdfLayer
                 pageIndex={pdfPageIndex}
@@ -882,6 +945,25 @@
       await loadPdfFromSource({ kind: 'file', path });
     }}
   />
+  {#if templatePickerOpen}
+    <TemplatePicker
+      onpick={(slide) => {
+        templatePickerOpen = false;
+        insertSlide(slide);
+      }}
+      onclose={() => (templatePickerOpen = false)}
+    />
+  {/if}
+  {#if editingSlide}
+    <SlideEditor
+      slide={editingSlide}
+      onchange={(next) => {
+        editingSlide = next;
+        documentStore.updateSlide(pageIndex, next);
+      }}
+      onclose={() => (editingSlide = null)}
+    />
+  {/if}
   <EraseDebugOverlay />
 </main>
 
@@ -1082,6 +1164,12 @@
   .blank-slot {
     background: #fff;
     box-sizing: border-box;
+  }
+  .slide-slot {
+    position: absolute;
+    inset: 0;
+    box-sizing: border-box;
+    overflow: hidden;
   }
   .empty {
     position: absolute;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -52,6 +52,11 @@
   import { createRafBatcher } from '$lib/canvas/inkBatch';
   import { eraseDebug } from '$lib/store/eraseDebug';
   import { activeGraph, clearActiveGraph, setActiveGraph } from '$lib/store/activeGraph';
+  import {
+    clearGraphPreview,
+    graphPreview as graphPreviewStore,
+    setGraphPreview,
+  } from '$lib/store/graphPreview';
   import { createGraphObject } from '$lib/graph/graphObject';
   import GraphEditor from '$lib/graph/GraphEditor.svelte';
   import { CommandPalette } from '$lib/command';
@@ -62,6 +67,7 @@
     ReplayLayer,
     SessionsPanel,
     player,
+    recorder,
     replayState,
   } from '$lib/session';
   import type { ReplayRenderState } from '$lib/session/player';
@@ -300,12 +306,25 @@
   const pageGraphs = $derived<GraphObject[]>(
     pageObjects.filter((o): o is GraphObject => o.type === 'graph'),
   );
+  const graphPreview = $derived($graphPreviewStore);
   const activeGraphRef = $derived($activeGraph);
   const editingGraph = $derived<GraphObject | null>(
     activeGraphRef && activeGraphRef.pageIndex === pageIndex
       ? (pageGraphs.find((g) => g.id === activeGraphRef.objectId) ?? null)
       : null,
   );
+  const renderedPageGraphs = $derived<GraphObject[]>(
+    graphPreview?.pageIndex === pageIndex
+      ? pageGraphs.map((graph) =>
+          graph.id === graphPreview?.graph.id ? graphPreview.graph : graph,
+        )
+      : pageGraphs,
+  );
+
+  $effect(() => {
+    const activeId = editingGraph?.id;
+    if (graphPreview && graphPreview.graph.id !== activeId) clearGraphPreview();
+  });
   const pageTextObjects = $derived<TextObject[]>(
     pageObjects.filter((o): o is TextObject => o.type === 'text'),
   );
@@ -551,6 +570,23 @@
   function onUpdateGraph(patch: Partial<GraphObject>): void {
     if (!editingGraph) return;
     documentStore.updateObject(pageIndex, editingGraph.id, patch);
+    clearGraphPreview();
+  }
+
+  function onPreviewGraph(patch: Partial<GraphObject>): void {
+    if (!editingGraph) return;
+    const before = graphPreview?.graph.id === editingGraph.id ? graphPreview.graph : editingGraph;
+    const after = { ...before, ...patch };
+    setGraphPreview({ pageIndex, graph: after });
+
+    if (!patch.parameters) return;
+    const previousValues = new Map(
+      before.parameters?.map((parameter) => [parameter.name, parameter.value]),
+    );
+    for (const parameter of patch.parameters) {
+      if (previousValues.get(parameter.name) === parameter.value) continue;
+      recorder.recordGraphParameter(pageIndex, editingGraph.id, parameter.name, parameter.value);
+    }
   }
 
   function onDeleteGraph(): void {
@@ -596,6 +632,7 @@
     stopSidebarBridge?.();
     registerZenFullscreenBridge(null);
     eraseBatcher.cancel();
+    clearGraphPreview();
     stopAutosave();
   });
 </script>
@@ -784,7 +821,7 @@
             >
               {#snippet overlay()}
                 <GraphLayer
-                  graphs={pageGraphs}
+                  graphs={renderedPageGraphs}
                   width={size.width}
                   height={size.height}
                   ptToPx={size.ptToPx}
@@ -820,6 +857,7 @@
               <GraphEditor
                 graph={editingGraph}
                 onUpdate={onUpdateGraph}
+                onPreview={onPreviewGraph}
                 onDelete={onDeleteGraph}
                 onClose={clearActiveGraph}
               />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte';
+  import { get } from 'svelte/store';
   import {
     CanvasStack,
     EraseDebugOverlay,
@@ -32,6 +33,7 @@
   import { shortcuts } from '$lib/app/shortcuts';
   import { setWindowFullscreenChromeless } from '$lib/app/windowFullscreen';
   import { openPdfDialog } from '$lib/app/openPdfDialog';
+  import { pageIndexAfterDelete, pageIndexAfterDuplicate } from '$lib/app/pageNav';
   import { loadPdfFromSource, stopAutosave } from '$lib/pdf/loader';
   import { reloadWarning, clearReloadWarning } from '$lib/store/reloadWarning';
   import { reloadPdf } from '$lib/app/actions';
@@ -221,17 +223,16 @@
 
   function onThumbDuplicate(i: number): void {
     documentStore.duplicatePage(i);
-    viewport.setPage(i + 1, pages.length + 1);
+    const total = get(currentDocument)?.pages.length ?? 0;
+    viewport.setPage(pageIndexAfterDuplicate(i, total), total);
   }
 
   function onThumbDelete(i: number): void {
     if (pages.length <= 1) return;
     documentStore.deletePage(i);
-    const nextTotal = pages.length - 1;
+    const total = get(currentDocument)?.pages.length ?? 0;
     const snap = viewport.snapshot();
-    if (snap.currentPageIndex >= i) {
-      viewport.setPage(Math.max(0, snap.currentPageIndex - 1), nextTotal);
-    }
+    viewport.setPage(pageIndexAfterDelete(i, snap.currentPageIndex, total), total);
   }
 
   function clearCurrentPage(): void {

--- a/tests/document-reorder.test.ts
+++ b/tests/document-reorder.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { createDocumentStore } from '$lib/store/document';
+import type { AnyObject, EldrawDocument, Page } from '$lib/types';
+
+function textObject(id: string): AnyObject {
+  return {
+    id,
+    createdAt: 0,
+    type: 'text',
+    at: { x: 0, y: 0 },
+    content: id,
+    latex: false,
+    fontSize: 12,
+    color: '#000000',
+  };
+}
+
+function doc(objects: AnyObject[]): EldrawDocument {
+  const page: Page = {
+    pageIndex: 0,
+    type: 'blank',
+    insertedAfterPdfPage: null,
+    width: 612,
+    height: 792,
+    objects,
+  };
+  return {
+    version: 1,
+    pdfHash: 'h',
+    pdfPath: null,
+    pages: [page],
+    palettes: [],
+    prefs: {
+      sidebarPinned: false,
+      defaultTool: 'pen',
+      toolDefaults: {
+        pen: { color: '#000000', width: 2, dash: 'solid', opacity: 1 },
+        highlighter: { color: '#ffff00', width: 8, dash: 'solid', opacity: 0.4 },
+        line: { color: '#000000', width: 2, dash: 'solid', opacity: 1 },
+      },
+    },
+  };
+}
+
+function makeStore(ids: string[]) {
+  const store = createDocumentStore();
+  store.load(doc(ids.map(textObject)));
+  const read = () => {
+    let current: AnyObject[] = [];
+    store.subscribe((d) => (current = d?.pages[0].objects ?? []))();
+    return current.map((o) => o.id);
+  };
+  return { store, read };
+}
+
+describe('reorderObjects', () => {
+  it('applies a valid permutation', () => {
+    const { store, read } = makeStore(['a', 'b', 'c']);
+    store.reorderObjects(0, [textObject('c'), textObject('a'), textObject('b')]);
+    expect(read()).toEqual(['c', 'a', 'b']);
+  });
+
+  it('is a single undoable action', () => {
+    const { store, read } = makeStore(['a', 'b', 'c']);
+    store.reorderObjects(0, [textObject('c'), textObject('b'), textObject('a')]);
+    expect(read()).toEqual(['c', 'b', 'a']);
+    store.undo(0);
+    expect(read()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('rejects a duplicated id rather than dropping an object', () => {
+    const { store, read } = makeStore(['a', 'b', 'c']);
+    // Same length and every id known, but 'c' would silently vanish.
+    store.reorderObjects(0, [textObject('a'), textObject('a'), textObject('b')]);
+    expect(read()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('rejects an order containing an unknown id', () => {
+    const { store, read } = makeStore(['a', 'b']);
+    store.reorderObjects(0, [textObject('a'), textObject('zzz')]);
+    expect(read()).toEqual(['a', 'b']);
+  });
+
+  it('rejects a length mismatch', () => {
+    const { store, read } = makeStore(['a', 'b', 'c']);
+    store.reorderObjects(0, [textObject('a'), textObject('b')]);
+    expect(read()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('ignores an unknown page index', () => {
+    const { store, read } = makeStore(['a']);
+    expect(() => store.reorderObjects(9, [textObject('a')])).not.toThrow();
+    expect(read()).toEqual(['a']);
+  });
+});

--- a/tests/document-store.test.ts
+++ b/tests/document-store.test.ts
@@ -58,14 +58,14 @@ describe('documentStore', () => {
     expect(get(store.canRedo(0))).toBe(true);
   });
 
-  it('removeObject drops and undo restores', () => {
+  it('removeObject undo restores the object at its original z-order position', () => {
     const store = createDocumentStore();
     const initial = docWithPages([{ ...pdfPage(0), objects: [stroke('a'), stroke('b')] }]);
     store.load(initial);
     store.removeObject(0, 'a');
     expect(get(store)!.pages[0].objects.map((o) => o.id)).toEqual(['b']);
     store.undo(0);
-    expect(get(store)!.pages[0].objects.map((o) => o.id)).toEqual(['b', 'a']);
+    expect(get(store)!.pages[0].objects.map((o) => o.id)).toEqual(['a', 'b']);
   });
 
   it('updateObject patches, undo reverts', () => {

--- a/tests/export-command.test.ts
+++ b/tests/export-command.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import { getCommands } from '$lib/command/commands';
+
+describe('annotated PDF export command', () => {
+  it('is available from the command palette', () => {
+    const command = getCommands().find((candidate) => candidate.id === 'file.exportAnnotatedPdf');
+    expect(command?.title).toBe('Export annotated PDF…');
+  });
+});

--- a/tests/graph-compile-cache.test.ts
+++ b/tests/graph-compile-cache.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { graphFnCacheKey, liveCacheKeys, pruneCache } from '$lib/graph/compileCache';
+
+function graph(id: string, fnIds: string[]) {
+  return { id, functions: fnIds.map((fid) => ({ id: fid })) };
+}
+
+describe('graphFnCacheKey', () => {
+  it('is stable for the same pair', () => {
+    expect(graphFnCacheKey('g1', 'f1')).toBe(graphFnCacheKey('g1', 'f1'));
+  });
+
+  it('cannot collide across a boundary-ambiguous split', () => {
+    // A naive `${a}-${b}` key would make these two pairs identical.
+    expect(graphFnCacheKey('a', 'b-c')).not.toBe(graphFnCacheKey('a-b', 'c'));
+  });
+});
+
+describe('liveCacheKeys', () => {
+  it('covers every function of every graph', () => {
+    const live = liveCacheKeys([graph('g1', ['f1', 'f2']), graph('g2', ['f3'])]);
+    expect(live.size).toBe(3);
+    expect(live.has(graphFnCacheKey('g1', 'f2'))).toBe(true);
+    expect(live.has(graphFnCacheKey('g2', 'f3'))).toBe(true);
+  });
+
+  it('is empty for no graphs', () => {
+    expect(liveCacheKeys([]).size).toBe(0);
+  });
+});
+
+describe('pruneCache', () => {
+  it('drops entries for deleted functions and keeps live ones', () => {
+    const cache = new Map<string, unknown>([
+      [graphFnCacheKey('g1', 'f1'), 'keep'],
+      [graphFnCacheKey('g1', 'f2'), 'drop'],
+      [graphFnCacheKey('gone', 'f9'), 'drop'],
+    ]);
+    const removed = pruneCache(cache, liveCacheKeys([graph('g1', ['f1'])]));
+    expect(removed).toBe(2);
+    expect([...cache.keys()]).toEqual([graphFnCacheKey('g1', 'f1')]);
+  });
+
+  it('empties the cache when every graph is deleted', () => {
+    const cache = new Map<string, unknown>([
+      [graphFnCacheKey('g1', 'f1'), 1],
+      [graphFnCacheKey('g2', 'f2'), 2],
+    ]);
+    expect(pruneCache(cache, liveCacheKeys([]))).toBe(2);
+    expect(cache.size).toBe(0);
+  });
+
+  it('does not grow across repeated churn', () => {
+    const cache = new Map<string, unknown>();
+    for (let i = 0; i < 500; i += 1) {
+      const graphs = [graph(`g${i}`, ['f1'])];
+      cache.set(graphFnCacheKey(`g${i}`, 'f1'), i);
+      pruneCache(cache, liveCacheKeys(graphs));
+    }
+    expect(cache.size).toBe(1);
+  });
+
+  it('is a no-op when everything is live', () => {
+    const cache = new Map<string, unknown>([[graphFnCacheKey('g1', 'f1'), 1]]);
+    expect(pruneCache(cache, liveCacheKeys([graph('g1', ['f1'])]))).toBe(0);
+    expect(cache.size).toBe(1);
+  });
+});

--- a/tests/graph-parameters.test.ts
+++ b/tests/graph-parameters.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_PARAMETER,
+  clampParameter,
+  mergeParameters,
+  parametersForGraph,
+} from '$lib/graph/parameters';
+import type { GraphObject, GraphParameter } from '$lib/types';
+
+function parameter(name: string, overrides: Partial<GraphParameter> = {}): GraphParameter {
+  return {
+    name,
+    value: 2,
+    min: -10,
+    max: 10,
+    step: 0.25,
+    ...overrides,
+  };
+}
+
+function graph(functions: GraphObject['functions'], parameters?: GraphParameter[]): GraphObject {
+  return {
+    id: 'graph-1',
+    createdAt: 0,
+    type: 'graph',
+    bounds: { x: 0, y: 0, w: 200, h: 100 },
+    xRange: [-10, 10],
+    yRange: [-10, 10],
+    gridStep: 1,
+    showAxes: true,
+    showGrid: true,
+    functions,
+    parameters,
+  };
+}
+
+describe('mergeParameters', () => {
+  it('preserves surviving settings, adds defaults, and drops removed names', () => {
+    const existing = [parameter('a'), parameter('removed', { value: 4 })];
+    expect(mergeParameters(existing, ['a', 'b'])).toEqual([
+      parameter('a'),
+      { name: 'b', ...DEFAULT_PARAMETER },
+    ]);
+  });
+
+  it('does not mutate the input array or its objects', () => {
+    const existing = Object.freeze([
+      Object.freeze(parameter('a', { showChip: true })),
+      Object.freeze(parameter('b')),
+    ]);
+    const snapshot = JSON.stringify(existing);
+    const merged = mergeParameters(existing, ['b', 'a']);
+
+    expect(JSON.stringify(existing)).toBe(snapshot);
+    expect(merged).toEqual([parameter('b'), parameter('a', { showChip: true })]);
+    expect(merged[0]).not.toBe(existing[1]);
+    expect(merged[1]).not.toBe(existing[0]);
+  });
+});
+
+describe('parametersForGraph', () => {
+  it('unions parameters across functions and preserves shared values', () => {
+    const value = graph(
+      [
+        {
+          id: 'f1',
+          expr: 'a*sin(x)',
+          kind: 'explicit',
+          color: '#000000',
+          width: 2,
+          dash: 'solid',
+          domain: null,
+        },
+        {
+          id: 'f2',
+          expr: 'a*cos(x) + b',
+          kind: 'explicit',
+          color: '#000000',
+          width: 2,
+          dash: 'solid',
+          domain: null,
+        },
+      ],
+      [parameter('a', { value: 3 })],
+    );
+
+    expect(parametersForGraph(value)).toEqual([
+      parameter('a', { value: 3 }),
+      { name: 'b', ...DEFAULT_PARAMETER },
+    ]);
+  });
+});
+
+describe('clampParameter', () => {
+  it('repairs non-finite fields without throwing', () => {
+    expect(() =>
+      clampParameter(
+        parameter('a', {
+          value: Number.NaN,
+          min: Number.NEGATIVE_INFINITY,
+          max: Number.POSITIVE_INFINITY,
+          step: Number.NaN,
+        }),
+      ),
+    ).not.toThrow();
+    expect(
+      clampParameter(
+        parameter('a', {
+          value: Number.NaN,
+          min: Number.NEGATIVE_INFINITY,
+          max: Number.POSITIVE_INFINITY,
+          step: Number.NaN,
+        }),
+      ),
+    ).toEqual({ name: 'a', ...DEFAULT_PARAMETER });
+  });
+
+  it('orders bounds, forces a positive step, and clamps the value', () => {
+    expect(clampParameter(parameter('a', { min: 5, max: -2, step: 0, value: 20 }))).toEqual({
+      name: 'a',
+      min: -2,
+      max: 5,
+      step: 0.1,
+      value: 5,
+    });
+    expect(clampParameter(parameter('b', { step: -1, value: -20 }))).toEqual({
+      name: 'b',
+      min: -10,
+      max: 10,
+      step: 0.1,
+      value: -10,
+    });
+  });
+});

--- a/tests/graph-parser.test.ts
+++ b/tests/graph-parser.test.ts
@@ -42,6 +42,15 @@ describe('parseExpression', () => {
     expect(compile('(-2)^2')(0)).toBe(4);
   });
 
+  it('supports unary signs in exponents without changing power precedence', () => {
+    expect(compile('x^-2')(3)).toBeCloseTo(1 / 9);
+    expect(compile('2^-x')(3)).toBeCloseTo(1 / 8);
+    expect(compile('e^-x')(2)).toBeCloseTo(Math.exp(-2));
+    expect(compile('x^--2')(3)).toBe(9);
+    expect(compile('-2^2')(0)).toBe(-4);
+    expect(compile('2^3^2')(0)).toBe(512);
+  });
+
   it('supports unary plus and minus', () => {
     expect(compile('-x')(5)).toBe(-5);
     expect(compile('--x')(5)).toBe(5);

--- a/tests/graph-parser.test.ts
+++ b/tests/graph-parser.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { parseExpression } from '$lib/graph/parser';
+import {
+  freeVariables,
+  parseExpression,
+  parseExpressionWithParams,
+  parseExpressionXY,
+  parseExpressionXYWithParams,
+} from '$lib/graph/parser';
+import type { GraphParameter } from '$lib/types';
 
 function compile(src: string): (x: number) => number {
   const r = parseExpression(src);
@@ -111,5 +118,72 @@ describe('parseExpression', () => {
     const f = compile('1/x');
     expect(f(0)).toBe(Infinity);
     expect(f(2)).toBe(0.5);
+  });
+});
+
+describe('freeVariables', () => {
+  it('returns free variables in first-appearance order without duplicates', () => {
+    expect(freeVariables('y = a*sin(b*x) + c + a', ['x', 'y'])).toEqual(['a', 'b', 'c']);
+  });
+
+  it('excludes function names, constants, and reserved variables', () => {
+    expect(freeVariables('sin(x)', ['x'])).toEqual([]);
+    expect(freeVariables('pi*x + e^x', ['x'])).toEqual([]);
+    expect(freeVariables('x^2 + y^2 = r^2', ['x', 'y'])).toEqual(['r']);
+  });
+
+  it('returns an empty list for input that cannot be tokenized', () => {
+    expect(() => freeVariables('a + @', ['x'])).not.toThrow();
+    expect(freeVariables('a + @', ['x'])).toEqual([]);
+  });
+});
+
+describe('parameterized expressions', () => {
+  const parameter = (name: string, value: number): GraphParameter => ({
+    name,
+    value,
+    min: -5,
+    max: 5,
+    step: 0.1,
+  });
+
+  it('evaluates and updates explicit parameters through a shared buffer', () => {
+    const result = parseExpressionWithParams('a*sin(x) + b', [
+      parameter('a', 2),
+      parameter('b', 1),
+    ]);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.compiled.fn(Math.PI / 2)).toBeCloseTo(3);
+    result.compiled.setParameter('a', 4);
+    expect(result.compiled.fn(Math.PI / 2)).toBeCloseTo(5);
+    result.compiled.setParameter('unknown', 100);
+    expect(result.compiled.fn(Math.PI / 2)).toBeCloseTo(5);
+    expect(result.compiled.parameterNames).toEqual(['a', 'b']);
+  });
+
+  it('evaluates and updates implicit parameters', () => {
+    const result = parseExpressionXYWithParams('x^2 + y^2 = r^2', [parameter('r', 2)]);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.compiled.fn(0, 2)).toBe(0);
+    result.compiled.setParameter('r', 3);
+    expect(result.compiled.fn(0, 2)).toBe(-5);
+  });
+
+  it('still reports undeclared identifiers cleanly', () => {
+    const result = parseExpressionWithParams('a*x + b', [parameter('a', 2)]);
+    expect(result).toEqual({ ok: false, error: "unknown identifier 'b'" });
+  });
+
+  it('preserves the legacy parser semantics', () => {
+    const negativePower = parseExpression('-2^2');
+    const associatedPower = parseExpression('2^3^2');
+    const implicit = parseExpressionXY('x^2 + y^2 = 4');
+    expect(negativePower.ok && negativePower.fn(0)).toBe(-4);
+    expect(associatedPower.ok && associatedPower.fn(0)).toBe(512);
+    expect(implicit.ok && implicit.fn(0, 2)).toBe(0);
   });
 });

--- a/tests/page-nav.test.ts
+++ b/tests/page-nav.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { pageIndexAfterDelete, pageIndexAfterDuplicate } from '$lib/app/pageNav';
+
+describe('pageIndexAfterDuplicate', () => {
+  it('lands on the copy that follows the source page', () => {
+    expect(pageIndexAfterDuplicate(0, 4)).toBe(1);
+    expect(pageIndexAfterDuplicate(2, 5)).toBe(3);
+  });
+
+  it('clamps when the source was the last page', () => {
+    expect(pageIndexAfterDuplicate(3, 4)).toBe(3);
+  });
+
+  it('returns 0 for an empty document', () => {
+    expect(pageIndexAfterDuplicate(2, 0)).toBe(0);
+  });
+});
+
+describe('pageIndexAfterDelete', () => {
+  it('keeps the same content in view when an earlier page is deleted', () => {
+    // 3 pages [A,B,C], viewing C (index 2), delete A -> C is now index 1.
+    expect(pageIndexAfterDelete(0, 2, 2)).toBe(1);
+  });
+
+  it('steps back when the current page is deleted', () => {
+    expect(pageIndexAfterDelete(2, 2, 2)).toBe(1);
+  });
+
+  it('leaves the position untouched when a later page is deleted', () => {
+    expect(pageIndexAfterDelete(2, 0, 2)).toBe(0);
+    expect(pageIndexAfterDelete(3, 1, 3)).toBe(1);
+  });
+
+  it('never goes below the first page', () => {
+    expect(pageIndexAfterDelete(0, 0, 1)).toBe(0);
+  });
+
+  it('clamps to the last remaining page', () => {
+    expect(pageIndexAfterDelete(0, 9, 2)).toBe(1);
+  });
+
+  it('returns 0 for an empty document', () => {
+    expect(pageIndexAfterDelete(0, 0, 0)).toBe(0);
+  });
+});

--- a/tests/select-ops.test.ts
+++ b/tests/select-ops.test.ts
@@ -125,4 +125,33 @@ describe('commit ops', () => {
     u();
     expect(objs.map((o) => o.id)).toEqual(['a', 'c', 'b']);
   });
+
+  it('reorderSelection is one undoable action that preserves every object', () => {
+    const a = mkShape('a');
+    const b = mkShape('b');
+    const c = mkShape('c');
+    documentStore.load(doc([a, b, c]));
+
+    reorderSelection(0, new Set(['a']), 'forward');
+    documentStore.undo(0);
+
+    let objs: ShapeObject[] = [];
+    const u = documentStore.objectsOnPage(0).subscribe((v) => (objs = v as ShapeObject[]));
+    u();
+    expect(objs.map((o) => o.id)).toEqual(['a', 'b', 'c']);
+
+    let canUndo = true;
+    const historySubscription = documentStore.history
+      .canUndo(0)
+      .subscribe((value) => (canUndo = value));
+    historySubscription();
+    expect(canUndo).toBe(false);
+
+    documentStore.redo(0);
+    const redoSubscription = documentStore
+      .objectsOnPage(0)
+      .subscribe((value) => (objs = value as ShapeObject[]));
+    redoSubscription();
+    expect(objs.map((o) => o.id)).toEqual(['b', 'a', 'c']);
+  });
 });

--- a/tests/session-player.test.ts
+++ b/tests/session-player.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { chapterMarkers, nearestPageChangeAtOrBefore, replayStateAt } from '$lib/session/player';
-import type { Point, StrokeObject, TextObject } from '$lib/types';
+import type { GraphObject, Point, StrokeObject, TextObject } from '$lib/types';
 import type { SessionEvent } from '$lib/session/types';
 
 function pt(x: number, t: number): Point {
@@ -28,6 +28,22 @@ function text(id: string, content = 'x'): TextObject {
     latex: false,
     fontSize: 16,
     color: '#000',
+  };
+}
+
+function graph(id: string): GraphObject {
+  return {
+    id,
+    createdAt: 0,
+    type: 'graph',
+    bounds: { x: 0, y: 0, w: 100, h: 100 },
+    xRange: [-10, 10],
+    yRange: [-10, 10],
+    gridStep: 1,
+    showAxes: true,
+    showGrid: true,
+    functions: [],
+    parameters: [{ name: 'a', value: 1, min: -5, max: 5, step: 0.1 }],
   };
 }
 
@@ -115,6 +131,23 @@ describe('replayStateAt', () => {
     const r = replayStateAt(events, 25);
     const t = r.byPage.get(0)?.[0] as TextObject;
     expect(t.content).toBe('new');
+  });
+
+  it('replays live graph parameter changes', () => {
+    const events: SessionEvent[] = [
+      { kind: 'objectAdd', t: 0, page: 0, obj: graph('g1') },
+      {
+        kind: 'graph.paramChange',
+        t: 20,
+        page: 0,
+        graphId: 'g1',
+        name: 'a',
+        value: 2.5,
+      },
+    ];
+    const r = replayStateAt(events, 25);
+    const replayed = r.byPage.get(0)?.[0] as GraphObject;
+    expect(replayed.parameters?.[0].value).toBe(2.5);
   });
 });
 

--- a/tests/session-recorder.test.ts
+++ b/tests/session-recorder.test.ts
@@ -138,6 +138,22 @@ describe('recorder', () => {
     expect(strokeEvents[0].t).toBeLessThanOrEqual(strokeEvents[1].t);
   });
 
+  it('records graph parameter previews while recording', async () => {
+    const h = makeHarness();
+    await h.recorder.start('/tmp/x.pdf');
+    h.now.ms = 250;
+    h.recorder.recordGraphParameter(0, 'g1', 'a', 2.5);
+
+    expect(h.recorder._inject.events.at(-1)).toEqual({
+      kind: 'graph.paramChange',
+      t: 250,
+      page: 0,
+      graphId: 'g1',
+      name: 'a',
+      value: 2.5,
+    });
+  });
+
   it('emits pageChange on viewport change, ignoring repeats', async () => {
     const h = makeHarness();
     h.now.ms = 0;

--- a/tests/shortcut-space-pan.test.ts
+++ b/tests/shortcut-space-pan.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { viewport, viewportStore } from '$lib/store/viewport';
+import { get } from 'svelte/store';
+import { shortcuts } from '$lib/app/shortcuts';
+
+type Listener = (event: unknown) => void;
+
+class FakeEventTarget {
+  listeners = new Map<string, Set<Listener>>();
+
+  addEventListener(type: string, fn: Listener): void {
+    if (!this.listeners.has(type)) this.listeners.set(type, new Set());
+    this.listeners.get(type)!.add(fn);
+  }
+
+  removeEventListener(type: string, fn: Listener): void {
+    this.listeners.get(type)?.delete(fn);
+  }
+
+  emit(type: string, event: unknown = {}): void {
+    for (const fn of [...(this.listeners.get(type) ?? [])]) fn(event);
+  }
+
+  count(type: string): number {
+    return this.listeners.get(type)?.size ?? 0;
+  }
+}
+
+const originalWindow = globalThis.window;
+const originalDocument = globalThis.document;
+
+let fakeWindow: FakeEventTarget;
+let fakeDocument: FakeEventTarget & { visibilityState: string };
+
+/** The action reads `window`/`document` when invoked, so stubbing the globals
+ *  before calling it is enough; no module cache juggling required. */
+function mountShortcuts() {
+  return shortcuts(null as never, undefined as never);
+}
+
+beforeEach(() => {
+  fakeWindow = new FakeEventTarget();
+  fakeDocument = Object.assign(new FakeEventTarget(), { visibilityState: 'visible' });
+  Object.defineProperty(globalThis, 'window', { value: fakeWindow, configurable: true });
+  Object.defineProperty(globalThis, 'document', { value: fakeDocument, configurable: true });
+  viewport.setPanMode(false);
+});
+
+afterEach(() => {
+  Object.defineProperty(globalThis, 'window', { value: originalWindow, configurable: true });
+  Object.defineProperty(globalThis, 'document', { value: originalDocument, configurable: true });
+  viewport.setPanMode(false);
+});
+
+function holdSpace(): void {
+  fakeWindow.emit('keydown', { key: ' ', target: null, preventDefault: () => {} });
+}
+
+describe('space-hold pan mode', () => {
+  it('enters pan mode while space is held and exits on keyup', () => {
+    const action = mountShortcuts();
+    holdSpace();
+    expect(get(viewportStore).panMode).toBe(true);
+
+    fakeWindow.emit('keyup', { key: ' ', target: null });
+    expect(get(viewportStore).panMode).toBe(false);
+    action?.destroy?.();
+  });
+
+  it('releases pan mode when the window loses focus', () => {
+    const action = mountShortcuts();
+    holdSpace();
+    expect(get(viewportStore).panMode).toBe(true);
+
+    // The keyup is delivered to whatever window took focus, never to us.
+    fakeWindow.emit('blur');
+    expect(get(viewportStore).panMode).toBe(false);
+    action?.destroy?.();
+  });
+
+  it('releases pan mode when the page becomes hidden', () => {
+    const action = mountShortcuts();
+    holdSpace();
+    fakeDocument.visibilityState = 'hidden';
+    fakeDocument.emit('visibilitychange');
+    expect(get(viewportStore).panMode).toBe(false);
+    action?.destroy?.();
+  });
+
+  it('leaves pan mode alone on blur when space was never held', () => {
+    const action = mountShortcuts();
+    viewport.setPanMode(true);
+    fakeWindow.emit('blur');
+    expect(get(viewportStore).panMode).toBe(true);
+    action?.destroy?.();
+  });
+
+  it('removes every listener it registered on destroy', () => {
+    const action = mountShortcuts();
+    expect(fakeWindow.count('blur')).toBe(1);
+    action?.destroy?.();
+    expect(fakeWindow.count('keydown')).toBe(0);
+    expect(fakeWindow.count('keyup')).toBe(0);
+    expect(fakeWindow.count('blur')).toBe(0);
+    expect(fakeDocument.count('visibilitychange')).toBe(0);
+  });
+});

--- a/tests/sidebar-import-color-hardening.test.ts
+++ b/tests/sidebar-import-color-hardening.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { previewImportedSidebarPayload } from '$lib/store/sidebar';
+
+/**
+ * Imported config is untrusted and its color values are interpolated straight
+ * into `style` attributes, so anything that is not a strict hex color must be
+ * rejected rather than passed through.
+ */
+const INJECTIONS = [
+  'red; position:fixed; inset:0; z-index:9999; background:black',
+  'url(https://example.com/x.png)',
+  'expression(alert(1))',
+  '#000; content: "x"',
+  'javascript:alert(1)',
+  'rgb(0,0,0); opacity: 0',
+  '#xyzxyz',
+  '#12345',
+  '',
+  'black',
+];
+
+function importState(state: unknown) {
+  return previewImportedSidebarPayload({ state });
+}
+
+function importPalette(color: unknown) {
+  return importState({ palettes: [{ id: 'p', name: 'P', colors: [color] }] });
+}
+
+describe('sidebar config import color hardening', () => {
+  it('accepts a strict hex palette color', () => {
+    const out = importPalette('#1a2b3c');
+    expect(out.palettes?.[0].colors).toEqual(['#1a2b3c']);
+  });
+
+  it('rejects every CSS injection attempt in a palette', () => {
+    for (const bad of INJECTIONS) {
+      const out = importPalette(bad);
+      const colors = out.palettes?.flatMap((p) => p.colors) ?? [];
+      expect(colors).not.toContain(bad);
+    }
+  });
+
+  it('rejects a non-hex activeColor', () => {
+    for (const bad of INJECTIONS) {
+      expect(importState({ activeColor: bad }).activeColor).not.toBe(bad);
+    }
+    expect(importState({ activeColor: '#abcdef' }).activeColor).toBe('#abcdef');
+  });
+
+  it('rejects a non-hex laser color', () => {
+    for (const bad of INJECTIONS) {
+      const out = importState({ laser: { color: bad, radius: 6 } });
+      expect(out.laser?.color).not.toBe(bad);
+    }
+    const ok = importState({ laser: { color: '#ff0000', radius: 6 } });
+    expect(ok.laser?.color).toBe('#ff0000');
+  });
+
+  it('rejects a non-hex tool style color', () => {
+    const style = (color: string) => ({ color, width: 2, dash: 'solid', opacity: 1 });
+    const out = importState({
+      toolStyles: {
+        pen: style(INJECTIONS[0]),
+        highlighter: style('#ffff00'),
+        line: style('#000000'),
+      },
+    });
+    expect(out.toolStyles?.pen.color).not.toBe(INJECTIONS[0]);
+  });
+
+  it('does not throw on malformed input', () => {
+    for (const bad of [null, undefined, 42, 'x', [], { palettes: 'nope' }]) {
+      expect(() => importState(bad)).not.toThrow();
+    }
+  });
+});

--- a/tests/slide-deck.test.ts
+++ b/tests/slide-deck.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+import {
+  addBlock,
+  createBlock,
+  createSlide,
+  moveBlock,
+  removeBlock,
+  setLayout,
+  updateBlock,
+} from '$lib/slides/deck';
+import { SLIDE_PAGE_SIZE, slidePage } from '$lib/slides/pageOps';
+import type { Slide } from '$lib/types';
+
+function freezeDeep<T>(value: T): T {
+  if (value !== null && typeof value === 'object') {
+    Object.freeze(value);
+    for (const child of Object.values(value)) freezeDeep(child);
+  }
+  return value;
+}
+
+function sampleSlide(): Slide {
+  const list = createBlock('list');
+  list.items = [{ text: 'Nested', level: 1 }];
+  return {
+    ...createSlide('content', 'Original'),
+    subtitle: 'Subtitle',
+    blocks: [createBlock('text'), list],
+    aside: [{ ...createBlock('callout'), text: 'Aside' }],
+    theme: { accent: '#112233' },
+  };
+}
+
+function expectInputUnchanged(before: Slide, after: Slide): void {
+  expect(before.title).toBe('Original');
+  expect(before.blocks).toHaveLength(2);
+  expect(before.blocks[1]).toMatchObject({
+    kind: 'list',
+    items: [{ text: 'Nested', level: 1 }],
+  });
+  expect(after).not.toBe(before);
+}
+
+describe('slide deck operations', () => {
+  it('creates sensible defaults for every block kind', () => {
+    const kinds = [
+      'text',
+      'list',
+      'definitions',
+      'table',
+      'math',
+      'graph',
+      'callout',
+      'image',
+      'spacer',
+    ] as const;
+    const blocks = kinds.map(createBlock);
+    expect(blocks.map((block) => block.kind)).toEqual(kinds);
+    expect(new Set(blocks.map((block) => block.id)).size).toBe(kinds.length);
+  });
+
+  describe('slide pages', () => {
+    it('exposes standard widescreen and letter dimensions', () => {
+      expect(SLIDE_PAGE_SIZE).toEqual({
+        widescreen: { width: 960, height: 540 },
+        letter: { width: 612, height: 792 },
+      });
+    });
+
+    it('creates a slide page with independently cloned slide data', () => {
+      const slide = freezeDeep(sampleSlide());
+      const page = slidePage(3, slide, 960, 540, 1);
+      expect(page).toMatchObject({
+        pageIndex: 3,
+        type: 'slide',
+        insertedAfterPdfPage: 1,
+        width: 960,
+        height: 540,
+        objects: [],
+      });
+      expect(page.slide).toEqual(slide);
+      expect(page.slide).not.toBe(slide);
+      expect(page.slide?.blocks).not.toBe(slide.blocks);
+    });
+  });
+
+  it('adds a cloned block without mutating or sharing with the input', () => {
+    const slide = freezeDeep(sampleSlide());
+    const added = createBlock('definitions');
+    const next = addBlock(slide, added, 1);
+    expectInputUnchanged(slide, next);
+    expect(next.blocks[1]).toEqual(added);
+    expect(next.blocks[1]).not.toBe(added);
+    expect(next.blocks[0]).not.toBe(slide.blocks[0]);
+    expect(next.aside).not.toBe(slide.aside);
+  });
+
+  it('clamps add indices and appends by default', () => {
+    const slide = freezeDeep(sampleSlide());
+    const first = addBlock(slide, createBlock('spacer'), -99);
+    const last = addBlock(slide, createBlock('math'), 999);
+    const appended = addBlock(slide, createBlock('table'));
+    expect(first.blocks[0].kind).toBe('spacer');
+    expect(last.blocks.at(-1)?.kind).toBe('math');
+    expect(appended.blocks.at(-1)?.kind).toBe('table');
+    expectInputUnchanged(slide, first);
+  });
+
+  it('updates a block immutably and preserves its id', () => {
+    const slide = freezeDeep(sampleSlide());
+    const target = slide.blocks[0];
+    const next = updateBlock(slide, target.id, { text: 'Changed', bold: true });
+    expectInputUnchanged(slide, next);
+    expect(next.blocks[0]).toMatchObject({ id: target.id, text: 'Changed', bold: true });
+    expect(next.blocks[1]).not.toBe(slide.blocks[1]);
+  });
+
+  it('returns an independent clone when updating a missing id', () => {
+    const slide = freezeDeep(sampleSlide());
+    const next = updateBlock(slide, 'missing', { text: 'Nope' });
+    expect(next).toEqual(slide);
+    expect(next.blocks).not.toBe(slide.blocks);
+  });
+
+  it('removes a block without mutating the input', () => {
+    const slide = freezeDeep(sampleSlide());
+    const next = removeBlock(slide, slide.blocks[0].id);
+    expectInputUnchanged(slide, next);
+    expect(next.blocks).toHaveLength(1);
+    expect(next.blocks[0]).not.toBe(slide.blocks[1]);
+  });
+
+  it('moves blocks and clamps the destination', () => {
+    const slide = freezeDeep({
+      ...sampleSlide(),
+      blocks: [createBlock('text'), createBlock('list'), createBlock('math')],
+    });
+    const firstId = slide.blocks[0].id;
+    const next = moveBlock(slide, 0, 99);
+    expect(next.blocks.map((block) => block.id)).toEqual([
+      slide.blocks[1].id,
+      slide.blocks[2].id,
+      firstId,
+    ]);
+    expect(slide.blocks[0].id).toBe(firstId);
+  });
+
+  it('handles out-of-range move sources as immutable no-ops', () => {
+    const slide = freezeDeep(sampleSlide());
+    for (const from of [-1, 99, 0.5]) {
+      const next = moveBlock(slide, from, 1);
+      expect(next).toEqual(slide);
+      expect(next).not.toBe(slide);
+      expect(next.blocks).not.toBe(slide.blocks);
+    }
+  });
+
+  it('changes layout while preserving independently cloned blocks', () => {
+    const slide = freezeDeep(sampleSlide());
+    const next = setLayout(slide, 'columns');
+    expect(next.layout).toBe('columns');
+    expect(next.blocks).toEqual(slide.blocks);
+    expect(next.blocks).not.toBe(slide.blocks);
+    expect(next.blocks[1]).not.toBe(slide.blocks[1]);
+    expectInputUnchanged(slide, next);
+  });
+});

--- a/tests/slide-deck.test.ts
+++ b/tests/slide-deck.test.ts
@@ -53,6 +53,8 @@ describe('slide deck operations', () => {
       'callout',
       'image',
       'mapping',
+      'diagram',
+      'numberline',
       'spacer',
     ] as const;
     const blocks = kinds.map(createBlock);
@@ -72,6 +74,22 @@ describe('slide deck operations', () => {
         { from: 1, to: 1 },
       ],
       height: 260,
+    });
+  });
+
+  it('creates diagram and number-line teaching blocks', () => {
+    const diagram = createBlock('diagram');
+    expect(diagram.nodes).toHaveLength(2);
+    expect(diagram.edges).toEqual([{ from: diagram.nodes[0].id, to: diagram.nodes[1].id }]);
+    expect(diagram.height).toBeGreaterThan(0);
+
+    expect(createBlock('numberline')).toMatchObject({
+      min: -10,
+      max: 10,
+      tickStep: 1,
+      labelStep: 5,
+      marks: [],
+      height: 160,
     });
   });
 
@@ -138,6 +156,7 @@ describe('slide deck operations', () => {
       left: ['Changed', ...mapping.left.slice(1)],
       pairs: [{ from: 0, to: 1 }],
     });
+
     expect(slide.blocks[0]).toEqual(mapping);
     expect(next.blocks[0]).toMatchObject({
       kind: 'mapping',
@@ -147,6 +166,37 @@ describe('slide deck operations', () => {
     if (next.blocks[0].kind !== 'mapping') throw new Error('Expected mapping block');
     expect(next.blocks[0].left).not.toBe(mapping.left);
     expect(next.blocks[0].pairs).not.toBe(mapping.pairs);
+  });
+
+  it('deep-clones diagram nodes and edges during updates', () => {
+    const diagram = createBlock('diagram');
+    const slide = freezeDeep({ ...createSlide('content'), blocks: [diagram] });
+    const next = updateBlock(slide, diagram.id, {
+      nodes: diagram.nodes.map((node, index) =>
+        index === 0 ? { ...node, text: 'Changed' } : node,
+      ),
+      edges: diagram.edges.map((edge) => ({ ...edge, label: 'Arrow' })),
+    });
+    expect(slide.blocks[0]).toEqual(diagram);
+    if (next.blocks[0].kind !== 'diagram') throw new Error('Expected diagram block');
+    expect(next.blocks[0].nodes[0].text).toBe('Changed');
+    expect(next.blocks[0].nodes).not.toBe(diagram.nodes);
+    expect(next.blocks[0].nodes[0]).not.toBe(diagram.nodes[0]);
+    expect(next.blocks[0].edges).not.toBe(diagram.edges);
+  });
+
+  it('deep-clones number-line marks during updates', () => {
+    const numberline = createBlock('numberline');
+    numberline.marks = [{ value: 2, kind: 'closed' }];
+    const slide = freezeDeep({ ...createSlide('content'), blocks: [numberline] });
+    const next = updateBlock(slide, numberline.id, {
+      marks: [{ value: 3, kind: 'open' }],
+    });
+    expect(slide.blocks[0]).toEqual(numberline);
+    if (next.blocks[0].kind !== 'numberline') throw new Error('Expected number-line block');
+    expect(next.blocks[0].marks).toEqual([{ value: 3, kind: 'open' }]);
+    expect(next.blocks[0].marks).not.toBe(numberline.marks);
+    expect(next.blocks[0].marks[0]).not.toBe(numberline.marks[0]);
   });
 
   it('returns an independent clone when updating a missing id', () => {

--- a/tests/slide-deck.test.ts
+++ b/tests/slide-deck.test.ts
@@ -52,11 +52,27 @@ describe('slide deck operations', () => {
       'graph',
       'callout',
       'image',
+      'mapping',
       'spacer',
     ] as const;
     const blocks = kinds.map(createBlock);
     expect(blocks.map((block) => block.kind)).toEqual(kinds);
     expect(new Set(blocks.map((block) => block.id)).size).toBe(kinds.length);
+  });
+
+  it('creates a mapping block with valid starter arrows', () => {
+    const mapping = createBlock('mapping');
+    expect(mapping).toMatchObject({
+      leftLabel: 'Domain',
+      rightLabel: 'Range',
+      left: ['Input 1', 'Input 2'],
+      right: ['Output 1', 'Output 2'],
+      pairs: [
+        { from: 0, to: 0 },
+        { from: 1, to: 1 },
+      ],
+      height: 260,
+    });
   });
 
   describe('slide pages', () => {
@@ -113,6 +129,24 @@ describe('slide deck operations', () => {
     expectInputUnchanged(slide, next);
     expect(next.blocks[0]).toMatchObject({ id: target.id, text: 'Changed', bold: true });
     expect(next.blocks[1]).not.toBe(slide.blocks[1]);
+  });
+
+  it('updates mapping data without sharing nested arrays or pairs', () => {
+    const mapping = createBlock('mapping');
+    const slide = freezeDeep({ ...createSlide('content'), blocks: [mapping] });
+    const next = updateBlock(slide, mapping.id, {
+      left: ['Changed', ...mapping.left.slice(1)],
+      pairs: [{ from: 0, to: 1 }],
+    });
+    expect(slide.blocks[0]).toEqual(mapping);
+    expect(next.blocks[0]).toMatchObject({
+      kind: 'mapping',
+      left: ['Changed', 'Input 2'],
+      pairs: [{ from: 0, to: 1 }],
+    });
+    if (next.blocks[0].kind !== 'mapping') throw new Error('Expected mapping block');
+    expect(next.blocks[0].left).not.toBe(mapping.left);
+    expect(next.blocks[0].pairs).not.toBe(mapping.pairs);
   });
 
   it('returns an independent clone when updating a missing id', () => {

--- a/tests/slide-diagram.test.ts
+++ b/tests/slide-diagram.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { render } from 'svelte/server';
+import { measureBlock } from '$lib/slides/layout';
+import { diagramGeometry, type DiagramGeometry } from '$lib/slides/render/diagramGeometry';
+import SlideLayer from '$lib/slides/render/SlideLayer.svelte';
+import { defaultSlideTheme } from '$lib/slides/theme';
+import type { Slide, SlideDiagramBlock } from '$lib/types';
+
+function diagram(overrides: Partial<SlideDiagramBlock> = {}): SlideDiagramBlock {
+  return {
+    id: 'diagram',
+    kind: 'diagram',
+    height: 180,
+    nodes: [
+      { id: 'input', text: '$x$', x: 0.1, y: 0.5, shape: 'plain' },
+      { id: 'machine', text: 'Multiply by $2$', x: 0.5, y: 0.5, shape: 'box' },
+      { id: 'output', text: '$2x$', x: 0.9, y: 0.5, shape: 'plain' },
+    ],
+    edges: [
+      { from: 'input', to: 'machine' },
+      { from: 'machine', to: 'output', label: '$f$' },
+    ],
+    ...overrides,
+  };
+}
+
+function geometryNumbers(geometry: DiagramGeometry): number[] {
+  return [
+    ...geometry.nodes.flatMap((node) => [node.x, node.y, node.w, node.h]),
+    ...geometry.edges.flatMap((edge) => [
+      edge.from.x,
+      edge.from.y,
+      edge.to.x,
+      edge.to.y,
+      edge.labelAt.x,
+      edge.labelAt.y,
+      ...edge.head.flatMap((point) => [point.x, point.y]),
+    ]),
+  ];
+}
+
+describe('slide diagram geometry', () => {
+  it('clamps nodes and keeps their boxes inside the block', () => {
+    const geometry = diagramGeometry(
+      diagram({
+        nodes: [
+          { id: 'a', text: 'A', x: -20, y: Number.NaN, w: 0.3, h: 0.2 },
+          { id: 'b', text: 'B', x: 20, y: 2, w: 4, h: -1 },
+        ],
+        edges: [{ from: 'a', to: 'b' }],
+      }),
+      500,
+      200,
+      defaultSlideTheme.bodySize,
+    );
+    for (const node of geometry.nodes) {
+      expect(node.x - node.w / 2).toBeGreaterThanOrEqual(0);
+      expect(node.x + node.w / 2).toBeLessThanOrEqual(500);
+      expect(node.y - node.h / 2).toBeGreaterThanOrEqual(0);
+      expect(node.y + node.h / 2).toBeLessThanOrEqual(200);
+    }
+    expect(geometryNumbers(geometry).every(Number.isFinite)).toBe(true);
+  });
+
+  it('skips unknown and self edges and resolves duplicate ids to the first node', () => {
+    const geometry = diagramGeometry(
+      diagram({
+        nodes: [
+          { id: 'a', text: 'first', x: 0.2, y: 0.5, w: 0.2, h: 0.2 },
+          { id: 'a', text: 'duplicate', x: 0.8, y: 0.2, w: 0.2, h: 0.2 },
+          { id: 'b', text: 'target', x: 0.8, y: 0.5, w: 0.2, h: 0.2 },
+        ],
+        edges: [
+          { from: 'a', to: 'b' },
+          { from: 'a', to: 'a' },
+          { from: 'missing', to: 'b' },
+        ],
+      }),
+      500,
+      200,
+      defaultSlideTheme.bodySize,
+    );
+    expect(geometry.edges).toHaveLength(1);
+    expect(geometry.edges[0].from.x).toBeCloseTo(150);
+    expect(geometry.edges[0].to.x).toBeCloseTo(350);
+  });
+
+  it('sizes omitted node dimensions and measures the declared block height', () => {
+    const block = diagram();
+    const geometry = diagramGeometry(block, 500, 180, defaultSlideTheme.bodySize);
+    expect(geometry.nodes.every((node) => node.w > 0 && node.h > 0)).toBe(true);
+    expect(measureBlock(block, defaultSlideTheme, 500)).toBe(180);
+  });
+
+  it('renders node text and edge labels through inline math', () => {
+    const slide: Slide = { layout: 'blank', title: '', blocks: [diagram()] };
+    const body = render(SlideLayer, {
+      props: { slide, theme: defaultSlideTheme, width: 612, height: 792, ptToPx: 1 },
+    }).body;
+    expect(body).toMatch(/class="diagram-node\b/);
+    expect(body).toMatch(/class="diagram-edge-label\b/);
+    expect(body.match(/class="katex"/g)?.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('does not produce NaN for degenerate dimensions', () => {
+    const geometry = diagramGeometry(diagram(), -1, Number.NaN, Number.NaN);
+    expect(geometryNumbers(geometry).every(Number.isFinite)).toBe(true);
+  });
+});

--- a/tests/slide-inline-math-seam.test.ts
+++ b/tests/slide-inline-math-seam.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { renderInlineMath } from '$lib/slides/render/inlineMath';
+
+describe('renderInlineMath', () => {
+  it('typesets bare math detected inside a heading', () => {
+    const html = renderInlineMath('Difference of Squares a^2-b^2=(a+b)(a-b)');
+    expect(html).toContain('katex');
+    expect(html).toContain('Difference of Squares');
+  });
+
+  it('typesets explicitly delimited math', () => {
+    expect(renderInlineMath('The line $y = mx + b$')).toContain('katex');
+  });
+
+  it('leaves prose untouched', () => {
+    const html = renderInlineMath('Check your answer');
+    expect(html).not.toContain('katex');
+    expect(html).toBe('Check your answer');
+  });
+
+  it('escapes html in text runs', () => {
+    expect(renderInlineMath('<script>alert(1)</script>')).not.toContain('<script>');
+  });
+
+  it('escapes html in a failed math run rather than emitting it raw', () => {
+    const html = renderInlineMath('$\\frac{<script>alert(1)</script>$');
+    expect(html).not.toContain('<script>');
+  });
+
+  it('returns an empty string for empty input', () => {
+    expect(renderInlineMath('')).toBe('');
+  });
+});

--- a/tests/slide-inline-math.test.ts
+++ b/tests/slide-inline-math.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { render } from 'svelte/server';
+import SlideLayer from '$lib/slides/render/SlideLayer.svelte';
+import { defaultSlideTheme } from '$lib/slides/theme';
+import type { Slide } from '$lib/types';
+
+describe('slide inline math rendering', () => {
+  it('renders math safely in title, subtitle, captions, and definition terms', () => {
+    const slide: Slide = {
+      layout: 'title',
+      title: 'Difference of Squares $a^2-b^2$ <script>',
+      subtitle: 'Factor as $(a+b)(a-b)$',
+      blocks: [
+        {
+          id: 'definitions',
+          kind: 'definitions',
+          items: [{ term: '$f(x)$', text: 'A function' }],
+        },
+        {
+          id: 'table',
+          kind: 'table',
+          caption: 'Values of $f(x)$',
+          header: ['x', 'f(x)'],
+          rows: [['1', '2']],
+        },
+        {
+          id: 'graph',
+          kind: 'graph',
+          caption: 'Graph of $y=x^2$',
+          height: 80,
+          graph: {
+            xRange: [-2, 2],
+            yRange: [0, 4],
+            gridStep: 1,
+            showAxes: true,
+            showGrid: true,
+            functions: [],
+          },
+        },
+        {
+          id: 'mapping',
+          kind: 'mapping',
+          caption: 'Relation $x \\mapsto x^2$',
+          leftLabel: 'Domain',
+          rightLabel: 'Range',
+          left: ['1'],
+          right: ['1'],
+          pairs: [{ from: 0, to: 0 }],
+          height: 100,
+        },
+      ],
+    };
+    const { body } = render(SlideLayer, {
+      props: {
+        slide,
+        theme: defaultSlideTheme,
+        width: 960,
+        height: 540,
+        ptToPx: 1,
+      },
+    });
+
+    expect(body).toMatch(/class="slide-title\b/);
+    expect(body).toMatch(/class="slide-subtitle\b/);
+    expect(body).toMatch(/class="mapping-caption\b/);
+    expect(body).toMatch(/<strong>[\s\S]*?class="katex"/);
+    expect(body.match(/class="katex"/g)?.length).toBeGreaterThanOrEqual(6);
+    expect(body).toContain('&lt;script&gt;');
+    expect(body).not.toContain('<script>');
+  });
+});

--- a/tests/slide-layout.test.ts
+++ b/tests/slide-layout.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+import { layoutSlide, type LayoutBox, type SlideLayout } from '$lib/slides/layout';
+import { defaultSlideTheme } from '$lib/slides/theme';
+import type { Slide, SlideBlock, SlideLayoutKind } from '$lib/types';
+
+function textBlock(id: string, text = 'A short teaching point'): SlideBlock {
+  return { id, kind: 'text', text };
+}
+
+function slide(layout: SlideLayoutKind, blocks: SlideBlock[], columnCount?: number): Slide {
+  return {
+    layout,
+    title: 'Linear functions',
+    subtitle: 'Slope and intercept',
+    blocks,
+    columnCount,
+  };
+}
+
+function overlaps(a: LayoutBox, b: LayoutBox): boolean {
+  return a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
+}
+
+function expectFinite(layout: SlideLayout): void {
+  for (const box of [
+    ...(layout.title ? [layout.title.box] : []),
+    ...(layout.subtitle ? [layout.subtitle.box] : []),
+    ...layout.blocks.map((placed) => placed.box),
+    ...layout.asides.map((placed) => placed.box),
+  ]) {
+    for (const value of [box.x, box.y, box.w, box.h]) {
+      expect(Number.isFinite(value)).toBe(true);
+    }
+  }
+}
+
+function expectPairwiseNonOverlapping(boxes: LayoutBox[]): void {
+  for (let first = 0; first < boxes.length; first += 1) {
+    for (let second = first + 1; second < boxes.length; second += 1) {
+      expect(overlaps(boxes[first], boxes[second])).toBe(false);
+    }
+  }
+}
+
+describe.each<SlideLayoutKind>(['title', 'content', 'columns', 'grid', 'blank'])(
+  '%s slide layout',
+  (kind) => {
+    it('places ordinary blocks in finite boxes within page margins', () => {
+      const result = layoutSlide(
+        slide(kind, [textBlock('a'), textBlock('b'), textBlock('c')], 2),
+        defaultSlideTheme,
+        960,
+        540,
+      );
+      expectFinite(result);
+      expect(result.overflow).toBe(false);
+      for (const { box } of result.blocks) {
+        expect(box.x).toBeGreaterThanOrEqual(960 * 0.06);
+        expect(box.x + box.w).toBeLessThanOrEqual(960 * 0.94);
+        expect(box.y).toBeGreaterThanOrEqual(0);
+        expect(box.y + box.h).toBeLessThanOrEqual(540);
+      }
+      if (kind !== 'columns') {
+        expectPairwiseNonOverlapping(result.blocks.map((placed) => placed.box));
+      }
+    });
+  },
+);
+
+describe('columns layout', () => {
+  it('splits evenly and balances equal-height blocks', () => {
+    const result = layoutSlide(
+      slide('columns', [textBlock('a'), textBlock('b'), textBlock('c'), textBlock('d')], 2),
+      defaultSlideTheme,
+      960,
+      540,
+    );
+    const left = result.blocks.filter((placed) => placed.box.x === result.blocks[0].box.x);
+    const right = result.blocks.filter((placed) => placed.box.x !== result.blocks[0].box.x);
+    expect(left).toHaveLength(2);
+    expect(right).toHaveLength(2);
+    expect(left[0].box.w).toBeCloseTo(right[0].box.w);
+    const leftBottom = Math.max(...left.map(({ box }) => box.y + box.h));
+    const rightBottom = Math.max(...right.map(({ box }) => box.y + box.h));
+    expect(leftBottom).toBeCloseTo(rightBottom);
+    expectPairwiseNonOverlapping(result.blocks.map((placed) => placed.box));
+  });
+});
+
+describe('grid layout', () => {
+  it('tiles equal padded cells without overlap', () => {
+    const result = layoutSlide(
+      slide(
+        'grid',
+        Array.from({ length: 6 }, (_, index) => textBlock(String(index))),
+        3,
+      ),
+      defaultSlideTheme,
+      960,
+      540,
+    );
+    expectPairwiseNonOverlapping(result.blocks.map((placed) => placed.box));
+    const widths = new Set(result.blocks.map(({ box }) => box.w.toFixed(6)));
+    const heights = new Set(result.blocks.map(({ box }) => box.h.toFixed(6)));
+    expect(widths.size).toBe(1);
+    expect(heights.size).toBe(1);
+    expect(new Set(result.blocks.map(({ box }) => box.x.toFixed(6))).size).toBe(3);
+    expect(new Set(result.blocks.map(({ box }) => box.y.toFixed(6))).size).toBe(2);
+  });
+});
+
+describe('slide layout boundaries', () => {
+  it('flags content that exceeds the available height', () => {
+    const result = layoutSlide(
+      slide(
+        'content',
+        Array.from({ length: 20 }, (_, index) =>
+          textBlock(`long-${index}`, 'This is a long line '.repeat(12)),
+        ),
+      ),
+      defaultSlideTheme,
+      612,
+      792,
+    );
+    expect(result.overflow).toBe(true);
+  });
+
+  it('scales horizontal margins with page width', () => {
+    const portrait = layoutSlide(
+      slide('blank', [textBlock('portrait')]),
+      defaultSlideTheme,
+      612,
+      792,
+    );
+    const landscape = layoutSlide(
+      slide('blank', [textBlock('landscape')]),
+      defaultSlideTheme,
+      960,
+      540,
+    );
+    expect(portrait.blocks[0].box.x / 612).toBeCloseTo(landscape.blocks[0].box.x / 960);
+    expect(portrait.blocks[0].box.x / 612).toBeCloseTo(0.065);
+  });
+
+  it.each([0, 99])('clamps columnCount %s safely', (columnCount) => {
+    const result = layoutSlide(
+      slide('columns', [textBlock('a'), textBlock('b')], columnCount),
+      defaultSlideTheme,
+      612,
+      792,
+    );
+    expectFinite(result);
+    expect(result.blocks).toHaveLength(2);
+    const xPositions = new Set(result.blocks.map(({ box }) => box.x));
+    expect(xPositions.size).toBe(columnCount === 0 ? 1 : 2);
+  });
+
+  it('handles empty slides and negative dimensions without NaN', () => {
+    for (const kind of ['title', 'content', 'columns', 'grid', 'blank'] as const) {
+      const empty = layoutSlide(slide(kind, [], 0), defaultSlideTheme, -612, -792);
+      expectFinite(empty);
+      expect(empty.blocks).toEqual([]);
+    }
+  });
+
+  it('handles ragged tables and invalid weights without throwing', () => {
+    const table: SlideBlock = {
+      id: 'table',
+      kind: 'table',
+      header: ['A', 'B', 'C'],
+      rows: [['one'], ['two', 'three']],
+      columnWeights: [1, 0],
+    };
+    const result = layoutSlide(slide('content', [table]), defaultSlideTheme, 612, 792);
+    expectFinite(result);
+    expect(result.blocks[0].box.h).toBeGreaterThan(0);
+  });
+});

--- a/tests/slide-list-markers.test.ts
+++ b/tests/slide-list-markers.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { formatAlpha, formatRoman, presentList } from '$lib/slides/listMarkers';
+import type { SlideListBlock } from '$lib/types';
+
+function list(
+  marker: SlideListBlock['marker'],
+  levels: number[],
+  markerByLevel?: SlideListBlock['markerByLevel'],
+): SlideListBlock {
+  return {
+    id: 'list',
+    kind: 'list',
+    marker,
+    markerByLevel,
+    items: levels.map((level, index) => ({ text: String(index), level })),
+  };
+}
+
+describe('slide list markers', () => {
+  it('steps decimal lists down and restarts numbering within each parent', () => {
+    const presented = presentList(list('decimal', [0, 1, 1, 2, 0, 1, 2, 2]));
+    expect(presented.map((item) => item.marker)).toEqual([
+      '1.',
+      'a.',
+      'b.',
+      'i.',
+      '2.',
+      'a.',
+      'i.',
+      'ii.',
+    ]);
+  });
+
+  it('steps bullet lists down to hollow bullets and dashes', () => {
+    expect(presentList(list('bullet', [0, 1, 2, 3])).map((item) => item.marker)).toEqual([
+      '•',
+      '◦',
+      '–',
+      '◦',
+    ]);
+  });
+
+  it('honors explicit per-level marker choices', () => {
+    const presented = presentList(list('bullet', [0, 1, 1, 2, 2], ['decimal', 'alpha', 'roman']));
+    expect(presented.map((item) => item.marker)).toEqual(['1.', 'a.', 'b.', 'i.', 'ii.']);
+  });
+
+  it('formats alphabetic and roman sequences beyond their first values', () => {
+    expect(formatAlpha(1)).toBe('a');
+    expect(formatAlpha(26)).toBe('z');
+    expect(formatAlpha(27)).toBe('aa');
+    expect(formatAlpha(52)).toBe('az');
+    expect(formatAlpha(53)).toBe('ba');
+    expect(formatRoman(4)).toBe('iv');
+    expect(formatRoman(9)).toBe('ix');
+    expect(formatRoman(27)).toBe('xxvii');
+
+    const alpha = presentList(
+      list(
+        'alpha',
+        Array.from({ length: 27 }, () => 0),
+      ),
+    );
+    const roman = presentList(
+      list(
+        'roman',
+        Array.from({ length: 9 }, () => 0),
+      ),
+    );
+    expect(alpha[26].marker).toBe('aa.');
+    expect(roman[8].marker).toBe('ix.');
+  });
+
+  it('uses marker-width-aware indentation', () => {
+    const presented = presentList(list('decimal', [...Array.from({ length: 12 }, () => 0), 1]));
+    expect(presented[0].markerWidthEm).toBeGreaterThan(1.2);
+    expect(presented[12].indentEm).toBeGreaterThan(presented[0].indentEm);
+  });
+});

--- a/tests/slide-mapping.test.ts
+++ b/tests/slide-mapping.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import { layoutSlide, measureBlock } from '$lib/slides/layout';
+import {
+  mappingGeometry,
+  MAX_MAPPING_ITEMS,
+  type MappingGeometry,
+} from '$lib/slides/render/mappingGeometry';
+import { defaultSlideTheme } from '$lib/slides/theme';
+import type { Slide, SlideMappingBlock } from '$lib/types';
+
+function mapping(overrides: Partial<SlideMappingBlock> = {}): SlideMappingBlock {
+  return {
+    id: 'mapping',
+    kind: 'mapping',
+    leftLabel: 'Domain',
+    rightLabel: 'Range',
+    left: ['1', '2', '3'],
+    right: ['4', '5'],
+    pairs: [
+      { from: 0, to: 1 },
+      { from: 2, to: 0 },
+    ],
+    height: 220,
+    ...overrides,
+  };
+}
+
+function geometryNumbers(geometry: MappingGeometry): number[] {
+  return [
+    geometry.leftOval.cx,
+    geometry.leftOval.cy,
+    geometry.leftOval.rx,
+    geometry.leftOval.ry,
+    geometry.rightOval.cx,
+    geometry.rightOval.cy,
+    geometry.rightOval.rx,
+    geometry.rightOval.ry,
+    ...geometry.leftItems.flatMap((item) => [item.x, item.y]),
+    ...geometry.rightItems.flatMap((item) => [item.x, item.y]),
+    ...geometry.arrows.flatMap((arrow) => [
+      arrow.from.x,
+      arrow.from.y,
+      arrow.to.x,
+      arrow.to.y,
+      ...arrow.head.flatMap((point) => [point.x, point.y]),
+    ]),
+  ];
+}
+
+describe('mapping layout', () => {
+  it('uses the declared height and full content width', () => {
+    const block = mapping();
+    const slide: Slide = { layout: 'blank', title: '', blocks: [block] };
+    const result = layoutSlide(slide, defaultSlideTheme, 960, 540);
+    expect(measureBlock(block, defaultSlideTheme, 400)).toBe(220);
+    expect(result.blocks[0].box.h).toBe(220);
+    expect(result.blocks[0].box.w).toBeCloseTo(960 * (1 - 0.065 * 2));
+  });
+
+  it('keeps both differently-sized ovals inside the block box', () => {
+    const width = 600;
+    const height = 240;
+    const geometry = mappingGeometry(mapping(), width, height, defaultSlideTheme.bodySize);
+    for (const oval of [geometry.leftOval, geometry.rightOval]) {
+      expect(oval.cx - oval.rx).toBeGreaterThanOrEqual(0);
+      expect(oval.cx + oval.rx).toBeLessThanOrEqual(width);
+      expect(oval.cy - oval.ry).toBeGreaterThanOrEqual(0);
+      expect(oval.cy + oval.ry).toBeLessThanOrEqual(height);
+    }
+    expect(geometry.leftOval.ry).toBeGreaterThan(geometry.rightOval.ry);
+    expect(geometry.rightOval.cx - geometry.rightOval.rx).toBeGreaterThan(
+      geometry.leftOval.cx + geometry.leftOval.rx,
+    );
+  });
+
+  it('draws arrows only for valid integer pairs', () => {
+    const geometry = mappingGeometry(
+      mapping({
+        pairs: [
+          { from: 0, to: 0 },
+          { from: -1, to: 0 },
+          { from: 0, to: -1 },
+          { from: 3, to: 0 },
+          { from: 0, to: 2 },
+          { from: 0.5, to: 1 },
+        ],
+      }),
+      600,
+      240,
+      defaultSlideTheme.bodySize,
+    );
+    expect(geometry.arrows).toHaveLength(1);
+    expect(geometry.arrows[0].from.y).toBe(geometry.leftItems[0].y);
+    expect(geometry.arrows[0].to.y).toBe(geometry.rightItems[0].y);
+  });
+
+  it('handles empty and huge sets without NaN', () => {
+    const empty = mappingGeometry(
+      mapping({ left: [], right: [], pairs: [{ from: 0, to: 0 }] }),
+      600,
+      240,
+      defaultSlideTheme.bodySize,
+    );
+    expect(empty.leftItems).toEqual([]);
+    expect(empty.rightItems).toEqual([]);
+    expect(empty.arrows).toEqual([]);
+
+    const huge = mappingGeometry(
+      mapping({
+        left: Array.from({ length: 500 }, (_, index) => String(index)),
+        right: Array.from({ length: 500 }, (_, index) => String(index)),
+        pairs: [
+          { from: MAX_MAPPING_ITEMS - 1, to: MAX_MAPPING_ITEMS - 1 },
+          { from: MAX_MAPPING_ITEMS, to: MAX_MAPPING_ITEMS },
+        ],
+      }),
+      600,
+      240,
+      defaultSlideTheme.bodySize,
+    );
+    expect(huge.leftItems.length).toBeLessThanOrEqual(MAX_MAPPING_ITEMS);
+    expect(huge.rightItems.length).toBeLessThanOrEqual(MAX_MAPPING_ITEMS);
+    expect(huge.leftItems.length).toBeLessThan(500);
+    expect(huge.arrows).toEqual([]);
+
+    const degenerate = mappingGeometry(mapping(), -600, Number.NaN, Number.NaN);
+    for (const geometry of [empty, huge, degenerate]) {
+      expect(geometryNumbers(geometry).every(Number.isFinite)).toBe(true);
+    }
+  });
+});

--- a/tests/slide-measure.test.ts
+++ b/tests/slide-measure.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { measureBlock } from '$lib/slides/layout';
+import { defaultSlideTheme } from '$lib/slides/theme';
+import type { SlideBlock } from '$lib/types';
+
+describe('measureBlock', () => {
+  it('increases text height when the available width narrows', () => {
+    const block: SlideBlock = {
+      id: 'text',
+      kind: 'text',
+      text: 'A deliberately long explanation of the distributive property and its consequences.',
+    };
+    expect(measureBlock(block, defaultSlideTheme, 120)).toBeGreaterThan(
+      measureBlock(block, defaultSlideTheme, 480),
+    );
+  });
+
+  it('measures declared graph, image, and spacer heights', () => {
+    const graph: SlideBlock = {
+      id: 'graph',
+      kind: 'graph',
+      height: 180,
+      graph: {
+        xRange: [-10, 10],
+        yRange: [-10, 10],
+        gridStep: 1,
+        showAxes: true,
+        showGrid: true,
+        functions: [],
+      },
+    };
+    const image: SlideBlock = {
+      id: 'image',
+      kind: 'image',
+      src: 'data:image/png;base64,AA==',
+      alt: '',
+      height: 90,
+    };
+    const spacer: SlideBlock = { id: 'space', kind: 'spacer', height: 72 };
+    expect(measureBlock(graph, defaultSlideTheme, 300)).toBe(180);
+    expect(measureBlock(image, defaultSlideTheme, 300)).toBe(90);
+    expect(measureBlock(spacer, defaultSlideTheme, 300)).toBe(72);
+  });
+
+  it('measures tables per row and tolerates ragged rows and bad weights', () => {
+    const table: SlideBlock = {
+      id: 'table',
+      kind: 'table',
+      header: ['Expression', 'Value', 'Notes'],
+      rows: [['x + 1'], ['x squared', '4', 'a longer note that wraps']],
+      columnWeights: [1, -1],
+    };
+    const measured = measureBlock(table, defaultSlideTheme, 240);
+    expect(Number.isFinite(measured)).toBe(true);
+    expect(measured).toBeGreaterThan(defaultSlideTheme.bodySize * 3);
+  });
+
+  it('clamps list indentation levels and handles degenerate widths', () => {
+    const list: SlideBlock = {
+      id: 'list',
+      kind: 'list',
+      marker: 'bullet',
+      items: [
+        { text: 'negative level', level: -100 },
+        { text: 'huge level', level: 99 },
+        { text: 'non-finite level', level: Number.NaN },
+      ],
+    };
+    for (const width of [0, -20, Number.NaN]) {
+      const measured = measureBlock(list, defaultSlideTheme, width);
+      expect(Number.isFinite(measured)).toBe(true);
+      expect(measured).toBeGreaterThan(0);
+    }
+  });
+});

--- a/tests/slide-measure.test.ts
+++ b/tests/slide-measure.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { measureBlock } from '$lib/slides/layout';
+import { captionHeight, measureBlock } from '$lib/slides/layout';
 import { defaultSlideTheme } from '$lib/slides/theme';
 import type { SlideBlock } from '$lib/types';
 
@@ -70,6 +70,27 @@ describe('measureBlock', () => {
       const measured = measureBlock(list, defaultSlideTheme, width);
       expect(Number.isFinite(measured)).toBe(true);
       expect(measured).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('captionHeight', () => {
+  it('is zero when there is no caption', () => {
+    expect(captionHeight(undefined, 12, 400)).toBe(0);
+    expect(captionHeight('', 12, 400)).toBe(0);
+  });
+
+  it('grows when a caption wraps to more lines', () => {
+    const short = captionHeight('Short', 12, 400);
+    const long = captionHeight('word '.repeat(80), 12, 400);
+    expect(long).toBeGreaterThan(short);
+  });
+
+  it('never returns a non-finite or negative value', () => {
+    for (const width of [0, -50, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const h = captionHeight('Caption', 12, width);
+      expect(Number.isFinite(h)).toBe(true);
+      expect(h).toBeGreaterThanOrEqual(0);
     }
   });
 });

--- a/tests/slide-numberline.test.ts
+++ b/tests/slide-numberline.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { measureBlock } from '$lib/slides/layout';
+import {
+  MAX_NUMBER_LINE_LABELS,
+  MAX_NUMBER_LINE_TICKS,
+  slideNumberLineGeometry,
+} from '$lib/slides/render/numberLineGeometry';
+import { defaultSlideTheme } from '$lib/slides/theme';
+import type { SlideNumberLineBlock } from '$lib/types';
+
+function numberLine(overrides: Partial<SlideNumberLineBlock> = {}): SlideNumberLineBlock {
+  return {
+    id: 'number-line',
+    kind: 'numberline',
+    min: 0,
+    max: 10,
+    tickStep: 2,
+    labelStep: 5,
+    marks: [
+      { value: 2, kind: 'open' },
+      { value: 4, kind: 'closed' },
+      { value: 6, kind: 'arrow-left' },
+      { value: 8, kind: 'arrow-right' },
+    ],
+    height: 120,
+    ...overrides,
+  };
+}
+
+describe('slide number-line geometry', () => {
+  it('places ticks, labels, and every mark kind with shared value-to-x geometry', () => {
+    const geometry = slideNumberLineGeometry(numberLine(), 600, 120, defaultSlideTheme);
+    expect(geometry.valid).toBe(true);
+    expect(geometry.ticks.map((tick) => tick.value)).toEqual([0, 2, 4, 6, 8, 10]);
+    expect(geometry.labels.map((label) => label.value)).toEqual([0, 5, 10]);
+    expect(geometry.marks.map((mark) => mark.kind)).toEqual([
+      'open',
+      'closed',
+      'arrow-left',
+      'arrow-right',
+    ]);
+    expect(geometry.labels[1].x).toBeCloseTo((geometry.x0 + geometry.x1) / 2);
+    expect(geometry.marks[0].x).toBeCloseTo(geometry.x0 + (geometry.x1 - geometry.x0) * 0.2);
+  });
+
+  it('guards invalid ranges and non-positive steps', () => {
+    for (const block of [numberLine({ min: 5, max: 5 }), numberLine({ min: 10, max: 5 })]) {
+      const geometry = slideNumberLineGeometry(block, 600, 120, defaultSlideTheme);
+      expect(geometry.valid).toBe(false);
+      expect(geometry.ticks).toEqual([]);
+      expect(geometry.labels).toEqual([]);
+      expect(geometry.marks).toEqual([]);
+    }
+    const noSteps = slideNumberLineGeometry(
+      numberLine({ tickStep: 0, labelStep: -1 }),
+      600,
+      120,
+      defaultSlideTheme,
+    );
+    expect(noSteps.valid).toBe(true);
+    expect(noSteps.ticks).toEqual([]);
+    expect(noSteps.labels).toEqual([]);
+  });
+
+  it('caps tiny steps and skips marks outside the range', () => {
+    const geometry = slideNumberLineGeometry(
+      numberLine({
+        tickStep: 0.000001,
+        labelStep: 0.000001,
+        marks: [
+          { value: -1, kind: 'open' },
+          { value: 11, kind: 'closed' },
+          { value: 5, kind: 'closed' },
+        ],
+      }),
+      600,
+      120,
+      defaultSlideTheme,
+    );
+    expect(geometry.ticks.length).toBeLessThanOrEqual(MAX_NUMBER_LINE_TICKS);
+    expect(geometry.labels.length).toBeLessThanOrEqual(MAX_NUMBER_LINE_LABELS);
+    expect(geometry.marks).toHaveLength(1);
+    expect(geometry.marks[0].value).toBe(5);
+  });
+
+  it('uses declared height and produces finite degenerate coordinates', () => {
+    const block = numberLine();
+    expect(measureBlock(block, defaultSlideTheme, 500)).toBe(120);
+    const geometry = slideNumberLineGeometry(block, -1, Number.NaN, {
+      ...defaultSlideTheme,
+      bodySize: Number.NaN,
+    });
+    expect(
+      [
+        geometry.x0,
+        geometry.x1,
+        geometry.y,
+        geometry.arrowSize,
+        ...geometry.ticks.flatMap((tick) => [tick.value, tick.x]),
+      ].every(Number.isFinite),
+    ).toBe(true);
+  });
+});

--- a/tests/slide-page-store.test.ts
+++ b/tests/slide-page-store.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createDocumentStore } from '$lib/store/document';
+import { createSlide } from '$lib/slides/deck';
+import { SLIDE_PAGE_SIZE } from '$lib/slides/pageOps';
+import type { EldrawDocument, Page, Slide } from '$lib/types';
+
+function pdfPage(pageIndex: number): Page {
+  return {
+    pageIndex,
+    type: 'pdf',
+    insertedAfterPdfPage: null,
+    pdfSourceIndex: pageIndex,
+    width: 612,
+    height: 792,
+    objects: [],
+  };
+}
+
+function doc(pages: Page[]): EldrawDocument {
+  return {
+    version: 1,
+    pdfHash: 'hash',
+    pdfPath: null,
+    pages,
+    palettes: [],
+    prefs: {
+      sidebarPinned: false,
+      defaultTool: 'pen',
+      toolDefaults: {
+        pen: { color: '#000000', width: 2, dash: 'solid', opacity: 1 },
+        highlighter: { color: '#ffff00', width: 8, dash: 'solid', opacity: 0.4 },
+        line: { color: '#000000', width: 2, dash: 'solid', opacity: 1 },
+      },
+    },
+  };
+}
+
+describe('slide pages in the document store', () => {
+  let store: ReturnType<typeof createDocumentStore>;
+
+  beforeEach(() => {
+    store = createDocumentStore();
+    store.load(doc([pdfPage(0), pdfPage(1)]));
+  });
+
+  function pages(): Page[] {
+    let current: Page[] = [];
+    store.subscribe((d) => (current = d?.pages ?? []))();
+    return current;
+  }
+
+  it('inserts a slide page after the given index and reindexes', () => {
+    const slide = createSlide('content', 'Heading');
+    store.insertSlidePageAfter(0, slide, SLIDE_PAGE_SIZE.widescreen.width, 540);
+
+    const result = pages();
+    expect(result).toHaveLength(3);
+    expect(result[1].type).toBe('slide');
+    expect(result[1].slide?.title).toBe('Heading');
+    expect(result.map((p) => p.pageIndex)).toEqual([0, 1, 2]);
+  });
+
+  it('gives the inserted slide the requested dimensions', () => {
+    store.insertSlidePageAfter(0, createSlide('title'), 960, 540);
+    expect(pages()[1]).toMatchObject({ width: 960, height: 540 });
+  });
+
+  it('does not alias the caller\u2019s slide object', () => {
+    const slide = createSlide('content', 'Original');
+    store.insertSlidePageAfter(0, slide, 960, 540);
+    slide.title = 'Mutated';
+    expect(pages()[1].slide?.title).toBe('Original');
+  });
+
+  it('replaces slide content with updateSlide', () => {
+    store.insertSlidePageAfter(0, createSlide('content', 'Before'), 960, 540);
+    store.updateSlide(1, createSlide('content', 'After'));
+    expect(pages()[1].slide?.title).toBe('After');
+  });
+
+  it('ignores updateSlide on a page that is not a slide', () => {
+    store.updateSlide(0, createSlide('content', 'Nope'));
+    expect(pages()[0].type).toBe('pdf');
+    expect(pages()[0].slide).toBeUndefined();
+  });
+
+  it('rejects an unusable slide rather than inserting a broken page', () => {
+    store.insertSlidePageAfter(0, null as unknown as Slide, 960, 540);
+    expect(pages()).toHaveLength(2);
+  });
+});
+
+describe('slide sanitization at the load boundary', () => {
+  function loadedPages(slide: unknown): Page[] {
+    const store = createDocumentStore();
+    const page = {
+      pageIndex: 0,
+      type: 'slide',
+      insertedAfterPdfPage: null,
+      width: 960,
+      height: 540,
+      slide,
+      objects: [],
+    } as unknown as Page;
+    store.load(doc([page]));
+    let current: Page[] = [];
+    store.subscribe((d) => (current = d?.pages ?? []))();
+    return current;
+  }
+
+  it('keeps a valid slide', () => {
+    const result = loadedPages(createSlide('content', 'Fine'));
+    expect(result[0].type).toBe('slide');
+    expect(result[0].slide?.title).toBe('Fine');
+  });
+
+  it('degrades an unusable slide to a blank page instead of dropping it', () => {
+    const result = loadedPages('not a slide');
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('blank');
+    expect(result[0].slide).toBeUndefined();
+  });
+
+  it('strips a hostile image source from a loaded slide', () => {
+    const hostile = {
+      layout: 'content',
+      title: 'Hostile',
+      blocks: [
+        { id: 'a', kind: 'image', src: 'javascript:alert(1)', alt: '', height: 100 },
+        { id: 'b', kind: 'text', text: 'safe' },
+      ],
+    };
+    const blocks = loadedPages(hostile)[0].slide?.blocks ?? [];
+    const images = blocks.filter((b) => b.kind === 'image');
+    for (const image of images) {
+      expect(image.kind === 'image' && image.src.startsWith('javascript:')).toBe(false);
+    }
+  });
+
+  it('does not throw on malformed slide input', () => {
+    for (const bad of [null, undefined, 42, [], { layout: 'nope' }, { blocks: 'x' }]) {
+      expect(() => loadedPages(bad)).not.toThrow();
+    }
+  });
+});

--- a/tests/slide-sanitize-caps.test.ts
+++ b/tests/slide-sanitize-caps.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeSlide } from '$lib/slides/deck';
+
+/**
+ * Slide data is loaded from untrusted sidecar JSON and every surviving element
+ * becomes DOM nodes and layout work, so oversized collections must be trimmed
+ * at the trust boundary rather than freezing the app on open.
+ */
+function slideWith(block: unknown) {
+  return sanitizeSlide({ layout: 'content', title: 'T', blocks: [block] });
+}
+
+describe('sanitizeSlide collection caps', () => {
+  it('caps list items', () => {
+    const items = Array.from({ length: 20_000 }, () => ({ text: 'x', level: 0 }));
+    const slide = slideWith({ id: 'a', kind: 'list', marker: 'bullet', items });
+    const block = slide?.blocks[0];
+    expect(block?.kind).toBe('list');
+    expect(block?.kind === 'list' && block.items.length).toBeLessThanOrEqual(500);
+  });
+
+  it('caps definition items', () => {
+    const items = Array.from({ length: 20_000 }, () => ({ term: 't', text: 'd' }));
+    const block = slideWith({ id: 'a', kind: 'definitions', items })?.blocks[0];
+    expect(block?.kind === 'definitions' && block.items.length).toBeLessThanOrEqual(200);
+  });
+
+  it('caps table rows and columns', () => {
+    const rows = Array.from({ length: 5_000 }, () => Array.from({ length: 400 }, () => 'cell'));
+    const header = Array.from({ length: 400 }, () => 'h');
+    const block = slideWith({ id: 'a', kind: 'table', header, rows })?.blocks[0];
+    expect(block?.kind).toBe('table');
+    if (block?.kind !== 'table') return;
+    expect(block.rows.length).toBeLessThanOrEqual(500);
+    expect(block.header.length).toBeLessThanOrEqual(100);
+    for (const row of block.rows) expect(row.length).toBeLessThanOrEqual(100);
+  });
+
+  it('caps graph functions', () => {
+    const functions = Array.from({ length: 2_000 }, (_unused, i) => ({
+      id: `f${i}`,
+      expr: 'x',
+      kind: 'explicit',
+      color: '#000000',
+      width: 2,
+      dash: 'solid',
+      domain: null,
+    }));
+    const block = slideWith({
+      id: 'a',
+      kind: 'graph',
+      height: 200,
+      graph: {
+        xRange: [-10, 10],
+        yRange: [-10, 10],
+        gridStep: 1,
+        showAxes: true,
+        showGrid: true,
+        functions,
+      },
+    })?.blocks[0];
+    expect(block?.kind === 'graph' && block.graph.functions.length).toBeLessThanOrEqual(50);
+  });
+
+  it('caps top-level blocks', () => {
+    const blocks = Array.from({ length: 20_000 }, (_unused, i) => ({
+      id: `b${i}`,
+      kind: 'text',
+      text: 'x',
+    }));
+    const slide = sanitizeSlide({ layout: 'content', title: 'T', blocks });
+    expect(slide?.blocks.length).toBeLessThanOrEqual(200);
+  });
+
+  it('caps asides', () => {
+    const aside = Array.from({ length: 2_000 }, (_unused, i) => ({
+      id: `c${i}`,
+      kind: 'callout',
+      text: 'x',
+      tone: 'tip',
+    }));
+    const slide = sanitizeSlide({ layout: 'content', title: 'T', blocks: [], aside });
+    expect((slide?.aside ?? []).length).toBeLessThanOrEqual(10);
+  });
+
+  it('completes quickly on a hostile document', () => {
+    const start = Date.now();
+    sanitizeSlide({
+      layout: 'content',
+      title: 'T',
+      blocks: Array.from({ length: 5_000 }, (_unused, i) => ({
+        id: `b${i}`,
+        kind: 'list',
+        marker: 'bullet',
+        items: Array.from({ length: 100 }, () => ({ text: 'x', level: 0 })),
+      })),
+    });
+    expect(Date.now() - start).toBeLessThan(5_000);
+  });
+});

--- a/tests/slide-sanitize.test.ts
+++ b/tests/slide-sanitize.test.ts
@@ -178,6 +178,7 @@ describe('sanitizeSlide trust boundary', () => {
         },
       ],
     });
+
     expect(slide?.theme).toBeUndefined();
     expect(slide?.blocks[0]).not.toHaveProperty('fontSize');
     expect(slide?.blocks[0]).not.toHaveProperty('marginTop');
@@ -191,6 +192,53 @@ describe('sanitizeSlide trust boundary', () => {
         functions: [{ width: 2 }],
       },
     });
+  });
+
+  it('bounds mapping elements and drops every invalid pair index', () => {
+    const input = {
+      layout: 'content',
+      blocks: [
+        {
+          id: 'mapping',
+          kind: 'mapping',
+          leftLabel: 'Domain',
+          rightLabel: 'Range',
+          left: Array.from({ length: 100_000 }, (_, index) => index),
+          right: Array.from({ length: 100_000 }, (_, index) => `R${index}`),
+          pairs: [
+            { from: 0, to: 0 },
+            { from: 99, to: 99 },
+            { from: -1, to: 0 },
+            { from: 100, to: 0 },
+            { from: 0, to: 100 },
+            { from: 0.5, to: 0 },
+            { from: 0, to: 1.5 },
+            { from: '0', to: 0 },
+            { from: NaN, to: 0 },
+            { from: 0, to: NaN },
+            { from: Infinity, to: 0 },
+            null,
+          ],
+          height: Infinity,
+        },
+      ],
+    };
+    expect(() => sanitizeSlide(input)).not.toThrow();
+    const slide = sanitizeSlide(input);
+    expect(slide?.blocks[0]).toMatchObject({
+      kind: 'mapping',
+      leftLabel: 'Domain',
+      rightLabel: 'Range',
+      pairs: [
+        { from: 0, to: 0 },
+        { from: 99, to: 99 },
+      ],
+      height: 260,
+    });
+    if (slide?.blocks[0]?.kind !== 'mapping') throw new Error('Expected mapping block');
+    expect(slide.blocks[0].left).toHaveLength(100);
+    expect(slide.blocks[0].right).toHaveLength(100);
+    expect(slide.blocks[0].left.every((value) => typeof value === 'string')).toBe(true);
   });
 
   it('never throws across malformed nested values', () => {

--- a/tests/slide-sanitize.test.ts
+++ b/tests/slide-sanitize.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeSlide } from '$lib/slides/deck';
+
+describe('sanitizeSlide trust boundary', () => {
+  it.each([null, undefined, 42, [], 'slide', true])('rejects non-object input: %j', (input) => {
+    expect(() => sanitizeSlide(input)).not.toThrow();
+    expect(sanitizeSlide(input)).toBeNull();
+  });
+
+  it('coerces layouts, clamps columns and drops unknown block kinds', () => {
+    expect(
+      sanitizeSlide({
+        layout: 'unknown',
+        title: 'Heading',
+        columnCount: -5,
+        blocks: [{ id: 'bad', kind: 'video' }],
+      }),
+    ).toEqual({ layout: 'content', title: 'Heading', columnCount: 1, blocks: [] });
+    expect(sanitizeSlide({ layout: 'grid', columnCount: 999, blocks: [] })?.columnCount).toBe(6);
+  });
+
+  it('generates unique block ids for missing and duplicate ids', () => {
+    const slide = sanitizeSlide({
+      layout: 'content',
+      blocks: [
+        { id: 'same', kind: 'text', text: 'One' },
+        { id: 'same', kind: 'text', text: 'Two' },
+        { kind: 'callout', text: 'Three', tone: 'tip' },
+      ],
+      aside: [{ id: 'same', kind: 'callout', text: 'Four', tone: 'note' }],
+    });
+    const ids = [...(slide?.blocks ?? []), ...(slide?.aside ?? [])].map((block) => block.id);
+    expect(ids.every((id) => typeof id === 'string' && id.length > 0)).toBe(true);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('clamps list levels and normalizes ragged table rows', () => {
+    const slide = sanitizeSlide({
+      layout: 'content',
+      blocks: [
+        {
+          id: 'list',
+          kind: 'list',
+          marker: 'bullet',
+          items: [
+            { text: 'Low', level: -10 },
+            { text: 'High', level: 20 },
+          ],
+        },
+        {
+          id: 'table',
+          kind: 'table',
+          header: ['A'],
+          rows: [['1', '2', '3'], ['4'], 'not-a-row', [5, null]],
+        },
+      ],
+    });
+    expect(slide?.blocks[0]).toMatchObject({
+      items: [
+        { text: 'Low', level: 0 },
+        { text: 'High', level: 3 },
+      ],
+    });
+    expect(slide?.blocks[1]).toMatchObject({
+      header: ['A', '', ''],
+      rows: [
+        ['1', '2', '3'],
+        ['4', '', ''],
+        ['', '', ''],
+      ],
+    });
+  });
+
+  it('drops unsafe colors everywhere they can reach CSS', () => {
+    const slide = sanitizeSlide({
+      layout: 'content',
+      theme: {
+        background: 'red; background:url(x)',
+        accent: '#123456',
+        titleColor: '#abcdef',
+        fontFamily: 'Inter; background:url(x)',
+      },
+      blocks: [
+        {
+          id: 'text',
+          kind: 'text',
+          text: 'Unsafe',
+          color: 'red; background:url(x)',
+        },
+        {
+          id: 'math',
+          kind: 'math',
+          latex: 'x',
+          display: true,
+          color: '#ABCDEF',
+        },
+        {
+          id: 'graph',
+          kind: 'graph',
+          height: 200,
+          graph: {
+            functions: [
+              {
+                id: 'fn',
+                expr: 'x',
+                kind: 'explicit',
+                color: 'red; background:url(x)',
+                width: 2,
+                dash: 'solid',
+                domain: null,
+              },
+            ],
+          },
+        },
+      ],
+    });
+    expect(slide?.theme).toEqual({ accent: '#123456', titleColor: '#abcdef' });
+    expect(slide?.blocks[0]).not.toHaveProperty('color');
+    expect(slide?.blocks[1]).toHaveProperty('color', '#ABCDEF');
+    expect(slide?.blocks[2]).toMatchObject({
+      graph: { functions: [{ color: '#2563eb' }] },
+    });
+  });
+
+  it.each([
+    'javascript:alert(1)',
+    'https://example.com/image.png',
+    'data:text/html,<script>alert(1)</script>',
+  ])('rejects unsafe image source %s', (src) => {
+    const slide = sanitizeSlide({
+      layout: 'content',
+      blocks: [{ id: 'image', kind: 'image', src, alt: '', height: 200 }],
+    });
+    expect(slide?.blocks).toEqual([]);
+  });
+
+  it('accepts supported base64 image data URLs', () => {
+    const slide = sanitizeSlide({
+      layout: 'content',
+      blocks: [
+        {
+          id: 'image',
+          kind: 'image',
+          src: 'data:image/webp;base64,AAAA',
+          alt: 'Description',
+          height: 200,
+        },
+      ],
+    });
+    expect(slide?.blocks).toHaveLength(1);
+  });
+
+  it('replaces NaN and Infinity and clamps finite numeric fields', () => {
+    const slide = sanitizeSlide({
+      layout: 'content',
+      theme: { bodySize: Infinity },
+      blocks: [
+        { id: 'text', kind: 'text', text: 'Text', fontSize: NaN, marginTop: Infinity },
+        { id: 'space', kind: 'spacer', height: Infinity },
+        {
+          id: 'graph',
+          kind: 'graph',
+          height: -10,
+          graph: {
+            xRange: [NaN, Infinity],
+            yRange: [-5, 5],
+            gridStep: Infinity,
+            functions: [
+              {
+                id: 'fn',
+                expr: 'x',
+                color: '#123456',
+                width: Infinity,
+                domain: null,
+              },
+            ],
+          },
+        },
+      ],
+    });
+    expect(slide?.theme).toBeUndefined();
+    expect(slide?.blocks[0]).not.toHaveProperty('fontSize');
+    expect(slide?.blocks[0]).not.toHaveProperty('marginTop');
+    expect(slide?.blocks[1]).toHaveProperty('height', 120);
+    expect(slide?.blocks[2]).toMatchObject({
+      height: 1,
+      graph: {
+        xRange: [-10, 10],
+        yRange: [-5, 5],
+        gridStep: 1,
+        functions: [{ width: 2 }],
+      },
+    });
+  });
+
+  it('never throws across malformed nested values', () => {
+    const hostile: unknown[] = [
+      { blocks: null },
+      { blocks: [null, [], 1, 'x'] },
+      { blocks: [{ kind: 'table', header: null, rows: [null, {}] }] },
+      { blocks: [{ kind: 'graph', graph: { functions: [null, 4, []] } }] },
+      Object.create(null),
+    ];
+    for (const input of hostile) expect(() => sanitizeSlide(input)).not.toThrow();
+  });
+});

--- a/tests/slide-sanitize.test.ts
+++ b/tests/slide-sanitize.test.ts
@@ -241,12 +241,138 @@ describe('sanitizeSlide trust boundary', () => {
     expect(slide.blocks[0].left.every((value) => typeof value === 'string')).toBe(true);
   });
 
+  it('sanitizes diagram nodes, edges, coordinates, ids, and oversized arrays', () => {
+    const input = {
+      layout: 'content',
+      blocks: [
+        {
+          id: 'diagram',
+          kind: 'diagram',
+          nodes: [
+            { id: 'a', text: 1, x: -4, y: 3, w: 0, h: Infinity, shape: 'box' },
+            { id: 'a', text: 'Duplicate', x: 0.4, y: 0.5, shape: 'plain' },
+            { id: 'b', text: 'B', x: NaN, y: Infinity, shape: 'circle' },
+            { id: '', text: 'Generated', x: 0.2, y: 0.3 },
+            ...Array.from({ length: 196 }, (_, index) => ({
+              id: `extra-${index}`,
+              text: 'Extra',
+              x: 0.5,
+              y: 0.5,
+            })),
+          ],
+          edges: [
+            { from: 'a', to: 'a' },
+            { from: 'a', to: 'missing' },
+            { from: 'missing', to: 'b' },
+            null,
+            ...Array.from({ length: 600 }, () => ({ from: 'a', to: 'b' })),
+          ],
+          height: Infinity,
+        },
+      ],
+    };
+    expect(() => sanitizeSlide(input)).not.toThrow();
+    const slide = sanitizeSlide(input);
+    if (slide?.blocks[0]?.kind !== 'diagram') throw new Error('Expected diagram block');
+    const diagram = slide.blocks[0];
+    expect(diagram.nodes).toHaveLength(100);
+    expect(new Set(diagram.nodes.map((node) => node.id)).size).toBe(100);
+    expect(diagram.nodes[0]).toMatchObject({ id: 'a', text: '', x: 0, y: 1, w: 0.01 });
+    expect(diagram.nodes[0]).not.toHaveProperty('h');
+    expect(diagram.nodes[2]).toMatchObject({ id: 'b', x: 0.5, y: 0.5 });
+    expect(diagram.nodes[2]).not.toHaveProperty('shape');
+    expect(diagram.edges).toHaveLength(496);
+    expect(diagram.edges.every((edge) => edge.from === 'a' && edge.to === 'b')).toBe(true);
+    expect(diagram.height).toBe(260);
+  });
+
+  it('repairs number lines and bounds tick and mark counts', () => {
+    const input = {
+      layout: 'content',
+      blocks: [
+        {
+          id: 'numberline',
+          kind: 'numberline',
+          min: 10,
+          max: -10,
+          tickStep: 0,
+          labelStep: NaN,
+          height: Infinity,
+          marks: [
+            { value: -999, kind: 'open' },
+            { value: 999, kind: 'closed' },
+            { value: 0, kind: 'invalid' },
+            { value: NaN, kind: 'open' },
+            ...Array.from({ length: 250 }, () => ({ value: 1, kind: 'arrow-right' })),
+          ],
+        },
+        {
+          id: 'tiny-step',
+          kind: 'numberline',
+          min: 0,
+          max: 1_000_000,
+          tickStep: 1e-12,
+          labelStep: -4,
+          marks: [],
+          height: 100,
+        },
+      ],
+    };
+    expect(() => sanitizeSlide(input)).not.toThrow();
+    const slide = sanitizeSlide(input);
+    if (slide?.blocks[0]?.kind !== 'numberline') throw new Error('Expected number-line block');
+    expect(slide.blocks[0]).toMatchObject({
+      min: -10,
+      max: 10,
+      tickStep: 0.02,
+      labelStep: 5,
+      height: 160,
+    });
+    expect(slide.blocks[0].marks).toHaveLength(198);
+    expect(slide.blocks[0].marks.slice(0, 2)).toEqual([
+      { value: -10, kind: 'open' },
+      { value: 10, kind: 'closed' },
+    ]);
+    if (slide?.blocks[1]?.kind !== 'numberline') throw new Error('Expected number-line block');
+    expect(slide.blocks[1].tickStep).toBe(1_000);
+    expect(slide.blocks[1].labelStep).toBe(1_000);
+  });
+
+  it('restricts list markers and table header orientation', () => {
+    const slide = sanitizeSlide({
+      layout: 'content',
+      blocks: [
+        {
+          id: 'list',
+          kind: 'list',
+          marker: 'invalid',
+          markerByLevel: ['decimal', 'invalid', 'roman', 'alpha', 'none'],
+          items: [],
+        },
+        {
+          id: 'table',
+          kind: 'table',
+          header: ['A'],
+          rows: [['B']],
+          headerOrientation: 'diagonal',
+        },
+      ],
+    });
+    expect(slide?.blocks[0]).toMatchObject({
+      marker: 'bullet',
+      markerByLevel: ['decimal', 'bullet', 'roman', 'alpha'],
+    });
+    expect(slide?.blocks[1]).toMatchObject({ headerOrientation: 'row' });
+  });
+
   it('never throws across malformed nested values', () => {
     const hostile: unknown[] = [
       { blocks: null },
       { blocks: [null, [], 1, 'x'] },
       { blocks: [{ kind: 'table', header: null, rows: [null, {}] }] },
       { blocks: [{ kind: 'graph', graph: { functions: [null, 4, []] } }] },
+      { blocks: [{ kind: 'diagram', nodes: [null, 4, []], edges: [null, {}] }] },
+      { blocks: [{ kind: 'numberline', marks: [null, {}, []] }] },
       Object.create(null),
     ];
     for (const input of hostile) expect(() => sanitizeSlide(input)).not.toThrow();

--- a/tests/slide-table-orientation.test.ts
+++ b/tests/slide-table-orientation.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { render } from 'svelte/server';
+import SlideLayer from '$lib/slides/render/SlideLayer.svelte';
+import { defaultSlideTheme } from '$lib/slides/theme';
+import type { Slide, SlideTableBlock } from '$lib/types';
+
+function renderTable(table: SlideTableBlock): string {
+  const slide: Slide = { layout: 'blank', title: '', blocks: [table] };
+  return render(SlideLayer, {
+    props: { slide, theme: defaultSlideTheme, width: 612, height: 792, ptToPx: 1 },
+  }).body;
+}
+
+function headerCellCount(html: string): number {
+  return html.match(/class="[^"]*\bheader-cell\b[^"]*"/g)?.length ?? 0;
+}
+
+describe('slide table header orientation', () => {
+  it('uses the header array as a top header row by default', () => {
+    const html = renderTable({
+      id: 'row-header',
+      kind: 'table',
+      header: ['Input', 'Output'],
+      rows: [['1'], ['2', '4']],
+    });
+    expect(headerCellCount(html)).toBe(2);
+    expect(html.match(/class="cell\b/g)).toHaveLength(6);
+  });
+
+  it('emphasizes the first cell of each ragged row for column headers', () => {
+    const html = renderTable({
+      id: 'column-header',
+      kind: 'table',
+      header: [],
+      headerOrientation: 'column',
+      rows: [
+        ['Input', '1', '2'],
+        ['Output', '3'],
+      ],
+    });
+    expect(headerCellCount(html)).toBe(2);
+    expect(html.match(/class="cell\b/g)).toHaveLength(6);
+  });
+
+  it('renders an empty row header without emphasizing data cells', () => {
+    const html = renderTable({
+      id: 'empty-header',
+      kind: 'table',
+      header: [],
+      headerOrientation: 'row',
+      rows: [['1', '2']],
+    });
+    expect(headerCellCount(html)).toBe(0);
+    expect(html.match(/class="cell\b/g)).toHaveLength(2);
+  });
+});

--- a/tests/slide-templates.test.ts
+++ b/tests/slide-templates.test.ts
@@ -18,6 +18,11 @@ describe('slide templates', () => {
       'Worked example',
       'Mapping diagram',
       'Relation practice',
+      'Function machine',
+      'Labelled expression',
+      'Number line',
+      'Sub-numbered steps',
+      'Data table',
       'Practice grid',
       'Concept + tip callout',
       'Blank workspace',
@@ -67,6 +72,35 @@ describe('slide templates', () => {
             { text: 'Is it a function?' },
           ],
         },
+      ],
+    });
+  });
+
+  it('builds the extended math-teaching structures', () => {
+    expect(applyTemplate('function-machine')).toMatchObject({
+      blocks: [{ kind: 'diagram', nodes: expect.any(Array), edges: expect.any(Array) }],
+    });
+    expect(applyTemplate('labelled-expression')).toMatchObject({
+      blocks: [{ kind: 'math' }, { kind: 'diagram' }],
+    });
+    expect(applyTemplate('number-line')).toMatchObject({
+      blocks: [{ kind: 'numberline' }, { kind: 'text' }],
+    });
+    expect(applyTemplate('sub-numbered-steps')).toMatchObject({
+      blocks: [
+        {
+          kind: 'list',
+          marker: 'decimal',
+          markerByLevel: ['decimal', 'alpha'],
+        },
+      ],
+    });
+    expect(applyTemplate('data-table')).toMatchObject({
+      blocks: [
+        { kind: 'table', headerOrientation: 'column' },
+        { kind: 'text' },
+        { kind: 'text' },
+        { kind: 'spacer' },
       ],
     });
   });

--- a/tests/slide-templates.test.ts
+++ b/tests/slide-templates.test.ts
@@ -16,6 +16,8 @@ describe('slide templates', () => {
       'Equation + graph',
       'Graph trio',
       'Worked example',
+      'Mapping diagram',
+      'Relation practice',
       'Practice grid',
       'Concept + tip callout',
       'Blank workspace',
@@ -44,5 +46,28 @@ describe('slide templates', () => {
   it('applies known templates and rejects unknown ids', () => {
     expect(applyTemplate('worked-example')?.title).toBe('Worked example');
     expect(applyTemplate('missing')).toBeNull();
+  });
+
+  it('builds the mapping templates with their intended teaching structures', () => {
+    expect(applyTemplate('mapping-diagram')).toMatchObject({
+      layout: 'content',
+      blocks: [{ kind: 'mapping' }, { kind: 'text' }],
+    });
+    expect(applyTemplate('relation-practice')).toMatchObject({
+      layout: 'columns',
+      columnCount: 2,
+      blocks: [
+        { kind: 'mapping' },
+        {
+          kind: 'list',
+          marker: 'decimal',
+          items: [
+            { text: 'Find the domain.' },
+            { text: 'Find the range.' },
+            { text: 'Is it a function?' },
+          ],
+        },
+      ],
+    });
   });
 });

--- a/tests/slide-templates.test.ts
+++ b/tests/slide-templates.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeSlide } from '$lib/slides/deck';
+import { applyTemplate, slideTemplates } from '$lib/slides/templates';
+
+describe('slide templates', () => {
+  it('ships the complete teaching template set', () => {
+    expect(slideTemplates.map((template) => template.name)).toEqual([
+      'Title slide',
+      'Agenda / topics',
+      'Section divider',
+      'Definitions',
+      'Bulleted concept',
+      'Numbered steps',
+      'Table',
+      'Two tables',
+      'Equation + graph',
+      'Graph trio',
+      'Worked example',
+      'Practice grid',
+      'Concept + tip callout',
+      'Blank workspace',
+    ]);
+  });
+
+  it.each(slideTemplates)('$name builds unique ids and round-trips cleanly', (template) => {
+    const slide = template.build();
+    const ids = [...slide.blocks, ...(slide.aside ?? [])].map((block) => block.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(sanitizeSlide(slide)).toEqual(slide);
+  });
+
+  it('builds fresh slide data on each invocation', () => {
+    for (const template of slideTemplates) {
+      const first = template.build();
+      const second = template.build();
+      expect(second).not.toBe(first);
+      expect(second.blocks).not.toBe(first.blocks);
+      for (let index = 0; index < first.blocks.length; index += 1) {
+        expect(second.blocks[index]).not.toBe(first.blocks[index]);
+      }
+    }
+  });
+
+  it('applies known templates and rejects unknown ids', () => {
+    expect(applyTemplate('worked-example')?.title).toBe('Worked example');
+    expect(applyTemplate('missing')).toBeNull();
+  });
+});

--- a/tests/slide-theme.test.ts
+++ b/tests/slide-theme.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { defaultSlideTheme, isSafeSlideTheme, resolveTheme } from '$lib/slides/theme';
+import type { SlideTheme } from '$lib/types';
+
+describe('slide theme validation', () => {
+  it('accepts the default theme', () => {
+    expect(isSafeSlideTheme(defaultSlideTheme)).toBe(true);
+  });
+
+  it.each([
+    { background: 'red; background: url(x)' },
+    { accent: 'javascript:' },
+    { textColor: '#xyz' },
+    { fontFamily: '<script>' },
+    { fontFamily: 'system-ui; color: red' },
+    { fontFamily: 'url(evil)' },
+    { fontFamily: 42 },
+  ])('rejects unsafe theme data %#', (patch) => {
+    expect(isSafeSlideTheme({ ...defaultSlideTheme, ...patch })).toBe(false);
+  });
+
+  it('rejects missing, extra, and non-object values', () => {
+    const missing: Partial<SlideTheme> = { ...defaultSlideTheme };
+    delete missing.bodySize;
+    expect(isSafeSlideTheme(missing)).toBe(false);
+    expect(isSafeSlideTheme({ ...defaultSlideTheme, extra: true })).toBe(false);
+    expect(isSafeSlideTheme(null)).toBe(false);
+    expect(isSafeSlideTheme('theme')).toBe(false);
+  });
+
+  it('falls back field-by-field instead of throwing', () => {
+    const resolved = resolveTheme(
+      {
+        ...defaultSlideTheme,
+        accent: 'javascript:',
+        fontFamily: '<script>',
+        bodySize: Number.NaN,
+      },
+      {
+        background: 'red; background: url(x)',
+        titleColor: '#xyz',
+        headingSize: -4,
+      } as Partial<typeof defaultSlideTheme>,
+    );
+    expect(resolved.accent).toBe(defaultSlideTheme.accent);
+    expect(resolved.fontFamily).toBe(defaultSlideTheme.fontFamily);
+    expect(resolved.bodySize).toBe(defaultSlideTheme.bodySize);
+    expect(resolved.background).toBe(defaultSlideTheme.background);
+    expect(resolved.titleColor).toBe(defaultSlideTheme.titleColor);
+    expect(resolved.headingSize).toBe(defaultSlideTheme.headingSize);
+  });
+
+  it('merges valid overrides over a valid base', () => {
+    const resolved = resolveTheme(
+      { ...defaultSlideTheme, accent: '#112233' },
+      { bodySize: 15, background: '#fefefe' },
+    );
+    expect(resolved.accent).toBe('#112233');
+    expect(resolved.bodySize).toBe(15);
+    expect(resolved.background).toBe('#fefefe');
+  });
+});

--- a/tests/temp-ink.test.ts
+++ b/tests/temp-ink.test.ts
@@ -56,6 +56,16 @@ describe('temp-ink fade', () => {
     expect(kept[1]).toBe(c);
   });
 
+  it('pruneStrokes drops expired strokes after a live stroke', () => {
+    const olderLive = createTempStroke([pt(0, 0, 0)], STYLE, 2000, 0);
+    const newerExpired = createTempStroke([pt(1, 1, 0)], STYLE, 500, 400);
+    const newestLive = createTempStroke([pt(2, 2, 0)], STYLE, 1000, 800);
+
+    const kept = pruneStrokes([olderLive, newerExpired, newestLive], 1000);
+
+    expect(kept).toEqual([olderLive, newestLive]);
+  });
+
   it('pruneStrokes returns the same array when nothing expired', () => {
     const a = createTempStroke([pt(0, 0, 0)], STYLE, 1000, 100);
     const arr = [a];

--- a/tests/text-autodetect.test.ts
+++ b/tests/text-autodetect.test.ts
@@ -32,6 +32,19 @@ describe('detectMathSegments', () => {
     ]);
   });
 
+  it('splits a valid expression from prose that follows it', () => {
+    expect(detectMathSegments('The line y = mx + b has slope m.')).toEqual([
+      { kind: 'text', value: 'The line ' },
+      { kind: 'math', value: 'y = mx + b', display: false },
+      { kind: 'text', value: ' has slope m.' },
+    ]);
+  });
+
+  it('does not promote either side of a prose-word boundary without complete operands', () => {
+    const source = 'the answer = whatever you want';
+    expect(detectMathSegments(source)).toEqual([{ kind: 'text', value: source }]);
+  });
+
   it.each([
     'Domain & Range',
     'The # of days in a month',
@@ -42,6 +55,7 @@ describe('detectMathSegments', () => {
     'It costs $5 today',
     'This is a pre-algebra lesson',
     '50% off',
+    'ID = AB',
   ])('leaves prose unchanged: %s', (source) => {
     expect(detectMathSegments(source)).toEqual([{ kind: 'text', value: source }]);
     expect(looksLikeMath(source)).toBe(false);
@@ -53,6 +67,18 @@ describe('detectMathSegments', () => {
       { kind: 'math', value: 'x = 4', display: false },
       { kind: 'text', value: ', then check.' },
     ]);
+  });
+
+  it('trims a dangling operand after a sentence comma', () => {
+    expect(detectMathSegments('Since x^2 = 16, x is 4 or -4.')).toEqual([
+      { kind: 'text', value: 'Since ' },
+      { kind: 'math', value: 'x^2 = 16', display: false },
+      { kind: 'text', value: ', x is 4 or -4.' },
+    ]);
+  });
+
+  it('keeps commas that are nested inside math brackets', () => {
+    expect(mathValues('Use f(x, y) = 2 and S = {1, 2}.')).toEqual(['f(x, y) = 2', 'S = {1, 2}']);
   });
 
   it('rejects incomplete bracketed expressions', () => {

--- a/tests/text-autodetect.test.ts
+++ b/tests/text-autodetect.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { autoSegment, detectMathSegments, looksLikeMath } from '$lib/text/autodetect';
+
+function mathValues(source: string): string[] {
+  return detectMathSegments(source)
+    .filter((segment) => segment.kind === 'math')
+    .map((segment) => segment.value);
+}
+
+describe('detectMathSegments', () => {
+  it.each([
+    ['y = 3x - 1', 'y = 3x - 1'],
+    ['f(x) = 3x + 5', 'f(x) = 3x + 5'],
+    ['x^2 + y^2 = r^2', 'x^2 + y^2 = r^2'],
+    ['-3z = 15', '-3z = 15'],
+    ['x + 7 = 18', 'x + 7 = 18'],
+    ['2x - 5y = 10', '2x - 5y = 10'],
+    ['x <= 11', 'x <= 11'],
+    ['\\frac{1}{2}', '\\frac{1}{2}'],
+    ['y = -1/2 x + 4', 'y = -1/2 x + 4'],
+    ['a_{ij} = 2', 'a_{ij} = 2'],
+  ])('detects %s', (source, expected) => {
+    expect(mathValues(source)).toEqual([expected]);
+    expect(looksLikeMath(source)).toBe(true);
+  });
+
+  it('extracts math from surrounding prose', () => {
+    expect(detectMathSegments('The slope of y = 3x - 1 is 3.')).toEqual([
+      { kind: 'text', value: 'The slope of ' },
+      { kind: 'math', value: 'y = 3x - 1', display: false },
+      { kind: 'text', value: ' is 3.' },
+    ]);
+  });
+
+  it.each([
+    'Domain & Range',
+    'The # of days in a month',
+    'Check your answer',
+    'well - known',
+    'Apply to both sides',
+    'Simplify to find the solution',
+    'It costs $5 today',
+    'This is a pre-algebra lesson',
+    '50% off',
+  ])('leaves prose unchanged: %s', (source) => {
+    expect(detectMathSegments(source)).toEqual([{ kind: 'text', value: source }]);
+    expect(looksLikeMath(source)).toBe(false);
+  });
+
+  it('keeps trailing punctuation outside detected math', () => {
+    expect(detectMathSegments('Solve x = 4, then check.')).toEqual([
+      { kind: 'text', value: 'Solve ' },
+      { kind: 'math', value: 'x = 4', display: false },
+      { kind: 'text', value: ', then check.' },
+    ]);
+  });
+
+  it('rejects incomplete bracketed expressions', () => {
+    expect(detectMathSegments('Use \\frac{1 here')).toEqual([
+      { kind: 'text', value: 'Use \\frac{1 here' },
+    ]);
+  });
+});
+
+describe('autoSegment', () => {
+  it('does not auto-detect inside explicit delimiters', () => {
+    expect(autoSegment('The line $y = mx + b$ has slope m = 3.')).toEqual([
+      { kind: 'text', value: 'The line ' },
+      { kind: 'math', value: 'y = mx + b', display: false },
+      { kind: 'text', value: ' has slope ' },
+      { kind: 'math', value: 'm = 3', display: false },
+      { kind: 'text', value: '.' },
+    ]);
+  });
+
+  it('preserves explicit display mode', () => {
+    expect(autoSegment('Use \\[x = 2\\] now')).toContainEqual({
+      kind: 'math',
+      value: 'x = 2',
+      display: true,
+    });
+  });
+});

--- a/tests/text-normalize-adjacency.test.ts
+++ b/tests/text-normalize-adjacency.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeMathSource } from '$lib/text/normalize';
+import { renderMixed } from '$lib/text/render';
+
+/**
+ * A LaTeX control sequence absorbs every letter that follows it, so a
+ * shorthand replacement sitting directly against a variable used to produce an
+ * undefined command such as `\ley`.
+ */
+describe('operator shorthand against an adjacent letter', () => {
+  const cases: [string, string][] = [
+    ['x<=y', '\\le'],
+    ['x>=y', '\\ge'],
+    ['x!=y', '\\ne'],
+    ['x->y', '\\to'],
+    ['a*b', '\\cdot'],
+    ['x+-y', '\\pm'],
+  ];
+
+  it.each(cases)('%s emits a terminated command', (input, command) => {
+    const normalized = normalizeMathSource(input);
+    expect(normalized).toContain(`${command} `);
+    expect(normalized).not.toMatch(new RegExp(`\\${command}[a-z]`));
+  });
+
+  it.each(cases)('%s renders without a KaTeX error', (input) => {
+    expect(renderMixed(input, 'auto').errored).toBe(false);
+  });
+
+  it('does not add a separator when one is not needed', () => {
+    expect(normalizeMathSource('x <= 5')).toContain('\\le');
+    expect(normalizeMathSource('x <= 5')).not.toContain('\\le  ');
+  });
+
+  it('stays idempotent', () => {
+    for (const [input] of cases) {
+      const once = normalizeMathSource(input);
+      expect(normalizeMathSource(once)).toBe(once);
+    }
+  });
+});
+
+describe('multi-character script wrapping', () => {
+  it('wraps a multi-digit exponent', () => {
+    expect(normalizeMathSource('x^10')).toBe('x^{10}');
+  });
+
+  it('wraps a multi-letter subscript', () => {
+    expect(normalizeMathSource('a_ij')).toBe('a_{ij}');
+  });
+
+  it('leaves a digit followed by a variable alone so the meaning is preserved', () => {
+    // TeX reads `x^2y` as x² times y. Wrapping it would silently mean x^(2y).
+    expect(normalizeMathSource('x^2y')).toBe('x^2y');
+    expect(normalizeMathSource('e^2x')).toBe('e^2x');
+    expect(normalizeMathSource('a^2b + c')).toBe('a^2b + c');
+  });
+
+  it('leaves a single-character script alone', () => {
+    expect(normalizeMathSource('x^2')).toBe('x^2');
+    expect(normalizeMathSource('a_i')).toBe('a_i');
+  });
+
+  it('does not re-wrap an already braced script', () => {
+    expect(normalizeMathSource('x^{10}')).toBe('x^{10}');
+  });
+});

--- a/tests/text-normalize.test.ts
+++ b/tests/text-normalize.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeMathSource } from '$lib/text/normalize';
+
+describe('normalizeMathSource', () => {
+  it('normalizes common teacher shorthand', () => {
+    expect(normalizeMathSource('x <= 4, y >= 2, x != y, a +- b')).toBe(
+      'x \\le 4, y \\ge 2, x \\ne y, a \\pm b',
+    );
+    expect(normalizeMathSource('x * y -> oo ...')).toBe('x \\cdot y \\to \\infty \\dots');
+  });
+
+  it('normalizes functions, roots, and Greek tokens', () => {
+    expect(normalizeMathSource('sin(x) + cos theta + sqrt(x^2 + pi)')).toBe(
+      '\\sin(x) + \\cos \\theta + \\sqrt{x^2 + \\pi}',
+    );
+    expect(normalizeMathSource('sqrt x')).toBe('\\sqrt x');
+    expect(normalizeMathSource('abs(x)')).toBe('\\operatorname{abs}(x)');
+  });
+
+  it('handles balanced nested square roots', () => {
+    expect(normalizeMathSource('sqrt(1 + sqrt(x))')).toBe('\\sqrt{1 + \\sqrt{x}}');
+  });
+
+  it('wraps multi-character superscripts and subscripts', () => {
+    expect(normalizeMathSource('x^10 + a_ij + y^2')).toBe('x^{10} + a_{ij} + y^2');
+  });
+
+  it('escapes special characters without double escaping', () => {
+    expect(normalizeMathSource('50% + #1 & x \\% \\# \\&')).toBe('50\\% + \\#1 \\& x \\% \\# \\&');
+  });
+
+  it('only replaces whole word constants and Greek names', () => {
+    expect(normalizeMathSource('pilot + spin + infty + pi')).toBe('pilot + spin + \\infty + \\pi');
+  });
+
+  it.each([
+    'x <= 10',
+    'sin(x) + sqrt(pi)',
+    'x^10 + a_ij',
+    '50% & #1',
+    '\\sin(x) + \\sqrt{x} + \\pi',
+  ])('is idempotent for %s', (source) => {
+    const once = normalizeMathSource(source);
+    expect(normalizeMathSource(once)).toBe(once);
+  });
+});

--- a/tests/text-render-mixed.test.ts
+++ b/tests/text-render-mixed.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+import { renderMixed } from '$lib/text/render';
+
+const render = vi.fn((input: string, opts: { displayMode?: boolean }) => {
+  if (input.includes('BROKEN')) throw new Error('broken math');
+  return `<katex data-display="${String(opts.displayMode)}">${input}</katex>`;
+});
+
+describe('renderMixed', () => {
+  it('does not call KaTeX in plain mode', () => {
+    render.mockClear();
+    expect(renderMixed('x = 2', 'plain', render)).toEqual({
+      runs: [{ kind: 'text', value: 'x = 2' }],
+      errored: false,
+    });
+    expect(render).not.toHaveBeenCalled();
+  });
+
+  it('renders the whole string in latex mode', () => {
+    const result = renderMixed('x^2', 'latex', render);
+    expect(result.runs).toHaveLength(1);
+    expect(result.runs[0]).toMatchObject({ kind: 'math', source: 'x^2', errored: false });
+  });
+
+  it('renders only explicitly delimited runs in mixed mode', () => {
+    const result = renderMixed('The line $y = mx + b$ has slope $m$.', 'mixed', render);
+    expect(result.runs.map((run) => run.kind)).toEqual(['text', 'math', 'text', 'math', 'text']);
+    expect(result.runs[1]).toMatchObject({ source: 'y = mx + b', display: false });
+  });
+
+  it('preserves display math from bracket delimiters', () => {
+    const result = renderMixed('Before \\[x = 2\\] after', 'mixed', render);
+    expect(result.runs[1]).toMatchObject({ kind: 'math', source: 'x = 2', display: true });
+  });
+
+  it('normalizes auto-detected math but not explicit LaTeX', () => {
+    render.mockClear();
+    renderMixed('Bare x <= 2 and $x <= 3$.', 'auto', render);
+    expect(render.mock.calls.map(([input]) => input)).toEqual(['x \\le 2', 'x <= 3']);
+  });
+
+  it('keeps escaped dollars literal', () => {
+    expect(renderMixed('It costs \\$5 today', 'auto', render).runs).toEqual([
+      { kind: 'text', value: 'It costs $5 today' },
+    ]);
+  });
+
+  it('does not truncate percent prose', () => {
+    expect(renderMixed('Get 50% off today', 'auto', render).runs).toEqual([
+      { kind: 'text', value: 'Get 50% off today' },
+    ]);
+  });
+
+  it('isolates failures and HTML-escapes fallback math', () => {
+    const result = renderMixed(
+      'Good $x = 2$ bad $BROKEN <script>alert(1)</script>$ end',
+      'mixed',
+      render,
+    );
+    expect(result.errored).toBe(true);
+    expect(result.runs).toHaveLength(5);
+    const failed = result.runs[3];
+    expect(failed).toMatchObject({ kind: 'math', errored: true });
+    if (failed.kind === 'math') {
+      expect(failed.html).toContain('&lt;script&gt;');
+      expect(failed.html).not.toContain('<script>');
+    }
+    expect(result.runs[1]).toMatchObject({ kind: 'math', errored: false });
+  });
+});

--- a/tests/text-segment.test.ts
+++ b/tests/text-segment.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { hasExplicitMath, segmentLatex } from '$lib/text/segment';
+
+describe('segmentLatex', () => {
+  it('segments inline dollar math without consuming sentence punctuation', () => {
+    expect(segmentLatex('The line $y = mx + b$ has slope $m$.')).toEqual([
+      { kind: 'text', value: 'The line ' },
+      { kind: 'math', value: 'y = mx + b', display: false },
+      { kind: 'text', value: ' has slope ' },
+      { kind: 'math', value: 'm', display: false },
+      { kind: 'text', value: '.' },
+    ]);
+  });
+
+  it('segments bracketed display math', () => {
+    expect(segmentLatex('Before \\[x^2 + y^2 = r^2\\] after')).toEqual([
+      { kind: 'text', value: 'Before ' },
+      { kind: 'math', value: 'x^2 + y^2 = r^2', display: true },
+      { kind: 'text', value: ' after' },
+    ]);
+  });
+
+  it('keeps unmatched dollars literal and unescapes escaped dollars', () => {
+    expect(segmentLatex('It costs $5 today and \\$6 tomorrow')).toEqual([
+      { kind: 'text', value: 'It costs $5 today and $6 tomorrow' },
+    ]);
+  });
+
+  it('reports only complete explicit math runs', () => {
+    expect(hasExplicitMath('price $5')).toBe(false);
+    expect(hasExplicitMath('value \\(x + 1\\)')).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Adds LaTeX support with automatic math detection, a native slide authoring system, PDF flatten export, and fixes eight confirmed bugs.

### LaTeX with auto-detection
Text objects gain four modes (`plain` / `latex` / `mixed` / `auto`), with `auto` the default for new text. Typing `The slope of y = 3x - 1 is 3` now typesets only the math, with no delimiters required. Explicit `$…$`, `\(…\)`, and `\[…\]` runs are honored and passed through untouched; heuristically detected bare math is normalized first (`<=` → `\le`, `sqrt(x)` → `\sqrt{x}`, and LaTeX-special characters escaped).

The detector is precision-first: a candidate run is accepted only if it carries a strong signal (a relation, a super/subscript with operands, a control sequence, a function call, or implicit multiplication), and runs containing consecutive prose words are split and re-evaluated rather than accepted wholesale. Benchmarked at **0 false positives across 22 prose strings and 0 misses across 14 math strings**.

### Slides
A third page kind, `slide`, sitting alongside `pdf` and `blank`. Teachers author a deck ahead of a lesson and ink on top of it live, so layouts deliberately reserve whitespace for handwriting.

- **12 block kinds**: text, list, definitions, table, math, graph, callout, image, mapping, diagram, numberline, spacer
- **5 layouts**: title, content, columns, grid, blank
- **21 templates**, all generic placeholder scaffolds
- Layout engine is pure and unit tested; rendering is DOM/SVG so KaTeX and real text layout work; graphs reuse the existing plotting stack rather than duplicating it
- Slide editor, template picker, deck outline, thumbnails, and command-palette entries

Notable block kinds driven by what math lessons actually need: `mapping` (domain/range ovals joined by arrows), `diagram` (function machines and leader-line labels), `numberline` as slide content, per-depth list markers for sub-numbered steps (`1.` → `a.`), and tables whose header runs down the first column.

### PDF flatten export
`export_flattened_pdf` was a stub returning `NotImplemented`. It now rasterizes via pdfium at 144 DPI and composites annotations, covering strokes, highlighters, lines with arrowheads, shapes, number lines, graphs, text, angle marks, and blank/slide pages. Writes are atomic, and untrusted paths and page indices are validated rather than unwrapped.

## Bug fixes

| Severity | Fix |
|---|---|
| major | z-order reorder pushed N+1 undo entries, so a single undo made objects disappear one at a time |
| major | undoing a single-object delete appended it to the end, losing its z-position |
| major | the graph parser rejected `x^-2`, `2^-x`, `e^-x` (precedence and right-associativity preserved) |
| major | page navigation after duplicate/delete predicted the page total from a stale count, off by one in both directions |
| minor | space-hold pan latched on when the window lost focus |
| minor | imported config accepted any string as a color and interpolated it into `style` attributes, allowing CSS injection |
| minor | temp-ink strokes were never pruned once fade time changed between strokes |
| minor | TOCTOU race let two instances reclaim the same stale lock |

## Security

Slide content and imported config are untrusted input that reaches the DOM through `{@html}` and inline styles, so both are sanitized at their trust boundary. Slides are validated on load; one that fails degrades to a blank page rather than being dropped, preserving any annotations on it. Diagram edges referencing unknown nodes, out-of-range mapping indices, non-`data:` image sources, and non-hex colors are all rejected. Config colors now use the existing strict `#rrggbb` boundary.

## Testing

- **912 frontend tests** across 95 files (up from 708), **78 Rust tests**
- `pnpm lint` (prettier + eslint + svelte-check) and `cargo fmt --check` / `clippy -D warnings` clean
- Every bug fix landed with a regression test written first
- Verified in a real browser: all 21 templates render with zero sanitize failures and zero layout overflow
- Verified the desktop shell launches and the webview initializes

## Notes for review

- Built across five git worktrees, then integrated; `src/lib/types.ts` was landed first as the shared contract
- One seam is worth a look: `slides/render/inlineMath.ts` originally probed for a property `renderMixed` never returned, so slide titles silently lost auto-detection. Fixed and covered by tests.
- Not exercised: PDF loading and multi-window IPC in the packaged app, which need a real document and a second monitor
