### PR TITLE
fix(pdf): make the documented pdfium setup work for dev builds and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,12 @@ jobs:
           workspaces: src-tauri
           shared-key: tauri-release
           cache-on-failure: true
+      # Without this the pdfium-backed rasterization tests skip themselves and
+      # report success, so PDF rendering would never actually be exercised.
+      - name: Fetch pdfium
+        run: ./scripts/fetch-pdfium.sh linux
       - run: cargo fmt --manifest-path src-tauri/Cargo.toml --check
       - run: cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
       - run: cargo test --manifest-path src-tauri/Cargo.toml
+        env:
+          ELDRAW_REQUIRE_PDFIUM: '1'

--- a/src-tauri/src/export.rs
+++ b/src-tauri/src/export.rs
@@ -2611,6 +2611,14 @@ mod tests {
             .join("pdfium")
             .join(library_name);
         if !library.exists() {
+            // Skipping silently once let this test report success in CI while
+            // pdfium rendering was never exercised at all. CI sets this so a
+            // missing binary is a failure rather than a quiet pass.
+            assert!(
+                std::env::var_os("ELDRAW_REQUIRE_PDFIUM").is_none(),
+                "ELDRAW_REQUIRE_PDFIUM is set but {} is missing; run scripts/fetch-pdfium.sh",
+                library.display()
+            );
             eprintln!("pdfium binary is not installed; source raster smoke test skipped");
             return;
         }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -51,9 +51,11 @@ impl AppState {
 /// Returns a process-wide Pdfium handle. The native binary is resolved by
 /// trying, in order:
 ///   1. `<resource_dir>/pdfium/` — bundled library shipped with the installer.
-///   2. The directory containing the current executable — useful for portable
-///      layouts and local `cargo run` with a sibling binary.
-///   3. The system loader — last-resort for developers who have pdfium
+///   2. The directory containing the current executable, and a `pdfium/`
+///      folder beside it — portable layouts and local `cargo run`.
+///   3. `<crate>/pdfium/` in debug builds — where `scripts/fetch-pdfium.sh`
+///      installs, so a dev build works straight after the documented setup.
+///   4. The system loader — last-resort for developers who have pdfium
 ///      installed system-wide.
 ///
 /// Initialization happens once per process; subsequent calls reuse the handle
@@ -75,6 +77,20 @@ pub fn pdfium(app: &AppHandle) -> AppResult<&'static Pdfium> {
             .and_then(|p| p.parent().map(PathBuf::from))
         {
             if let Some(pdfium) = try_bind(&exe_dir, &mut attempts) {
+                return Ok(pdfium);
+            }
+            let sibling = exe_dir.join("pdfium");
+            if let Some(pdfium) = try_bind(&sibling, &mut attempts) {
+                return Ok(pdfium);
+            }
+        }
+
+        // `scripts/fetch-pdfium.sh` installs into the source tree, which is not
+        // next to the binary a dev build produces. Without this, the documented
+        // fetch-then-`tauri dev` flow fails to find the library it just placed.
+        if cfg!(debug_assertions) {
+            let source_tree = Path::new(env!("CARGO_MANIFEST_DIR")).join("pdfium");
+            if let Some(pdfium) = try_bind(&source_tree, &mut attempts) {
                 return Ok(pdfium);
             }
         }


### PR DESCRIPTION
## What

`pnpm tauri dev` fails on a fresh clone with `failed to load pdfium binary`, even after running the documented setup.

`scripts/fetch-pdfium.sh` installs the library into `src-tauri/pdfium/`, but `state.rs` resolved it only from the Tauri resource dir, next to the executable, or system-wide. A dev build puts the executable in `src-tauri/target/debug/`, so the library that was just fetched is never found. CONTRIBUTING documents `fetch-pdfium.sh` then `pnpm tauri dev` as the setup path, so the documented flow was broken.

## Why it went unnoticed

`source_page_rasterizes_when_pdfium_binary_is_present` returns early and reports **ok** when the library is missing, and CI never fetched it. pdfium rasterization has therefore never actually run in CI — the test has been passing vacuously.

## Changes

- Debug builds also resolve pdfium from the crate's `pdfium/` directory, and a `pdfium/` folder beside the executable is checked too. Release/bundled resolution is unchanged.
- CI fetches pdfium before the Rust job, so the rasterization test does real work.
- CI sets `ELDRAW_REQUIRE_PDFIUM=1`, which turns the silent skip into a hard failure. Local runs without the variable still skip, so contributors who haven't fetched aren't blocked.

## Testing

Verified the guard in both directions rather than assuming:
- library present + `ELDRAW_REQUIRE_PDFIUM=1` → test runs and passes
- library removed + `ELDRAW_REQUIRE_PDFIUM=1` → **fails** with a message naming the path and the script to run
- library removed, no variable → skips, as before

End-to-end: with `src-tauri/target/debug/pdfium/` and `target/debug/libpdfium.so` both deleted, the app now starts and binds pdfium from the source tree with no error.

84 Rust tests pass with `ELDRAW_REQUIRE_PDFIUM=1`; `cargo fmt --check` and `clippy -D warnings` clean.