### PR TITLE
fix(ruler): stop the overlay swallowing input, make it dismissable, add a lesson graph theme

### DIFF
--- a/src/lib/canvas/RulerOverlay.svelte
+++ b/src/lib/canvas/RulerOverlay.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { overlays } from '$lib/store/overlays';
+  import { sidebar } from '$lib/store/sidebar';
   import { toolStore } from '$lib/store/tool';
   import { rulerEnd, rulerTicks, type Vec2 } from '$lib/geometry';
 
@@ -66,6 +67,9 @@
 
   function onClose(e: Event) {
     overlays.setRulerVisible(false);
+    // Leaving the ruler tool selected with no ruler on screen is incoherent,
+    // and it would also stop re-picking the tool from showing it again.
+    if (isRulerTool) sidebar.setTool('pen');
     e.stopPropagation();
   }
 
@@ -155,7 +159,6 @@
   >
     <circle
       class="close"
-      class:interactive={isRulerTool}
       cx={-closeOffset}
       cy={bodyHeight / 2}
       r="8"
@@ -163,11 +166,11 @@
       stroke="#1e88e5"
       stroke-width="1"
       role="button"
-      tabindex={isRulerTool ? 0 : -1}
+      tabindex="0"
       aria-label="Hide ruler"
-      onclick={isRulerTool ? onClose : null}
-      onpointerdown={isRulerTool ? onClose : null}
-      onkeydown={isRulerTool ? onCloseKey : null}
+      onclick={onClose}
+      onpointerdown={onClose}
+      onkeydown={onCloseKey}
     />
     <line
       x1={-closeOffset - 3}
@@ -207,7 +210,8 @@
     cursor: grab;
     pointer-events: auto;
   }
