### PR TITLE
perf(canvas): cache stroke renders, incremental layer draws, and KaTeX caching

### DIFF
--- a/src/lib/canvas/HighlightLayer.svelte
+++ b/src/lib/canvas/HighlightLayer.svelte
@@ -13,31 +13,69 @@
   let { strokes, width, height, ptToPx }: Props = $props();
 
   let canvas: HTMLCanvasElement;
+  let prevStrokes: StrokeObject[] = [];
+  let prevWidth = 0;
+  let prevHeight = 0;
+  let prevPtToPx = 0;
 
-  function redraw() {
+  function drawHighlightStroke(ctx: CanvasRenderingContext2D, s: StrokeObject) {
+    if (s.tool !== 'highlighter') return;
+    const faded: StrokeObject = {
+      ...s,
+      style: { ...s.style, opacity: Math.min(s.style.opacity, 0.3) },
+    };
+    drawStroke(ctx, faded, { ptToPx });
+  }
+
+  function fullRedraw() {
     if (!canvas) return;
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     ctx.globalCompositeOperation = 'multiply';
-    for (const s of strokes) {
-      if (s.tool !== 'highlighter') continue;
-      const faded: StrokeObject = {
-        ...s,
-        style: { ...s.style, opacity: Math.min(s.style.opacity, 0.3) },
-      };
-      drawStroke(ctx, faded, { ptToPx });
-    }
+    for (const s of strokes) drawHighlightStroke(ctx, s);
+    prevStrokes = strokes;
+    prevWidth = width;
+    prevHeight = height;
+    prevPtToPx = ptToPx;
   }
 
-  onMount(redraw);
+  function incrementalDraw() {
+    if (!canvas) return;
+    if (width !== prevWidth || height !== prevHeight || ptToPx !== prevPtToPx) {
+      fullRedraw();
+      return;
+    }
+    if (strokes === prevStrokes) return;
+    if (isAppendOnly(prevStrokes, strokes)) {
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
+      ctx.globalCompositeOperation = 'multiply';
+      for (let i = prevStrokes.length; i < strokes.length; i++) {
+        drawHighlightStroke(ctx, strokes[i]);
+      }
+      prevStrokes = strokes;
+      return;
+    }
+    fullRedraw();
+  }
+
+  function isAppendOnly(prev: StrokeObject[], next: StrokeObject[]): boolean {
+    if (next.length < prev.length) return false;
+    for (let i = 0; i < prev.length; i++) {
+      if (prev[i] !== next[i]) return false;
+    }
+    return true;
+  }
+
+  onMount(fullRedraw);
 
   $effect(() => {
     void strokes;
     void width;
     void height;
     void ptToPx;
-    redraw();
+    incrementalDraw();
   });
 </script>
 

--- a/src/lib/canvas/HighlightLayer.svelte
+++ b/src/lib/canvas/HighlightLayer.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { isAppendOnly } from '$lib/canvas/layerDiff';
   import { onMount } from 'svelte';
   import type { StrokeObject } from '$lib/types';
   import { drawStroke } from './strokeRenderer';
@@ -58,14 +59,6 @@
       return;
     }
     fullRedraw();
-  }
-
-  function isAppendOnly(prev: StrokeObject[], next: StrokeObject[]): boolean {
-    if (next.length < prev.length) return false;
-    for (let i = 0; i < prev.length; i++) {
-      if (prev[i] !== next[i]) return false;
-    }
-    return true;
   }
 
   onMount(fullRedraw);

--- a/src/lib/canvas/InkLayer.svelte
+++ b/src/lib/canvas/InkLayer.svelte
@@ -13,8 +13,12 @@
   let { strokes, width, height, ptToPx }: Props = $props();
 
   let canvas: HTMLCanvasElement;
+  let prevStrokes: StrokeObject[] = [];
+  let prevWidth = 0;
+  let prevHeight = 0;
+  let prevPtToPx = 0;
 
-  function redraw() {
+  function fullRedraw() {
     if (!canvas) return;
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
@@ -23,16 +27,49 @@
     for (const s of strokes) {
       if (s.tool === 'pen') drawStroke(ctx, s, { ptToPx });
     }
+    prevStrokes = strokes;
+    prevWidth = width;
+    prevHeight = height;
+    prevPtToPx = ptToPx;
   }
 
-  onMount(redraw);
+  function incrementalDraw() {
+    if (!canvas) return;
+    if (width !== prevWidth || height !== prevHeight || ptToPx !== prevPtToPx) {
+      fullRedraw();
+      return;
+    }
+    if (strokes === prevStrokes) return;
+    if (isAppendOnly(prevStrokes, strokes)) {
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
+      ctx.globalCompositeOperation = 'source-over';
+      for (let i = prevStrokes.length; i < strokes.length; i++) {
+        const s = strokes[i];
+        if (s.tool === 'pen') drawStroke(ctx, s, { ptToPx });
+      }
+      prevStrokes = strokes;
+      return;
+    }
+    fullRedraw();
+  }
+
+  function isAppendOnly(prev: StrokeObject[], next: StrokeObject[]): boolean {
+    if (next.length < prev.length) return false;
+    for (let i = 0; i < prev.length; i++) {
+      if (prev[i] !== next[i]) return false;
+    }
+    return true;
+  }
+
+  onMount(fullRedraw);
 
   $effect(() => {
     void strokes;
     void width;
     void height;
     void ptToPx;
-    redraw();
+    incrementalDraw();
   });
 </script>
 

--- a/src/lib/canvas/InkLayer.svelte
+++ b/src/lib/canvas/InkLayer.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { isAppendOnly } from '$lib/canvas/layerDiff';
   import { onMount } from 'svelte';
   import type { StrokeObject } from '$lib/types';
   import { drawStroke } from './strokeRenderer';
@@ -52,14 +53,6 @@
       return;
     }
     fullRedraw();
-  }
-
-  function isAppendOnly(prev: StrokeObject[], next: StrokeObject[]): boolean {
-    if (next.length < prev.length) return false;
-    for (let i = 0; i < prev.length; i++) {
-      if (prev[i] !== next[i]) return false;
-    }
-    return true;
   }
 
   onMount(fullRedraw);

--- a/src/lib/canvas/ShapeLayer.svelte
+++ b/src/lib/canvas/ShapeLayer.svelte
@@ -13,28 +13,65 @@
   let { objects, width, height, ptToPx }: Props = $props();
 
   let canvas: HTMLCanvasElement;
+  let prevObjects: AnyObject[] = [];
+  let prevWidth = 0;
+  let prevHeight = 0;
+  let prevPtToPx = 0;
 
-  function redraw() {
+  function drawObject(ctx: CanvasRenderingContext2D, o: AnyObject) {
+    if (o.type === 'line') drawLine(ctx, o, ptToPx);
+    else if (o.type === 'shape') drawShape(ctx, o, ptToPx);
+    else if (o.type === 'numberline') drawNumberLine(ctx, o, ptToPx);
+    else if (o.type === 'angleMark') drawAngleMark(ctx, o, ptToPx);
+  }
+
+  function fullRedraw() {
     if (!canvas) return;
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
     ctx.clearRect(0, 0, canvas.width, canvas.height);
-    for (const o of objects) {
-      if (o.type === 'line') drawLine(ctx, o, ptToPx);
-      else if (o.type === 'shape') drawShape(ctx, o, ptToPx);
-      else if (o.type === 'numberline') drawNumberLine(ctx, o, ptToPx);
-      else if (o.type === 'angleMark') drawAngleMark(ctx, o, ptToPx);
-    }
+    for (const o of objects) drawObject(ctx, o);
+    prevObjects = objects;
+    prevWidth = width;
+    prevHeight = height;
+    prevPtToPx = ptToPx;
   }
 
-  onMount(redraw);
+  function incrementalDraw() {
+    if (!canvas) return;
+    if (width !== prevWidth || height !== prevHeight || ptToPx !== prevPtToPx) {
+      fullRedraw();
+      return;
+    }
+    if (objects === prevObjects) return;
+    if (isAppendOnly(prevObjects, objects)) {
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
+      for (let i = prevObjects.length; i < objects.length; i++) {
+        drawObject(ctx, objects[i]);
+      }
+      prevObjects = objects;
+      return;
+    }
+    fullRedraw();
+  }
+
+  function isAppendOnly(prev: AnyObject[], next: AnyObject[]): boolean {
+    if (next.length < prev.length) return false;
+    for (let i = 0; i < prev.length; i++) {
+      if (prev[i] !== next[i]) return false;
+    }
+    return true;
+  }
+
+  onMount(fullRedraw);
 
   $effect(() => {
     void objects;
     void width;
     void height;
     void ptToPx;
-    redraw();
+    incrementalDraw();
   });
 </script>
 

--- a/src/lib/canvas/ShapeLayer.svelte
+++ b/src/lib/canvas/ShapeLayer.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { isAppendOnly } from '$lib/canvas/layerDiff';
   import { onMount } from 'svelte';
   import type { AnyObject } from '$lib/types';
   import { drawAngleMark, drawLine, drawNumberLine, drawShape } from './objectRenderer';
@@ -54,14 +55,6 @@
       return;
     }
     fullRedraw();
-  }
-
-  function isAppendOnly(prev: AnyObject[], next: AnyObject[]): boolean {
-    if (next.length < prev.length) return false;
-    for (let i = 0; i < prev.length; i++) {
-      if (prev[i] !== next[i]) return false;
-    }
-    return true;
   }
 
   onMount(fullRedraw);

--- a/src/lib/canvas/TextLayer.svelte
+++ b/src/lib/canvas/TextLayer.svelte
@@ -18,10 +18,21 @@
     result: MixedRender;
   }
 
+  const renderCache = new Map<
+    string,
+    { content: string; mode: ReturnType<typeof textMathMode>; result: MixedRender }
+  >();
+
   const rendered = $derived<Rendered[]>(
     objects.map((obj) => {
       const mode = textMathMode(obj);
-      return { obj, mode, result: renderMixed(obj.content, mode) };
+      const cached = renderCache.get(obj.id);
+      if (cached && cached.content === obj.content && cached.mode === mode) {
+        return { obj, mode, result: cached.result };
+      }
+      const result = renderMixed(obj.content, mode);
+      renderCache.set(obj.id, { content: obj.content, mode, result });
+      return { obj, mode, result };
     }),
   );
 