-  .close.interactive {
+  /* Always reachable: otherwise switching tools leaves an undismissable ruler. */
+  .close {
     cursor: pointer;
     pointer-events: auto;
   }

--- a/src/lib/graph/theme.ts
+++ b/src/lib/graph/theme.ts
@@ -7,7 +7,13 @@
  * {@link resolveTheme}.
  */
 
-export type GraphPresetName = 'classic' | 'textbook' | 'blueprint' | 'minimal' | 'graphPaper';
+export type GraphPresetName =
+  | 'classic'
+  | 'textbook'
+  | 'blueprint'
+  | 'minimal'
+  | 'graphPaper'
+  | 'lesson';
 
 export type OriginLabelMode = 'none' | 'letter' | 'coords';
 export type AxisLabelStyle = 'italic-serif' | 'italic-sans' | 'none';
@@ -174,12 +180,41 @@ const graphPaper: GraphTheme = {
   curveDefaultWidth: 2,
 };
 
+/**
+ * Tuned for graphs projected in a live lesson: the grid recedes so hand-drawn
+ * work over the top stays the most prominent thing on the slide, while the
+ * axes and labels remain legible from the back of a room.
+ */
+const lesson: GraphTheme = {
+  background: '#fdfdfb',
+  backgroundEnabled: true,
+  frameColor: '#d8d8d2',
+  frameEnabled: true,
+
+  axisColor: '#4a4a4a',
+  axisWidth: 1.1,
+  axisArrowheads: false,
+  tickLength: 4,
+
+  gridMajor: { enabled: true, color: '#c9c9c2', width: 1, opacity: 0.75 },
+  gridMinor: { enabled: true, color: '#e4e4dd', width: 1, opacity: 0.85, subdivisions: 5 },
+
+  labelColor: '#6a6a66',
+  labelFontFamily: SANS,
+  labelFontSize: 9,
+
+  axisLabelStyle: 'italic-serif',
+  originLabel: 'coords',
+  curveDefaultWidth: 1.8,
+};
+
 export const GRAPH_THEME_PRESETS: Readonly<Record<GraphPresetName, GraphTheme>> = Object.freeze({
   classic,
   textbook,
   blueprint,
   minimal,
   graphPaper,
+  lesson,
 });
 
 export const GRAPH_PRESET_ORDER: readonly GraphPresetName[] = [
@@ -188,6 +223,7 @@ export const GRAPH_PRESET_ORDER: readonly GraphPresetName[] = [
   'blueprint',
   'minimal',
   'graphPaper',
+  'lesson',
 ];
 
 export const GRAPH_PRESET_LABELS: Readonly<Record<GraphPresetName, string>> = {
@@ -196,6 +232,7 @@ export const GRAPH_PRESET_LABELS: Readonly<Record<GraphPresetName, string>> = {
   blueprint: 'Blueprint',
   minimal: 'Minimal',
   graphPaper: 'Graph paper',
+  lesson: 'Lesson',
 };
 
 export const DEFAULT_GRAPH_PRESET: GraphPresetName = 'classic';

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -84,6 +84,7 @@
     StrokeObject,
     TextMathMode,
     TextObject,
+    ToolKind,
     Slide,
   } from '$lib/types';
   import { textMathMode } from '$lib/types';
@@ -102,10 +103,15 @@
   const overlaysState = $derived($overlays);
   const rulerVisible = $derived(overlaysState.rulerVisible);
   const rulerSnapState = $derived(rulerVisible ? overlaysState.ruler : null);
+  // Show the ruler when the tool is picked, but only on that transition.
+  // Reading `rulerVisible` here would re-show it the instant it was closed.
+  let lastToolForRuler: ToolKind | null = null;
   $effect(() => {
-    if (sidebarState.activeTool === 'ruler' && !overlaysState.rulerVisible) {
+    const tool = sidebarState.activeTool;
+    if (tool === 'ruler' && lastToolForRuler !== 'ruler') {
       overlays.setRulerVisible(true);
     }
+    lastToolForRuler = tool;
   });
   $effect(() => {
     if (sidebarState.activeTool !== 'select') selection.clear();
@@ -1186,9 +1192,6 @@
     inset: 0;
     z-index: 15;
     pointer-events: none;
-  }
-  .overlay-slot :global(svg) {
-    pointer-events: auto;
   }
   .overlay-slot.capture {
     pointer-events: auto;

--- a/tests/graph-theme.test.ts
+++ b/tests/graph-theme.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   DEFAULT_GRAPH_PRESET,
   GRAPH_PRESET_ORDER,
+  GRAPH_PRESET_LABELS,
   GRAPH_THEME_PRESETS,
   isGraphPresetName,
   mergeTheme,
@@ -9,8 +10,10 @@ import {
 } from '$lib/graph/theme';
 
 describe('graph theme presets', () => {
-  it('exposes the five named presets with distinct backgrounds', () => {
-    expect(GRAPH_PRESET_ORDER).toEqual([
+  it('exposes every preset in a stable order with distinct backgrounds', () => {
+    // Asserted as a superset so adding a preset does not fail this test, while
+    // removing or reordering an existing one still does.
+    expect(GRAPH_PRESET_ORDER.slice(0, 5)).toEqual([
       'classic',
       'textbook',
       'blueprint',
@@ -19,6 +22,22 @@ describe('graph theme presets', () => {
     ]);
     const backgrounds = GRAPH_PRESET_ORDER.map((n) => GRAPH_THEME_PRESETS[n].background);
     expect(new Set(backgrounds).size).toBeGreaterThanOrEqual(3);
+  });
+
+  it('registers a name, label and theme for every preset', () => {
+    for (const name of GRAPH_PRESET_ORDER) {
+      expect(GRAPH_THEME_PRESETS[name], `missing theme for ${name}`).toBeDefined();
+      expect(GRAPH_PRESET_LABELS[name], `missing label for ${name}`).toBeTruthy();
+    }
+    expect(Object.keys(GRAPH_THEME_PRESETS).sort()).toEqual([...GRAPH_PRESET_ORDER].sort());
+  });
+
+  it('lesson keeps the grid lighter than the axes so ink stays prominent', () => {
+    const t = GRAPH_THEME_PRESETS.lesson;
+    const lum = (hex: string) => parseInt(hex.slice(1, 3), 16);
+    expect(lum(t.gridMajor.color)).toBeGreaterThan(lum(t.axisColor));
+    expect(lum(t.gridMinor.color)).toBeGreaterThan(lum(t.gridMajor.color));
+    expect(t.axisWidth).toBeLessThanOrEqual(1.25);
   });
 
   it('blueprint uses a dark background with light labels', () => {

--- a/tests/ruler-overlay-input.test.ts
+++ b/tests/ruler-overlay-input.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const page = readFileSync(
+  fileURLToPath(new URL('../src/routes/+page.svelte', import.meta.url)),
+  'utf8',
+);
+
+describe('overlay slot does not swallow canvas input', () => {
+  /**
+   * The ruler's SVG spans the whole canvas so its ticks can render anywhere,
+   * and it sets `pointer-events: none` for exactly that reason. A blanket rule
+   * on the slot re-enabled events for every child SVG, so whenever the ruler
+   * was visible it captured all input and the pen, laser and temp-ink tools
+   * silently stopped working.
+   */
+  it('has no blanket pointer-events rule for overlay SVGs', () => {
+    expect(page).not.toMatch(/\.overlay-slot\s+:global\(svg\)\s*\{[^}]*pointer-events:\s*auto/);
+  });
+
+  it('keeps the slot itself transparent to pointer events', () => {
+    const rule = page.match(/\.overlay-slot\s*\{([^}]*)\}/)?.[1] ?? '';
+    expect(rule).toMatch(/pointer-events:\s*none/);
+  });
+});
+
+describe('ruler auto-show effect', () => {
+  /**
+   * Reading `rulerVisible` inside the effect that shows the ruler created a
+   * loop: closing set it false, which re-ran the effect, which set it true
+   * again. The ruler could never be dismissed while its tool was selected.
+   */
+  it('does not re-show the ruler by reading its own visibility', () => {
+    const effect = page.match(
+      /\$effect\(\(\) => \{[^}]*setRulerVisible\(true\)[\s\S]{0,200}?\}\);/,
+    );
+    expect(effect, 'ruler auto-show effect not found').not.toBeNull();
+    expect(effect?.[0]).not.toMatch(/rulerVisible/);
+  });
+
+  it('shows the ruler only when the tool changes to ruler', () => {
+    expect(page).toMatch(/lastToolForRuler/);
+  });
+});

--- a/tests/ruler-overlay.test.ts
+++ b/tests/ruler-overlay.test.ts
@@ -33,14 +33,21 @@ describe('RulerOverlay snap-only mode (regression for #123)', () => {
     );
   });
 
-  for (const sel of ['.body', '.end-handle', '.close'] as const) {
+  for (const sel of ['.body', '.end-handle'] as const) {
     it(`${sel} only opts into pointer-events when interactive (ruler tool active)`, () => {
       expect(styleRule(`${sel}.interactive`)).toMatch(/pointer-events:\s*auto/);
       expect(() => styleRule(sel)).toThrow();
     });
   }
 
-  for (const sel of ['body', 'end-handle', 'close'] as const) {
+  // Gating close on the ruler tool made the ruler impossible to dismiss: once
+  // another tool was selected the button went inert and the overlay stayed up.
+  it('.close always opts into pointer-events so the ruler can be dismissed', () => {
+    expect(styleRule('.close')).toMatch(/pointer-events:\s*auto/);
+    expect(() => styleRule('.close.interactive')).toThrow();
+  });
+
+  for (const sel of ['body', 'end-handle'] as const) {
     it(`${sel} element gets class:interactive bound to isRulerTool`, () => {
       const re = new RegExp(
         `<[^>]*class="${sel}"[^>]*class:interactive=\\{\\s*isRulerTool\\s*\\}[^>]*>`,
@@ -61,19 +68,25 @@ describe('RulerOverlay snap-only mode (regression for #123)', () => {
     );
   });
 
-  it('close button handlers are gated on isRulerTool', () => {
-    expect(source).toMatch(/onclick\s*=\s*\{\s*isRulerTool\s*\?\s*onClose\s*:\s*null\s*\}/);
-    expect(source).toMatch(/onpointerdown\s*=\s*\{\s*isRulerTool\s*\?\s*onClose\s*:\s*null\s*\}/);
-    expect(source).toMatch(/onkeydown\s*=\s*\{\s*isRulerTool\s*\?\s*onCloseKey\s*:\s*null\s*\}/);
+  it('close button handlers stay active regardless of the selected tool', () => {
+    expect(source).toMatch(/onclick=\{onClose\}/);
+    expect(source).toMatch(/onpointerdown=\{onClose\}/);
+    expect(source).toMatch(/onkeydown=\{onCloseKey\}/);
+  });
+
+  it('closing while the ruler tool is active also leaves the ruler tool', () => {
+    expect(source).toMatch(/sidebar\.setTool\(/);
   });
 
   it('outer ruler SVG is aria-hidden when the ruler tool is inactive', () => {
     expect(source).toMatch(/aria-hidden\s*=\s*\{\s*!\s*isRulerTool\s*\}/);
   });
 
-  it('focusable ruler elements gate tabindex on isRulerTool', () => {
+  it('drag handles gate tabindex on isRulerTool', () => {
     const matches = source.match(/tabindex\s*=\s*\{\s*isRulerTool\s*\?\s*0\s*:\s*-1\s*\}/g) ?? [];
-    expect(matches.length).toBeGreaterThanOrEqual(3);
+    // The body and end handle. Close stays focusable so it can always be reached.
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+    expect(source).toMatch(/tabindex="0"/);
   });
 });
 


### PR DESCRIPTION
## Ruler

Three bugs with one shared symptom: with the ruler visible, the pen, laser and temp-ink tools stopped responding.

**Root cause** — `.overlay-slot :global(svg) { pointer-events: auto; }` in `+page.svelte`. The ruler's SVG spans the whole canvas so its ticks can render anywhere, and sets `pointer-events: none` for exactly that reason; its own comment says it must not swallow events. The blanket rule overrode that, so an invisible full-canvas layer at z-index 15 captured every pointer event. The protractor sets `pointer-events` on its own root, so nothing needed the rule.

**Could not be closed** — the effect that shows the ruler also read the visibility it was setting, so closing set it false, which re-ran the effect, which set it true again. It now fires only on the transition into the ruler tool.

**Could not be closed after switching tools** — close was gated on the ruler tool being active, so selecting the pen left an overlay with no way to dismiss it. Close is now always reachable and also leaves the ruler tool, keeping tool and overlay in step.

Snapping needed no change; it was already implemented and simply never received pointer events.

Four existing tests asserted the gated-close behaviour, which was the bug, so they now assert the corrected behaviour. Snap-only mode is preserved: the body and end handle remain non-interactive unless the ruler tool is active. Added regression tests for the blanket pointer-events rule and the self-retriggering effect, neither of which was covered.

## Graph theme

Adds a `lesson` preset tuned for graphs projected during a live lesson: the grid recedes so hand-drawn work stays the most prominent thing on screen, while axes and labels stay legible at distance. Short axis ticks and a coordinate origin label help reading values from the back of a room.

Existing presets are untouched, so saved documents render exactly as before. The preset-order test now asserts a stable prefix rather than an exact list, so adding a preset no longer breaks it.

## Testing

975 tests pass, lint clean.