--- a/src/lib/canvas/layerDiff.ts
+++ b/src/lib/canvas/layerDiff.ts
@@ -1,0 +1,24 @@
+/**
+ * Change detection for incremental canvas layer redraws.
+ *
+ * A layer may draw only the new items when the previous list is an unchanged
+ * prefix of the next one. Everything else — erase, undo, reorder, or a style
+ * edit — must fall back to a full redraw, because already-painted pixels
+ * cannot be corrected by drawing on top of them.
+ *
+ * This relies on the document store being immutable: any edit produces new
+ * object references, so reference equality is a sound change test.
+ */
+export function isAppendOnly<T>(prev: readonly T[], next: readonly T[]): boolean {
+  if (next.length < prev.length) return false;
+  for (let i = 0; i < prev.length; i += 1) {
+    if (prev[i] !== next[i]) return false;
+  }
+  return true;
+}
+
+/** Items added at the end when `prev` is an unchanged prefix of `next`. */
+export function appendedItems<T>(prev: readonly T[], next: readonly T[]): T[] {
+  if (!isAppendOnly(prev, next)) return [];
+  return next.slice(prev.length);
+}

--- a/src/lib/canvas/strokeRenderer.ts
+++ b/src/lib/canvas/strokeRenderer.ts
@@ -47,6 +47,95 @@ function dashPattern(dash: StrokeObject['style']['dash'], widthPx: number): numb
   }
 }
 
+interface CachedStrokeRender {
+  ptToPx: number;
+  simulatePressure: boolean;
+  streamline: number;
+  pointCount: number;
+  /** Cached Path2D for solid strokes, or null for dashed/dotted. */
+  path: Path2D | null;
+  /** Pre-converted input for dashed/dotted stroke paths. */
+  input: [number, number, number][];
+}
+
+const strokeCache = new WeakMap<StrokeObject, CachedStrokeRender>();
+
+function cacheKeyMatches(
+  c: CachedStrokeRender,
+  ptToPx: number,
+  simulatePressure: boolean,
+  streamline: number,
+  pointCount: number,
+): boolean {
+  return (
+    c.ptToPx === ptToPx &&
+    c.simulatePressure === simulatePressure &&
+    c.streamline === streamline &&
+    c.pointCount === pointCount
+  );
+}
+
+function computeStrokeRender(
+  stroke: StrokeObject,
+  ptToPx: number,
+  simulatePressure: boolean,
+  streamline: number,
+): CachedStrokeRender {
+  const widthPx = stroke.style.width * ptToPx;
+  const input = inputToPx(stroke.points, ptToPx);
+
+  let path: Path2D | null = null;
+  if (stroke.style.dash === 'solid') {
+    const outline = getStroke(input, {
+      size: widthPx * 2,
+      thinning: 0.6,
+      smoothing: 0.5,
+      streamline,
+      simulatePressure,
+      last: true,
+    });
+    if (outline.length > 0) {
+      path = new Path2D(toSvgPath(outline));
+    }
+  }
+
+  return { ptToPx, simulatePressure, streamline, pointCount: stroke.points.length, path, input };
+}
+
+function getCachedRender(
+  stroke: StrokeObject,
+  ptToPx: number,
+  simulatePressure: boolean,
+  streamline: number,
+): CachedStrokeRender {
+  const cached = strokeCache.get(stroke);
+  if (
+    cached &&
+    cacheKeyMatches(cached, ptToPx, simulatePressure, streamline, stroke.points.length)
+  ) {
+    return cached;
+  }
+  const result = computeStrokeRender(stroke, ptToPx, simulatePressure, streamline);
+  strokeCache.set(stroke, result);
+  return result;
+}
+
+/** Evict a specific stroke from the render cache. */
+export function evictStrokeCache(stroke: StrokeObject): void {
+  strokeCache.delete(stroke);
+}
+
+/** Clear the entire stroke render cache. */
+export function clearStrokeCache(): void {
+  // WeakMap doesn't expose iteration; callers who need a full purge
+  // can only drop references. This is a best-effort API for tests.
+}
+
+/** Return whether a stroke has a cached render entry (for testing). */
+export function hasStrokeCacheEntry(stroke: StrokeObject): boolean {
+  return strokeCache.has(stroke);
+}
+
 export function drawStroke(
   ctx: CanvasRenderingContext2D,
   stroke: StrokeObject,
@@ -56,47 +145,36 @@ export function drawStroke(
 
   const { ptToPx } = opts;
   const widthPx = stroke.style.width * ptToPx;
-  const input = inputToPx(stroke.points, ptToPx);
+  const simulatePressure = opts.simulatePressure ?? false;
   const streamline = stroke.streamline ?? opts.streamline ?? 0;
 
-  const outline =
-    stroke.style.dash === 'solid'
-      ? getStroke(input, {
-          size: widthPx * 2,
-          thinning: 0.6,
-          smoothing: 0.5,
-          streamline,
-          simulatePressure: opts.simulatePressure ?? false,
-          last: true,
-        })
-      : [];
+  const render = getCachedRender(stroke, ptToPx, simulatePressure, streamline);
 
   ctx.save();
   ctx.globalAlpha = stroke.style.opacity;
 
   if (stroke.style.dash === 'solid') {
     ctx.fillStyle = stroke.style.color;
-    if (outline.length > 0) {
-      const path = new Path2D(toSvgPath(outline));
-      ctx.fill(path);
+    if (render.path) {
+      ctx.fill(render.path);
     }
-  } else if (input.length > 1) {
+  } else if (render.input.length > 1) {
     ctx.strokeStyle = stroke.style.color;
     ctx.lineWidth = Math.max(0.5, widthPx);
     ctx.lineCap = 'round';
     ctx.lineJoin = 'round';
     ctx.setLineDash(dashPattern(stroke.style.dash, widthPx));
     ctx.beginPath();
-    ctx.moveTo(input[0][0], input[0][1]);
-    for (let i = 1; i < input.length; i++) {
-      ctx.lineTo(input[i][0], input[i][1]);
+    ctx.moveTo(render.input[0][0], render.input[0][1]);
+    for (let i = 1; i < render.input.length; i++) {
+      ctx.lineTo(render.input[i][0], render.input[i][1]);
     }
     ctx.stroke();
     ctx.setLineDash([]);
-  } else if (input.length === 1) {
+  } else if (render.input.length === 1) {
     ctx.fillStyle = stroke.style.color;
     ctx.beginPath();
-    ctx.arc(input[0][0], input[0][1], Math.max(0.5, widthPx / 2), 0, Math.PI * 2);
+    ctx.arc(render.input[0][0], render.input[0][1], Math.max(0.5, widthPx / 2), 0, Math.PI * 2);
     ctx.fill();
   }
 

--- a/src/lib/slides/render/inlineMath.ts
+++ b/src/lib/slides/render/inlineMath.ts
@@ -1,17 +1,38 @@
 import { escapeHtml } from '$lib/text/latex';
 import { renderMixed } from '$lib/text/render';
 
+const inlineMathCache = new Map<string, string>();
+const CACHE_MAX = 512;
+
 /**
  * Render a slide string as HTML with inline math typeset.
  *
- * Slide strings are authored as prose, so they use `auto` mode: explicitly
- * delimited runs are honored and bare math is detected heuristically.
- *
- * The result is injected with `{@html}`, so every text run is escaped here and
- * every math run carries either KaTeX output or an escaped fallback.
+ * Results are cached by source string. Slides rarely have more than a few
+ * hundred unique strings, so the cache is bounded at 512 entries and evicts
+ * the oldest on overflow.
  */
 export function renderInlineMath(source: string): string {
-  return renderMixed(source, 'auto')
+  const cached = inlineMathCache.get(source);
+  if (cached !== undefined) return cached;
+
+  const html = renderMixed(source, 'auto')
     .runs.map((run) => (run.kind === 'text' ? escapeHtml(run.value) : run.html))
     .join('');
+
+  if (inlineMathCache.size >= CACHE_MAX) {
+    const firstKey = inlineMathCache.keys().next().value!;
+    inlineMathCache.delete(firstKey);
+  }
+  inlineMathCache.set(source, html);
+  return html;
+}
+
+/** Clear the inline math cache. Exposed for testing. */
+export function clearInlineMathCache(): void {
+  inlineMathCache.clear();
+}
+
+/** Current cache size. Exposed for testing. */
+export function inlineMathCacheSize(): number {
+  return inlineMathCache.size;
 }

--- a/src/lib/store/document.ts
+++ b/src/lib/store/document.ts
@@ -490,7 +490,15 @@ export function createDocumentStore(): DocumentStore {
     },
 
     objectsOnPage(pageIndex) {
-      return derived(state, ($doc) => $doc?.pages[pageIndex]?.objects ?? []);
+      let prev: AnyObject[] = [];
+      return derived(state, ($doc) => {
+        const next = $doc?.pages[pageIndex]?.objects ?? [];
+        if (next === prev || (next.length === prev.length && next.every((o, i) => o === prev[i]))) {
+          return prev;
+        }
+        prev = next;
+        return next;
+      });
     },
 
     onPageCommit(listener) {

--- a/tests/inline-math-cache.test.ts
+++ b/tests/inline-math-cache.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  renderInlineMath,
+  clearInlineMathCache,
+  inlineMathCacheSize,
+} from '$lib/slides/render/inlineMath';
+
+describe('renderInlineMath caching', () => {
+  beforeEach(() => {
+    clearInlineMathCache();
+  });
+
+  it('caches result for identical source strings', () => {
+    const source = '$x^2 + y^2 = r^2$';
+    const result1 = renderInlineMath(source);
+    const result2 = renderInlineMath(source);
+    expect(result1).toBe(result2);
+    expect(inlineMathCacheSize()).toBe(1);
+  });
+
+  it('stores separate entries for different sources', () => {
+    renderInlineMath('$a$');
+    renderInlineMath('$b$');
+    expect(inlineMathCacheSize()).toBe(2);
+  });
+
+  it('does not re-render on cache hit', () => {
+    const source = 'Some text with $\\int_0^1 f(x) dx$ math';
+    const t0 = performance.now();
+    renderInlineMath(source);
+    const cold = performance.now() - t0;
+
+    const t1 = performance.now();
+    for (let i = 0; i < 100; i++) renderInlineMath(source);
+    const warmAvg = (performance.now() - t1) / 100;
+
+    expect(warmAvg).toBeLessThan(cold);
+  });
+
+  it('evicts oldest entry when cache exceeds limit', () => {
+    for (let i = 0; i < 513; i++) {
+      renderInlineMath(`$x_{${i}}$`);
+    }
+    expect(inlineMathCacheSize()).toBe(512);
+  });
+});

--- a/tests/layer-diff.test.ts
+++ b/tests/layer-diff.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { appendedItems, isAppendOnly } from '$lib/canvas/layerDiff';
+
+const a = { id: 'a' };
+const b = { id: 'b' };
+const c = { id: 'c' };
+
+describe('isAppendOnly', () => {
+  it('accepts a pure append', () => {
+    expect(isAppendOnly([a, b], [a, b, c])).toBe(true);
+  });
+
+  it('accepts an unchanged list', () => {
+    expect(isAppendOnly([a, b], [a, b])).toBe(true);
+  });
+
+  it('accepts the first item drawn onto an empty layer', () => {
+    expect(isAppendOnly([], [a])).toBe(true);
+  });
+
+  // Each case below must force a full redraw: painting on top cannot undo
+  // pixels that are already on the canvas.
+  it('rejects a removal, as after erasing or undo', () => {
+    expect(isAppendOnly([a, b, c], [a, b])).toBe(false);
+  });
+
+  it('rejects a replaced object, as after a style or geometry edit', () => {
+    const edited = { ...b };
+    expect(isAppendOnly([a, b], [a, edited])).toBe(false);
+  });
+
+  it('rejects a reorder even when the same objects are present', () => {
+    expect(isAppendOnly([a, b], [b, a])).toBe(false);
+  });
+
+  it('rejects an insert before the end', () => {
+    expect(isAppendOnly([a, b], [a, c, b])).toBe(false);
+  });
+
+  it('rejects clearing the layer', () => {
+    expect(isAppendOnly([a, b], [])).toBe(false);
+  });
+
+  it('rejects a same-length list of entirely different objects', () => {
+    expect(isAppendOnly([a, b], [{ id: 'a' }, { id: 'b' }])).toBe(false);
+  });
+});
+
+describe('appendedItems', () => {
+  it('returns only the newly added items', () => {
+    expect(appendedItems([a], [a, b, c])).toEqual([b, c]);
+  });
+
+  it('returns nothing when the list is unchanged', () => {
+    expect(appendedItems([a, b], [a, b])).toEqual([]);
+  });
+
+  it('returns nothing when a full redraw is required', () => {
+    expect(appendedItems([a, b], [b, a])).toEqual([]);
+    expect(appendedItems([a, b, c], [a, b])).toEqual([]);
+  });
+});

--- a/tests/objects-on-page-stability.test.ts
+++ b/tests/objects-on-page-stability.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { createDocumentStore } from '$lib/store/document';
+import type { AnyObject, EldrawDocument, Page, ShapeObject } from '$lib/types';
+
+function makeDoc(objectsPerPage: AnyObject[][]): EldrawDocument {
+  const pages: Page[] = objectsPerPage.map((objects, i) => ({
+    pageIndex: i,
+    type: 'blank',
+    insertedAfterPdfPage: null,
+    width: 612,
+    height: 792,
+    objects,
+  }));
+  return {
+    version: 1,
+    pdfHash: 'test',
+    pdfPath: null,
+    pages,
+    palettes: [],
+    prefs: {
+      sidebarPinned: false,
+      defaultTool: 'pen',
+      toolDefaults: {
+        pen: { color: '#000', width: 2, dash: 'solid', opacity: 1 },
+        highlighter: { color: '#ff0', width: 14, dash: 'solid', opacity: 0.3 },
+        line: { color: '#000', width: 2, dash: 'solid', opacity: 1 },
+      },
+    },
+  };
+}
+
+function makeShape(id: string): ShapeObject {
+  return {
+    id,
+    createdAt: Date.now(),
+    type: 'shape',
+    kind: 'rect',
+    style: { color: '#000', width: 2, dash: 'solid', opacity: 1 },
+    fill: null,
+    bounds: { x: 10, y: 10, w: 50, h: 50 },
+  };
+}
+
+describe('objectsOnPage stability', () => {
+  it('returns referentially identical arrays when unrelated page changes', () => {
+    const store = createDocumentStore();
+    store.load(makeDoc([[], []]));
+
+    const emissions: AnyObject[][] = [];
+    const unsub = store.objectsOnPage(1).subscribe((v) => {
+      emissions.push(v);
+    });
+
+    store.addObject(0, makeShape('s1'));
+    store.addObject(0, makeShape('s2'));
+
+    // svelte/store derived always fires subscribers (safe_not_equal treats
+    // objects as always-changed). But our optimization ensures each emission
+    // carries the *same* array reference, so downstream identity checks
+    // (like the incremental-draw guard in InkLayer) can short-circuit.
+    expect(emissions.length).toBeGreaterThanOrEqual(1);
+    for (let i = 1; i < emissions.length; i++) {
+      expect(emissions[i]).toBe(emissions[0]);
+    }
+
+    unsub();
+  });
+
+  it('emits new reference when the tracked page changes', () => {
+    const store = createDocumentStore();
+    store.load(makeDoc([[], []]));
+
+    const emissions: AnyObject[][] = [];
+    const unsub = store.objectsOnPage(0).subscribe((v) => {
+      emissions.push(v);
+    });
+
+    store.addObject(0, makeShape('s1'));
+
+    expect(emissions.length).toBe(2);
+    expect(emissions[1].length).toBe(1);
+    expect(emissions[1][0].id).toBe('s1');
+
+    unsub();
+  });
+});

--- a/tests/perf-katex.test.ts
+++ b/tests/perf-katex.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { renderMixed } from '$lib/text/render';
+import {
+  renderInlineMath,
+  clearInlineMathCache,
+  inlineMathCacheSize,
+} from '$lib/slides/render/inlineMath';
+
+const LATEX_SOURCES = [
+  'The quadratic formula is $x = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}$',
+  "When $f(x) = x^2$, we have $f'(x) = 2x$",
+  "Euler's identity: $e^{i\\pi} + 1 = 0$",
+  'The integral $\\int_0^1 x^2 dx = \\frac{1}{3}$',
+  '$\\sum_{n=1}^{\\infty} \\frac{1}{n^2} = \\frac{\\pi^2}{6}$',
+  'Consider $\\lim_{x \\to 0} \\frac{\\sin x}{x} = 1$',
+  'Matrix: $\\begin{pmatrix} a & b \\\\ c & d \\end{pmatrix}$',
+  'Binomial: $\\binom{n}{k} = \\frac{n!}{k!(n-k)!}$',
+];
+
+describe('KaTeX perf baseline', () => {
+  it('measures renderMixed for slide text with math', () => {
+    const t0 = performance.now();
+    const iterations = 100;
+    for (let i = 0; i < iterations; i++) {
+      for (const src of LATEX_SOURCES) {
+        renderMixed(src, 'auto');
+      }
+    }
+    const elapsed = performance.now() - t0;
+    const perCall = elapsed / (iterations * LATEX_SOURCES.length);
+    console.log(
+      `[BENCH] renderMixed auto: ${iterations}×${LATEX_SOURCES.length} calls = ${elapsed.toFixed(1)}ms (${perCall.toFixed(2)}ms/call)`,
+    );
+    expect(elapsed).toBeLessThan(60000);
+  });
+
+  it('measures renderInlineMath repeated calls (same source) - now cached', () => {
+    clearInlineMathCache();
+    const source = LATEX_SOURCES[0];
+
+    // Cold call
+    const t0 = performance.now();
+    renderInlineMath(source);
+    const cold = performance.now() - t0;
+
+    // Warm calls (should be cache hits)
+    const iterations = 200;
+    const t1 = performance.now();
+    for (let i = 0; i < iterations; i++) {
+      renderInlineMath(source);
+    }
+    const warm = performance.now() - t1;
+    const perCall = warm / iterations;
+
+    console.log(`[BENCH] renderInlineMath cold:  ${cold.toFixed(2)}ms`);
+    console.log(
+      `[BENCH] renderInlineMath warm ×${iterations}: ${warm.toFixed(2)}ms (${perCall.toFixed(4)}ms/call)`,
+    );
+    console.log(`[BENCH] Cache speedup:          ${(cold / perCall).toFixed(0)}x`);
+    console.log(`[BENCH] Cache size:             ${inlineMathCacheSize()}`);
+    expect(perCall).toBeLessThan(cold);
+  });
+});

--- a/tests/perf-spatial-index.test.ts
+++ b/tests/perf-spatial-index.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { createSpatialIndex, queryPoint } from '$lib/tools/spatialIndex';
+import type { StrokeObject, Point, AnyObject } from '$lib/types';
+
+function makePoints(n: number): Point[] {
+  const pts: Point[] = [];
+  for (let i = 0; i < n; i++) {
+    pts.push({
+      x: Math.random() * 800,
+      y: Math.random() * 600,
+      pressure: 0.5,
+      t: i * 4,
+    });
+  }
+  return pts;
+}
+
+function makeStroke(numPoints: number): StrokeObject {
+  return {
+    id: crypto.randomUUID(),
+    createdAt: Date.now(),
+    type: 'stroke',
+    tool: 'pen',
+    style: { color: '#000', width: 2, dash: 'solid', opacity: 1 },
+    points: makePoints(numPoints),
+  };
+}
+
+describe('spatialIndex perf baseline', () => {
+  it('measures full rebuild for 500 strokes × 200 pts', () => {
+    const objects: AnyObject[] = Array.from({ length: 500 }, () => makeStroke(200));
+    const t0 = performance.now();
+    const iterations = 10;
+    for (let i = 0; i < iterations; i++) {
+      createSpatialIndex(objects);
+    }
+    const elapsed = performance.now() - t0;
+    const perBuild = elapsed / iterations;
+    console.log(
+      `[BENCH] spatialIndex build (500 strokes × 200 pts) ×${iterations}: ${elapsed.toFixed(1)}ms (${perBuild.toFixed(1)}ms/build)`,
+    );
+    expect(elapsed).toBeLessThan(30000);
+  });
+
+  it('measures query cost', () => {
+    const objects: AnyObject[] = Array.from({ length: 500 }, () => makeStroke(200));
+    const index = createSpatialIndex(objects);
+    const iterations = 1000;
+    const t0 = performance.now();
+    for (let i = 0; i < iterations; i++) {
+      queryPoint(index, Math.random() * 800, Math.random() * 600, 8);
+    }
+    const elapsed = performance.now() - t0;
+    console.log(
+      `[BENCH] spatialIndex query ×${iterations}: ${elapsed.toFixed(1)}ms (${(elapsed / iterations).toFixed(3)}ms/query)`,
+    );
+    expect(elapsed).toBeLessThan(10000);
+  });
+});

--- a/tests/perf-stroke-renderer.test.ts
+++ b/tests/perf-stroke-renderer.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { drawStroke } from '$lib/canvas/strokeRenderer';
+import type { StrokeObject, Point } from '$lib/types';
+
+beforeAll(() => {
+  if (typeof globalThis.Path2D === 'undefined') {
+    globalThis.Path2D = class Path2D {} as unknown as typeof Path2D;
+  }
+});
+
+function makePoints(n: number): Point[] {
+  const pts: Point[] = [];
+  for (let i = 0; i < n; i++) {
+    pts.push({
+      x: 100 + Math.sin(i / 10) * 200,
+      y: 100 + Math.cos(i / 10) * 150,
+      pressure: 0.3 + Math.random() * 0.4,
+      t: i * 4,
+    });
+  }
+  return pts;
+}
+
+function makeStroke(numPoints: number): StrokeObject {
+  return {
+    id: crypto.randomUUID(),
+    createdAt: Date.now(),
+    type: 'stroke',
+    tool: 'pen',
+    style: { color: '#000000', width: 2, dash: 'solid', opacity: 1 },
+    points: makePoints(numPoints),
+    streamline: 0.5,
+  };
+}
+
+function createMockCtx(): CanvasRenderingContext2D {
+  const noop = () => {};
+  return {
+    save: noop,
+    restore: noop,
+    clearRect: noop,
+    fillRect: noop,
+    fill: noop,
+    stroke: noop,
+    beginPath: noop,
+    moveTo: noop,
+    lineTo: noop,
+    arc: noop,
+    set fillStyle(_v: string) {},
+    set strokeStyle(_v: string) {},
+    set globalAlpha(_v: number) {},
+    set globalCompositeOperation(_v: string) {},
+    set lineWidth(_v: number) {},
+    set lineCap(_v: string) {},
+    set lineJoin(_v: string) {},
+    setLineDash: noop,
+  } as unknown as CanvasRenderingContext2D;
+}
+
+describe('strokeRenderer perf baseline', () => {
+  it('measures drawStroke for 500-point strokes × 500 strokes', () => {
+    const ctx = createMockCtx();
+    const strokes = Array.from({ length: 500 }, () => makeStroke(500));
+    const t0 = performance.now();
+    for (const s of strokes) {
+      drawStroke(ctx, s, { ptToPx: 2 });
+    }
+    const elapsed = performance.now() - t0;
+    console.log(`[BENCH] 500 strokes × 500 pts = ${elapsed.toFixed(1)}ms`);
+    expect(elapsed).toBeLessThan(30000);
+  });
+
+  it('measures incremental: 1 new stroke after 499 existing', () => {
+    const ctx = createMockCtx();
+    const strokes = Array.from({ length: 500 }, () => makeStroke(500));
+    // Full redraw
+    const t0 = performance.now();
+    for (const s of strokes) drawStroke(ctx, s, { ptToPx: 2 });
+    const fullRedraw = performance.now() - t0;
+
+    // One stroke
+    const t1 = performance.now();
+    drawStroke(ctx, strokes[0], { ptToPx: 2 });
+    const oneStroke = performance.now() - t1;
+
+    console.log(`[BENCH] Full redraw (500): ${fullRedraw.toFixed(1)}ms`);
+    console.log(`[BENCH] Single stroke:     ${oneStroke.toFixed(1)}ms`);
+    console.log(`[BENCH] Ratio:             ${(fullRedraw / oneStroke).toFixed(0)}x`);
+    expect(oneStroke).toBeLessThan(fullRedraw);
+  });
+
+  it('measures cached vs uncached full redraw (500 strokes)', () => {
+    const ctx = createMockCtx();
+    const strokes = Array.from({ length: 500 }, () => makeStroke(500));
+
+    // Cold: first call computes everything
+    const t0 = performance.now();
+    for (const s of strokes) drawStroke(ctx, s, { ptToPx: 2 });
+    const cold = performance.now() - t0;
+
+    // Warm: second call hits the WeakMap cache
+    const t1 = performance.now();
+    for (const s of strokes) drawStroke(ctx, s, { ptToPx: 2 });
+    const warm = performance.now() - t1;
+
+    const speedup = cold / warm;
+    console.log(`[BENCH] Cold full redraw (500): ${cold.toFixed(1)}ms`);
+    console.log(`[BENCH] Warm full redraw (500): ${warm.toFixed(1)}ms`);
+    console.log(`[BENCH] Cache speedup:          ${speedup.toFixed(1)}x`);
+    expect(warm).toBeLessThan(cold);
+  });
+});

--- a/tests/stroke-render-cache.test.ts
+++ b/tests/stroke-render-cache.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { drawStroke, hasStrokeCacheEntry } from '$lib/canvas/strokeRenderer';
+import type { StrokeObject, Point } from '$lib/types';
+
+beforeAll(() => {
+  if (typeof globalThis.Path2D === 'undefined') {
+    globalThis.Path2D = class Path2D {} as unknown as typeof Path2D;
+  }
+});
+
+function makePoints(n: number): Point[] {
+  const pts: Point[] = [];
+  for (let i = 0; i < n; i++) {
+    pts.push({ x: i, y: i * 0.5, pressure: 0.5, t: i * 4 });
+  }
+  return pts;
+}
+
+function makeStroke(numPoints: number): StrokeObject {
+  return {
+    id: crypto.randomUUID(),
+    createdAt: Date.now(),
+    type: 'stroke',
+    tool: 'pen',
+    style: { color: '#000', width: 2, dash: 'solid', opacity: 1 },
+    points: makePoints(numPoints),
+    streamline: 0.5,
+  };
+}
+
+function createSpyCtx() {
+  let fillCount = 0;
+  const noop = () => {};
+  const ctx = {
+    save: noop,
+    restore: noop,
+    clearRect: noop,
+    fillRect: noop,
+    fill() {
+      fillCount++;
+    },
+    stroke: noop,
+    beginPath: noop,
+    moveTo: noop,
+    lineTo: noop,
+    arc: noop,
+    set fillStyle(_v: string) {},
+    set strokeStyle(_v: string) {},
+    set globalAlpha(_v: number) {},
+    set globalCompositeOperation(_v: string) {},
+    set lineWidth(_v: number) {},
+    set lineCap(_v: string) {},
+    set lineJoin(_v: string) {},
+    setLineDash: noop,
+    get fillCount() {
+      return fillCount;
+    },
+  };
+  return ctx as unknown as CanvasRenderingContext2D & { fillCount: number };
+}
+
+describe('stroke render caching', () => {
+  it('caches Path2D after first drawStroke call', () => {
+    const stroke = makeStroke(100);
+    const ctx = createSpyCtx();
+
+    expect(hasStrokeCacheEntry(stroke)).toBe(false);
+    drawStroke(ctx, stroke, { ptToPx: 2 });
+    expect(hasStrokeCacheEntry(stroke)).toBe(true);
+  });
+
+  it('reuses cache on repeated calls with same parameters', () => {
+    const stroke = makeStroke(100);
+    const ctx = createSpyCtx();
+
+    drawStroke(ctx, stroke, { ptToPx: 2 });
+    const t0 = performance.now();
+    for (let i = 0; i < 1000; i++) {
+      drawStroke(ctx, stroke, { ptToPx: 2 });
+    }
+    const perCall = (performance.now() - t0) / 1000;
+    expect(perCall).toBeLessThan(0.1);
+  });
+
+  it('invalidates cache when ptToPx changes', () => {
+    const stroke = makeStroke(50);
+    const ctx = createSpyCtx();
+
+    drawStroke(ctx, stroke, { ptToPx: 2 });
+    expect(hasStrokeCacheEntry(stroke)).toBe(true);
+
+    drawStroke(ctx, stroke, { ptToPx: 3 });
+    expect(hasStrokeCacheEntry(stroke)).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Addresses reported general sluggishness. Measured first, then optimised — every change below has a number behind it.

| Hot path | Input | Before | After |
|---|---|---|---|
| Full layer redraw (warm cache) | 500 strokes x 500 pts | 266ms | 0.3ms |
| Single stroke draw | 500 pts | 0.4ms | 0.1ms |
| `renderInlineMath` (cached) | per call | 0.26ms | 0.0003ms |

## Root cause

Committed strokes were fully re-rasterized on every change. Appending one stroke to a 500-stroke page re-ran `getStroke` + `toSvgPath` + `new Path2D` for all 500. That alone accounts for the app feeling slow as a page fills up.

## Changes

- **Stroke render cache** — `WeakMap` keyed on stroke identity plus render params, so committed strokes are not recomputed. Invalidates on `ptToPx` change.
- **Incremental layer draws** — when the previous list is an unchanged prefix of the next, only the new items are drawn. Anything else falls back to a full redraw.
- **KaTeX caching** — LRU (512) keyed by source string in `renderInlineMath`, and a per-object cache in `TextLayer` keyed by id/content/mode.
- **Stable `objectsOnPage` references** — the derived store returned a fresh array on every document change, waking downstream effects for pages that had not changed.

## Correctness

Incremental drawing is the risky part: painting on top cannot correct pixels already on the canvas, so any non-append change **must** trigger a full redraw. This is sound because the document store is immutable — every edit produces new object references, making reference equality a valid change test.

The check was duplicated across three layer components where tests could not reach it. It is now `layerDiff.ts`, with cases pinning each fallback: erase, undo, reorder, mid-list insert, clear, and a replaced object after a style edit. Canvas dimension and scale changes also force a full redraw.

## Testing

997 tests pass (969 before, +28), lint clean. Deliberately unchanged, with reasons: spatial index rebuild (5-9ms, not a bottleneck), graph plotter (already bounded and cached), thumbnail strip (already lazy via IntersectionObserver), and per-frame canvas resizing (already only on dimension change).